### PR TITLE
Fix maintenance secret reference in pg

### DIFF
--- a/pkg/comp-functions/functions/vshn-postgres-func/maintenance.go
+++ b/pkg/comp-functions/functions/vshn-postgres-func/maintenance.go
@@ -60,7 +60,7 @@ var (
 			ValueFrom: &corev1.EnvVarSource{
 				SecretKeyRef: &corev1.SecretKeySelector{
 					LocalObjectReference: corev1.LocalObjectReference{
-						Name: service + maintSecretName,
+						Name: maintSecretName,
 					},
 					Key: "SG_NAMESPACE",
 				},
@@ -71,7 +71,7 @@ var (
 			ValueFrom: &corev1.EnvVarSource{
 				SecretKeyRef: &corev1.SecretKeySelector{
 					LocalObjectReference: corev1.LocalObjectReference{
-						Name: service + maintSecretName,
+						Name: maintSecretName,
 					},
 					Key: "k8sUsername",
 				},
@@ -82,7 +82,7 @@ var (
 			ValueFrom: &corev1.EnvVarSource{
 				SecretKeyRef: &corev1.SecretKeySelector{
 					LocalObjectReference: corev1.LocalObjectReference{
-						Name: service + maintSecretName,
+						Name: maintSecretName,
 					},
 					Key: "clearPassword",
 				},


### PR DESCRIPTION
## Summary

* The reference secret is wrong for pg after redis maintenance was introduced.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
