### PR TITLE
Add option to enable and disable email alerting feature for postgresql

### DIFF
--- a/test/transforms/vshn-postgres/alerting/06-GivenNoEmail.yaml
+++ b/test/transforms/vshn-postgres/alerting/06-GivenNoEmail.yaml
@@ -1,5 +1,18 @@
 apiVersion: apiextensions.crossplane.io/v1alpha1
 kind: FunctionIO
+config:
+  kind: ConfigMap
+  metadata:
+    annotations: {}
+    labels:
+      name: xfn-config
+    name: xfn-config
+  apiVersion: v1
+  data:
+    emailAlertingEnabled: true
+    emailAlertingSmtpFromAddress: foo@example.com
+    emailAlertingSmtpUsername:  foo@example.com
+    emailAlertingSmtpHost: mail.example.com:465
 observed:
   composite:
     resource:

--- a/test/transforms/vshn-postgres/alerting/07-GivenEmail.yaml
+++ b/test/transforms/vshn-postgres/alerting/07-GivenEmail.yaml
@@ -1,5 +1,18 @@
 apiVersion: apiextensions.crossplane.io/v1alpha1
 kind: FunctionIO
+config:
+  kind: ConfigMap
+  metadata:
+    annotations: {}
+    labels:
+      name: xfn-config
+    name: xfn-config
+  apiVersion: v1
+  data:
+    emailAlertingEnabled: true
+    emailAlertingSmtpFromAddress: foo@example.com
+    emailAlertingSmtpUsername:  foo@example.com
+    emailAlertingSmtpHost: mail.example.com:465
 observed:
   composite:
     resource:

--- a/test/transforms/vshn-postgres/alerting/09-GivenEmailAlertingDisabled.yaml
+++ b/test/transforms/vshn-postgres/alerting/09-GivenEmailAlertingDisabled.yaml
@@ -9,7 +9,7 @@ config:
     name: xfn-config
   apiVersion: v1
   data:
-    emailAlertingEnabled: true
+    emailAlertingEnabled: false
     emailAlertingSmtpFromAddress: foo@example.com
     emailAlertingSmtpUsername:  foo@example.com
     emailAlertingSmtpHost: mail.example.com:465
@@ -45,7 +45,7 @@ observed:
         compositionUpdatePolicy: Automatic
         parameters:
           monitoring:
-            email: ""
+            email: "no-reply@example.com"
       status:
         instanceNamespace: my-psql
 desired:

--- a/test/transforms/vshn-postgres/alerting/10-GivenNoEmailAlertingDisabled.yaml
+++ b/test/transforms/vshn-postgres/alerting/10-GivenNoEmailAlertingDisabled.yaml
@@ -9,7 +9,7 @@ config:
     name: xfn-config
   apiVersion: v1
   data:
-    emailAlertingEnabled: true
+    emailAlertingEnabled: false
     emailAlertingSmtpFromAddress: foo@example.com
     emailAlertingSmtpUsername:  foo@example.com
     emailAlertingSmtpHost: mail.example.com:465
@@ -43,9 +43,7 @@ observed:
         compositionRevisionRef:
           name: vshnpostgres.vshn.appcat.vshn.io-ce52f13
         compositionUpdatePolicy: Automatic
-        parameters:
-          monitoring:
-            email: ""
+        parameters: {}
       status:
         instanceNamespace: my-psql
 desired:


### PR DESCRIPTION
## Summary

This PR adds the option to enable and disable the email alerting feature. This is necessary so that we don't accidentally create a Alertmanager config to send email alerts if email alerting isn't enabled at all for the cluster.

See companion PR for component: https://github.com/vshn/component-appcat/pull/169

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
