### PR TITLE
Fix test race condition

### DIFF
--- a/pkg/maintenance/postgresql_test.go
+++ b/pkg/maintenance/postgresql_test.go
@@ -339,7 +339,7 @@ func TestPostgreSQL_DoMaintenance(t *testing.T) {
 		},
 		{
 			name:         "GivenMaintenanceTooLong_ThenExpectNoRepack",
-			maintTimeout: time.Second,
+			maintTimeout: time.Millisecond,
 			objs: []client.Object{
 				&stackgresv1.SGCluster{
 					ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
## Summary

* This small change should resolve the race condition in `GivenMaintenanceTooLong_ThenExpectNoRepack` test

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
