### PR TITLE
Use unique key to keep track of probers instead of the whole ProberInfo

### DIFF
--- a/pkg/sliexporter/probes/manager_test.go
+++ b/pkg/sliexporter/probes/manager_test.go
@@ -94,7 +94,11 @@ func TestManger_Multi(t *testing.T) {
 		return pa.getCount() == 9
 	}, time.Second, 10*time.Millisecond)
 	assert.EqualValues(t, 9, pa.getCount())
-	m.StopProbe(pa.GetInfo())
+	m.StopProbe(ProbeInfo{
+		Service:   "fake",
+		Namespace: "foo",
+		Name:      "alice",
+	})
 
 	pb.tick(nil)
 	pb.tick(nil)
@@ -119,9 +123,10 @@ func TestManger_Multi(t *testing.T) {
 func newFakeProbe(service, namespace, name string) *fakeProbe {
 	return &fakeProbe{
 		info: ProbeInfo{
-			Service:   service,
-			Name:      name,
-			Namespace: namespace,
+			Service:      service,
+			Name:         name,
+			Namespace:    namespace,
+			Organization: "foo",
 		},
 		results: make(chan error, 10),
 		ticker:  make(chan time.Time, 10),


### PR DESCRIPTION
By adding the organization to the ProberInfo, the same AppCat instance can have two different ProberInfos. This meant we did not properly stop probes as for deletion we did not provide the organization.

This fixes the issue we see that the prober tries to connect to a non existing database.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
