### PR TITLE
Add service level guaranteed availability

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,11 +161,12 @@ The controller manages and achieves the following:
 ## SLI Exporter
 ### Metrics
 
-The exporter exposes a histogram `appcat_probes_seconds` with four labels
+The exporter exposes a histogram `appcat_probes_seconds` with five labels
 
 * `service`, the service type that was probed (e.g. `VSHNPostgreSQL`)
 * `namespace`, the namespace of the claim that was monitored
 * `name`, the name of the claim that was monitored
+* `sla`, the service level. Can either be `besteffort` or `guaranteed`
 * `reason`, if the probe was successful. Can either be `success`, `fail-timeout`, or `fail-unkown`
 
 #### Adding a Prober

--- a/apis/vshn/v1/common_types.go
+++ b/apis/vshn/v1/common_types.go
@@ -41,6 +41,13 @@ type K8upRestoreSpec struct {
 	BackupName string `json:"backupName,omitempty"`
 }
 
+type VSHNDBaaSServiceLevel string
+
+const (
+	BestEffort VSHNDBaaSServiceLevel = "besteffort"
+	Guaranteed VSHNDBaaSServiceLevel = "guaranteed"
+)
+
 // VSHNDBaaSMaintenanceScheduleSpec contains settings to control the maintenance of an instance.
 type VSHNDBaaSMaintenanceScheduleSpec struct {
 	// +kubebuilder:validation:Enum=monday;tuesday;wednesday;thursday;friday;saturday;sunday

--- a/apis/vshn/v1/dbaas_vshn_postgresql.go
+++ b/apis/vshn/v1/dbaas_vshn_postgresql.go
@@ -84,7 +84,7 @@ type VSHNPostgreSQLParameters struct {
 
 	// Instances configures the number of PostgreSQL instances for the cluster.
 	// Each instance contains one Postgres server.
-	// Out of all of the Postgres servers, one is elected as the primary, the rest remain as read-only replicas.
+	// Out of all Postgres servers, one is elected as the primary, the rest remain as read-only replicas.
 	Instances int `json:"instances,omitempty"`
 
 	// This section allows to configure Postgres replication mode and HA roles groups.
@@ -142,6 +142,12 @@ type VSHNPostgreSQLServiceSpec struct {
 
 	// Extensions allow to enable/disable any of the supported
 	Extensions []VSHNDBaaSPostgresExtension `json:"extensions,omitempty"`
+
+	// +kubebuilder:validation:Enum="besteffort";"guaranteed"
+	// +kubebuilder:default="besteffort"
+
+	// ServiceLevel defines the service level of this service. Either Best Effort or Guaranteed Availability is allowed.
+	ServiceLevel VSHNDBaaSServiceLevel `json:"serviceLevel,omitempty"`
 }
 
 // VSHNDBaaSPostgresExtension contains the name of a single extension.

--- a/cmd/grpc.go
+++ b/cmd/grpc.go
@@ -106,7 +106,7 @@ var images = map[string][]runtime.Transform{
 			TransformFunc: vpf.ConfigureReplication,
 		},
 		{
-			Name:          "loadbalancer",
+			Name:          "load-balancer",
 			TransformFunc: vpf.AddLoadBalancerIPToConnectionDetails,
 		},
 	},

--- a/crds/vshn.appcat.vshn.io_vshnpostgresqls.yaml
+++ b/crds/vshn.appcat.vshn.io_vshnpostgresqls.yaml
@@ -67,7 +67,7 @@ spec:
                       type: object
                     instances:
                       default: 1
-                      description: Instances configures the number of PostgreSQL instances for the cluster. Each instance contains one Postgres server. Out of all of the Postgres servers, one is elected as the primary, the rest remain as read-only replicas.
+                      description: Instances configures the number of PostgreSQL instances for the cluster. Each instance contains one Postgres server. Out of all Postgres servers, one is elected as the primary, the rest remain as read-only replicas.
                       maximum: 3
                       minimum: 1
                       type: integer
@@ -3566,6 +3566,13 @@ spec:
                           description: PGSettings contains additional PostgreSQL settings.
                           type: object
                           x-kubernetes-preserve-unknown-fields: true
+                        serviceLevel:
+                          default: besteffort
+                          description: ServiceLevel defines the service level of this service. Either Best Effort or Guaranteed Availability is allowed.
+                          enum:
+                            - besteffort
+                            - guaranteed
+                          type: string
                       type: object
                       default: {}
                     size:

--- a/pkg/sliexporter/probes/manager.go
+++ b/pkg/sliexporter/probes/manager.go
@@ -35,6 +35,7 @@ type ProbeInfo struct {
 	Name         string
 	Namespace    string
 	Organization string
+	ServiceLevel string
 }
 
 // key uniquely identifies a prober
@@ -51,7 +52,7 @@ func NewManager(l logr.Logger) Manager {
 		Name:    "appcat_probes_seconds",
 		Help:    "Latency of probes to appact services",
 		Buckets: []float64{0.001, 0.002, 0.003, 0.004, 0.005, 0.01, 0.015, 0.02, 0.025, 0.05, 0.1, .5, 1},
-	}, []string{"service", "namespace", "name", "reason", "organization"})
+	}, []string{"service", "namespace", "name", "reason", "organization", "sla"})
 
 	return Manager{
 		hist:      hist,
@@ -122,6 +123,7 @@ func (m Manager) sendProbe(ctx context.Context, p Prober) {
 		"namespace":    pi.Namespace,
 		"name":         pi.Name,
 		"organization": pi.Organization,
+		"sla":          pi.ServiceLevel,
 	})
 	if err != nil {
 		return

--- a/pkg/sliexporter/probes/postgresql.go
+++ b/pkg/sliexporter/probes/postgresql.go
@@ -20,6 +20,7 @@ type PostgreSQL struct {
 	Instance     string
 	Namespace    string
 	Organization string
+	ServiceLevel string
 }
 
 // Close closes open connections to the PostgreSQL server.
@@ -37,6 +38,7 @@ func (p PostgreSQL) GetInfo() ProbeInfo {
 		Name:         p.Instance,
 		Namespace:    p.Namespace,
 		Organization: p.Organization,
+		ServiceLevel: p.ServiceLevel,
 	}
 }
 
@@ -51,7 +53,7 @@ func (p PostgreSQL) Probe(ctx context.Context) error {
 }
 
 // NewPostgreSQL connects to the provided dsn and returns a prober
-func NewPostgreSQL(service, name, namespace, dsn, organization string, ops ...func(*pgxpool.Config) error) (*PostgreSQL, error) {
+func NewPostgreSQL(service, name, namespace, dsn, organization, sla string, ops ...func(*pgxpool.Config) error) (*PostgreSQL, error) {
 	conf, err := pgxpool.ParseConfig(dsn)
 	if err != nil {
 		return nil, err
@@ -77,6 +79,7 @@ func NewPostgreSQL(service, name, namespace, dsn, organization string, ops ...fu
 		Instance:     name,
 		Namespace:    namespace,
 		Organization: organization,
+		ServiceLevel: sla,
 	}, nil
 }
 

--- a/pkg/sliexporter/probes/postgresql_test.go
+++ b/pkg/sliexporter/probes/postgresql_test.go
@@ -40,7 +40,7 @@ func TestPostgreSQL_Probe(t *testing.T) {
 				res.GetPort("5432/tcp"),
 				db,
 			),
-			"test",
+			"test", "besteffort",
 		)
 		return err == nil
 	}, 2*time.Second, 500*time.Millisecond)


### PR DESCRIPTION
## Summary

This PR adds `sla` label to the SLI Prober so that it can be used later on by alerts and ultimately arrive in OpsGenie if necessary

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
