### PR TITLE
Actually disable the AOF rewrite before backup

### DIFF
--- a/pkg/comp-functions/functions/vshnredis/script/backup.sh
+++ b/pkg/comp-functions/functions/vshnredis/script/backup.sh
@@ -10,6 +10,8 @@ redis_cmd() {
 
 rewrite_percentage=$(redis_cmd --raw CONFIG GET auto-aof-rewrite-percentage | tail -n 1) 1>&2
 
+redis_cmd CONFIG SET auto-aof-rewrite-percentage 0 1>&2
+
 redis_cmd SAVE 1>&2
 
 until redis_cmd INFO persistence | grep aof_rewrite_in_progress:0 > /dev/null


### PR DESCRIPTION
## Summary
Previously the script didn't actually disable the AOF rewrite prior to taking the backup.

See: https://redis.io/docs/management/persistence/


## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
