### PR TITLE
Fix display issue for Redis Backups

### DIFF
--- a/pkg/apiserver/vshn/redis/table.go
+++ b/pkg/apiserver/vshn/redis/table.go
@@ -32,8 +32,8 @@ func (v *vshnRedisBackupStorage) ConvertToTable(_ context.Context, obj runtime.O
 		backups = append(backups, *backup)
 	}
 
-	for _, backup := range backups {
-		table.Rows = append(table.Rows, backupToTableRow(&backup))
+	for i := range backups {
+		table.Rows = append(table.Rows, backupToTableRow(&backups[i]))
 	}
 
 	if opt, ok := tableOptions.(*metav1.TableOptions); !ok || !opt.NoHeaders {

--- a/pkg/apiserver/vshn/redis/table_test.go
+++ b/pkg/apiserver/vshn/redis/table_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	vshnv1 "github.com/vshn/appcat/apis/appcat/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -62,4 +63,47 @@ func Test_vshnRedisBackupStorage_ConvertToTable(t *testing.T) {
 			assert.Len(t, got.Rows, tt.wantRows)
 		})
 	}
+}
+
+func Test_vshnRedisBackupStorage_ConvertToTable_noduplicate(t *testing.T) {
+	v := &vshnRedisBackupStorage{}
+	obj := vshnv1.VSHNRedisBackupList{
+		Items: []vshnv1.VSHNRedisBackup{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "foo1",
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "foo2",
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "foo3",
+				},
+			},
+		},
+	}
+	got, err := v.ConvertToTable(context.TODO(), &obj, nil)
+	assert.NoError(t, err)
+	assert.Len(t, got.Rows, 3)
+
+	foo1, ok := got.Rows[0].Object.Object.(*vshnv1.VSHNRedisBackup)
+	if assert.True(t, ok, "unexpected type for foo1") {
+		assert.Equal(t, "foo1", foo1.Namespace)
+	}
+	foo2, ok := got.Rows[1].Object.Object.(*vshnv1.VSHNRedisBackup)
+	if assert.True(t, ok, "unexpected type for foo1") {
+		assert.Equal(t, "foo2", foo2.Namespace)
+	}
+	foo3, ok := got.Rows[2].Object.Object.(*vshnv1.VSHNRedisBackup)
+	if assert.True(t, ok, "unexpected type for foo1") {
+		assert.Equal(t, "foo3", foo3.Namespace)
+	}
+
 }


### PR DESCRIPTION
There was a display issue caused by the classic Go iteration bug. We attached the same object to each row. This meant if kubectl tired to display additional columns (such as the namespace when listing all redis backups over all namespaces) it showed the same data of the last object for every row.


## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
