### PR TITLE
Add vshn postgres repack to maintenance

### DIFF
--- a/apis/stackgres/v1/sgdbops.go
+++ b/apis/stackgres/v1/sgdbops.go
@@ -5,6 +5,7 @@ import (
 )
 
 const SGDbOpsOpRestart = "restart"
+const SGDbOpsOpRepack = "repack"
 
 const SGDbOpsRestartMethodInPlace = "InPlace"
 

--- a/cmd/maintenance.go
+++ b/cmd/maintenance.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -56,7 +57,7 @@ func newMaintenanceCMD() *cobra.Command {
 
 func (c *controller) runMaintenance(cmd *cobra.Command, _ []string) error {
 
-	kubeClient, err := client.New(ctrl.GetConfigOrDie(), client.Options{
+	kubeClient, err := client.NewWithWatch(ctrl.GetConfigOrDie(), client.Options{
 		Scheme: pkg.SetupScheme(),
 	})
 	if err != nil {
@@ -72,8 +73,9 @@ func (c *controller) runMaintenance(cmd *cobra.Command, _ []string) error {
 		}
 
 		pg := maintenance.PostgreSQL{
-			Client: kubeClient,
-			SgURL:  "https://stackgres-restapi." + sgNamespace + ".svc",
+			Client:       kubeClient,
+			SgURL:        "https://stackgres-restapi." + sgNamespace + ".svc",
+			MaintTimeout: time.Hour,
 		}
 		return pg.DoMaintenance(cmd.Context())
 	case redis:

--- a/docs/modules/ROOT/pages/explanations/comp-functions/vshn-postgres.adoc
+++ b/docs/modules/ROOT/pages/explanations/comp-functions/vshn-postgres.adoc
@@ -22,6 +22,8 @@ What kind of operation it creates depends on following factors:
 * If the instance is on an older minor version, then do a minor upgrade
 * If the StackGres API is not available do a security update
 
+After instance update/upgrade completion, a `pg_repack` operation will be performed on all databases.
+
 The StackGres operator API is used to query what versions are currently supported.
 If a new StackGres release supports newer minor versions of PostgreSQL, then all instances of that major version will do an update during their next maintenance window.
 


### PR DESCRIPTION
## Summary

* This PR adds another step in the maintenance of VSHN Postgres instances. After any update/upgrade is done, the `pg_repack` is performed on all databases.
* This step is part of the cronjob and not of the composition functions.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
