### PR TITLE
Don't return error on deletion

### DIFF
--- a/pkg/apiserver/vshn/redis/delete.go
+++ b/pkg/apiserver/vshn/redis/delete.go
@@ -2,7 +2,6 @@ package redis
 
 import (
 	"context"
-	"fmt"
 
 	v1 "github.com/vshn/appcat/apis/appcat/v1"
 	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
@@ -16,11 +15,15 @@ var _ rest.GracefulDeleter = &vshnRedisBackupStorage{}
 var _ rest.CollectionDeleter = &vshnRedisBackupStorage{}
 
 func (v vshnRedisBackupStorage) Delete(_ context.Context, name string, _ rest.ValidateObjectFunc, _ *metav1.DeleteOptions) (runtime.Object, bool, error) {
-	return &v1.VSHNPostgresBackup{}, false, fmt.Errorf("method not implemented")
+	return &v1.VSHNRedisBackup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}, false, nil
 }
 
 func (v *vshnRedisBackupStorage) DeleteCollection(ctx context.Context, _ rest.ValidateObjectFunc, _ *metav1.DeleteOptions, _ *metainternalversion.ListOptions) (runtime.Object, error) {
-	return &v1.VSHNPostgresBackupList{
-		Items: []v1.VSHNPostgresBackup{},
-	}, fmt.Errorf("method not implemented")
+	return &v1.VSHNRedisBackupList{
+		Items: []v1.VSHNRedisBackup{},
+	}, nil
 }


### PR DESCRIPTION
## Summary

Deletion should not return an error. It looks like the kube-controller calls the deletion function when a namespace is deleted.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
