### PR TITLE
Add SLA report template

### DIFF
--- a/pkg/reporting/render.go
+++ b/pkg/reporting/render.go
@@ -1,0 +1,77 @@
+package reporting
+
+import (
+	"bytes"
+	"embed"
+	"encoding/json"
+	"fmt"
+	"text/template"
+	"time"
+)
+
+type Renderer interface {
+	RenderAsciidoc() (string, error)
+	PrepareJSONPayload() ([]byte, error)
+}
+
+type DocGenPDF struct {
+	Asciidoc             string `json:"asciidoc,omitempty"`
+	VshnDocgenId         string `json:"vshn_docgen_id,omitempty"`
+	VshnTextRoleOfVshnAg string `json:"vshn_text_role_of_vshn_ag,omitempty"`
+}
+
+//go:embed template/sla-report.txt
+var slaReportGoTemplate embed.FS
+var appcatSLAReport = "appcat-sla-report"
+
+type ServiceInstance struct {
+	Namespace  string
+	Instance   string
+	TargetSLA  float32
+	OutcomeSLA float32
+}
+
+type SLARenderer struct {
+	Customer      string
+	Cluster       string
+	ExceptionLink string
+	Month         time.Month
+	SI            []ServiceInstance
+}
+
+// RenderAsciidoc renders the sla go template into an asciidoc template
+func (s *SLARenderer) RenderAsciidoc() (string, error) {
+	t, err := template.ParseFS(slaReportGoTemplate, "template/sla-report.txt")
+	if err != nil {
+		return "", fmt.Errorf("cannot parse sla-report go template: %v", err)
+	}
+
+	buf := new(bytes.Buffer)
+
+	err = t.Execute(buf, s)
+	if err != nil {
+		return "", fmt.Errorf("cannot render sla-report go template: %v", err)
+	}
+	return buf.String(), nil
+}
+
+// PrepareJSONPayload creates a json payload that is ready to be used for docgen api
+// endpoint https://docgen.vshn.net/api/pdf
+func (s *SLARenderer) PrepareJSONPayload() ([]byte, error) {
+	asciidocTemplate, err := s.RenderAsciidoc()
+	if err != nil {
+		return nil, err
+	}
+
+	d := DocGenPDF{
+		Asciidoc:     asciidocTemplate,
+		VshnDocgenId: appcatSLAReport,
+	}
+
+	payload, err := json.Marshal(d)
+	if err != nil {
+		return nil, fmt.Errorf("cannot marshal sla-report json payload: %v", err)
+	}
+
+	return payload, nil
+}

--- a/pkg/reporting/render_test.go
+++ b/pkg/reporting/render_test.go
@@ -1,0 +1,99 @@
+package reporting
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestSLARenderer_RenderAsciidoc(t *testing.T) {
+	tests := map[string]struct {
+		renderer         SLARenderer
+		expectedAsciidoc string
+		err              error
+	}{
+		"WhenSLARender_ThenOutput": {
+			renderer: SLARenderer{
+				Customer:      "TestCustomer",
+				Cluster:       "TestCluster",
+				ExceptionLink: "https://vshn.ch",
+				Month:         2,
+				SI: []ServiceInstance{
+					{
+						Namespace:  "dev-namespace",
+						Instance:   "postgres-dev",
+						TargetSLA:  99.9,
+						OutcomeSLA: 99.1,
+					},
+				},
+			},
+			expectedAsciidoc: "= SLA Report\n\nimage::vshn.png[VSHN Logo,100,54,id=vshn_logo]\n\n*Version of the document" +
+				": May 2023* +\n\n---\n\n[big]#Customer: *TestCustomer* +\nMonth: *February* +\nCluster: *TestCluster*#\n" +
+				"\n---\n\n[cols=\"Namespace, Instance, SLA Target, SLA Outcome\"]\n|===\n| Namespace| Instance| SLA Target|" +
+				" SLA Outcome\n\n|dev-namespace|postgres-dev|99.9%|*99.1%*\n\n|===\n\nNOTE: [small]#The list of exceptions " +
+				"which are excluded from outcome can be viewed  https://vshn.ch[at].#\n",
+			err: nil,
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+
+			// WHEN
+			asciidoc, err := tc.renderer.RenderAsciidoc()
+
+			// THEN
+			if tc.err != nil {
+				assert.Equal(t, tc.err, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectedAsciidoc, asciidoc)
+		})
+	}
+}
+
+func TestSLARenderer_PrepareJSONPayload(t *testing.T) {
+	tests := map[string]struct {
+		renderer        SLARenderer
+		expectedPayload string
+		err             error
+	}{
+		"WhenSLARender_ThenOutputPayload": {
+			renderer: SLARenderer{
+				Customer:      "TestCustomer",
+				Cluster:       "TestCluster",
+				ExceptionLink: "https://vshn.ch",
+				Month:         2,
+				SI: []ServiceInstance{
+					{
+						Namespace:  "dev-namespace",
+						Instance:   "postgres-dev",
+						TargetSLA:  99.9,
+						OutcomeSLA: 99.1,
+					},
+				},
+			},
+			expectedPayload: "{\"asciidoc\":\"= SLA Report\\n\\nimage::vshn.png[VSHN Logo,100,54,id=vshn_logo]\\n\\n*" +
+				"Version of the document: May 2023* +\\n\\n---\\n\\n[big]#Customer: *TestCustomer* +\\nMonth: *February*" +
+				" +\\nCluster: *TestCluster*#\\n\\n---\\n\\n[cols=\\\"Namespace, Instance, SLA Target, SLA Outcome\\\"]" +
+				"\\n|===\\n| Namespace| Instance| SLA Target| SLA Outcome\\n\\n|dev-namespace|postgres-dev|99.9%|*99.1%*" +
+				"\\n\\n|===\\n\\nNOTE: [small]#The list of exceptions which are excluded from outcome can be viewed  " +
+				"https://vshn.ch[at].#\\n\",\"vshn_docgen_id\":\"appcat-sla-report\"}",
+			err: nil,
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+
+			// WHEN
+			payload, err := tc.renderer.PrepareJSONPayload()
+
+			// THEN
+			if tc.err != nil {
+				assert.Equal(t, tc.err, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, []byte(tc.expectedPayload), payload)
+		})
+	}
+}

--- a/pkg/reporting/template/sla-report.txt
+++ b/pkg/reporting/template/sla-report.txt
@@ -1,0 +1,23 @@
+= SLA Report
+
+image::vshn.png[VSHN Logo,100,54,id=vshn_logo]
+
+*Version of the document: May 2023* +
+
+---
+
+[big]#Customer: *{{.Customer}}* +
+Month: *{{.Month}}* +
+Cluster: *{{.Cluster}}*#
+
+---
+
+[cols="Namespace, Instance, SLA Target, SLA Outcome"]
+|===
+| Namespace| Instance| SLA Target| SLA Outcome
+{{range .SI}}
+|{{.Namespace}}|{{.Instance}}|{{.TargetSLA}}%|*{{.OutcomeSLA}}%*
+{{end}}
+|===
+
+NOTE: [small]#The list of exceptions which are excluded from outcome can be viewed  {{.ExceptionLink}}[at].#


### PR DESCRIPTION
## Summary

Added a go template that will output an asciidoc ready template for docgen.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
