### PR TITLE
Update postres backup table

### DIFF
--- a/apis/appcat/v1/vshn_postgres_backup_types.go
+++ b/apis/appcat/v1/vshn_postgres_backup_types.go
@@ -21,8 +21,8 @@ var (
 	BackupInformation = "backupInformation"
 	// Timing holds field path name timing
 	Timing = "timing"
-	// Stored holds field path name stored
-	Stored = "stored"
+	// End holds field path name end
+	End = "end"
 )
 
 // VSHNPostgreSQLName represents the name of a VSHNPostgreSQL

--- a/pkg/apiserver/vshn/postgres/table.go
+++ b/pkg/apiserver/vshn/postgres/table.go
@@ -43,7 +43,7 @@ func (v *vshnPostgresBackupStorage) ConvertToTable(_ context.Context, obj runtim
 		table.ColumnDefinitions = []metav1.TableColumnDefinition{
 			{Name: "Backup Name", Type: "string", Format: "name", Description: desc["name"]},
 			{Name: "Database Instance", Type: "string", Description: "The database instance"},
-			{Name: "Stored Time", Type: "string", Description: "When backup is stored"},
+			{Name: "Finished On", Type: "string", Description: "The data is available up to this time"},
 			{Name: "Status", Type: "string", Description: "The state of this backup"},
 			{Name: "Age", Type: "date", Description: desc["creationTimestamp"]},
 		}
@@ -56,18 +56,18 @@ func backupToTableRow(backup *v1.VSHNPostgresBackup) metav1.TableRow {
 		Cells: []interface{}{
 			backup.GetName(),
 			backup.Status.DatabaseInstance,
-			getStoredTime(backup.Status.Process),
+			getEndTime(backup.Status.Process),
 			getProcessStatus(backup.Status.Process),
 			duration.HumanDuration(time.Since(backup.GetCreationTimestamp().Time))},
 		Object: runtime.RawExtension{Object: backup},
 	}
 }
 
-func getStoredTime(process *runtime.RawExtension) string {
+func getEndTime(process *runtime.RawExtension) string {
 	if process != nil && process.Object != nil {
 		if v, err := runtime.DefaultUnstructuredConverter.ToUnstructured(process.Object); err == nil {
-			if storedTime, exists, _ := unstructured.NestedString(v, v1.Timing, v1.Stored); exists {
-				return storedTime
+			if endTime, exists, _ := unstructured.NestedString(v, v1.Timing, v1.End); exists {
+				return endTime
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

* After some research it turns out that the _end time_ of a postgres backup is the relevant timestamp that we have to show to the customer. All the data is saved and available up to this timestamp.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
