### PR TITLE
Fix resource calculation by taking sidecars into account

### DIFF
--- a/docs/modules/ROOT/pages/explanations/webhooks.adoc
+++ b/docs/modules/ROOT/pages/explanations/webhooks.adoc
@@ -5,6 +5,7 @@ APPUiO Cloud provides a quota system, which AppCat has to comply and integrate i
 It accomplishes that, by providing nice error messages, if any of the given quotas are breached.
 
 There are multiple quotas that need to be complied by this system:
+
 * the amount of namespaces an organization can have
 * the amount of resources that can be used within a namespace
 
@@ -16,8 +17,11 @@ If the requested AppCat instance would tip the amount of namespaces over this th
 Additionally, each namespace has quotas that need to comply.
 Via AppCat comp-functions, we set the quotas to a slightly higher value than the APPUiO Cloud default:
 
-* 4.5 CPU limts/requests
-* 16.5Gb Memory limits/requests
+* 4.5 CPU limits/requests + limits/requests of all sidecars
+* 16.5Gb Memory limits/requests + limits/requests of all sidecars
+
+The limits/requests of the sidecars are automatically calculated based on the defined limits/requests of all involved sidecars.
+They are defined in the `sideCars` section of the service in the https://github.com/vshn/component-appcat/blob/master/class/defaults.yml[componet-appcat].
 
 This should ensure that for each service at least one replica can be instantiated with the `*-8` plans.
 These values are written into annotations on the namespace.

--- a/pkg/common/utils/sidecars.go
+++ b/pkg/common/utils/sidecars.go
@@ -1,0 +1,112 @@
+package utils
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/spf13/viper"
+	"github.com/vshn/appcat/v4/pkg/comp-functions/runtime"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type Sidecars map[string]sidecar
+
+type sidecar struct {
+	Limits struct {
+		CPU    string `json:"cpu"`
+		Memory string `json:"memory"`
+	} `json:"limits"`
+	Requests struct {
+		CPU    string `json:"cpu"`
+		Memory string `json:"memory"`
+	} `json:"requests"`
+}
+
+func GetAllSideCarsResources(s *Sidecars) (Resources, error) {
+
+	rTot := Resources{}
+
+	for sidecar := range *s {
+		r, err := s.convertSidecarToResource(sidecar)
+		if err != nil {
+			return Resources{}, err
+		}
+		rTot.AddResources(r)
+	}
+
+	return rTot, nil
+}
+func FetchSidecarsFromCluster(ctx context.Context, c client.Client, name string) (*Sidecars, error) {
+	s := &Sidecars{}
+	cm := &corev1.ConfigMap{}
+
+	ns := viper.GetString("PLANS_NAMESPACE")
+	key := client.ObjectKey{Name: name, Namespace: ns}
+	err := c.Get(ctx, key, cm)
+
+	if err != nil {
+		return &Sidecars{}, err
+	}
+
+	err = json.Unmarshal([]byte(cm.Data["sideCars"]), s)
+	if err != nil {
+		return &Sidecars{}, err
+	}
+
+	return s, nil
+}
+
+func FetchSidecarsFromConfig(ctx context.Context, iof *runtime.Runtime) (*Sidecars, error) {
+	s := &Sidecars{}
+
+	err := json.Unmarshal([]byte(iof.Config.Data["sideCars"]), s)
+	if err != nil {
+		return &Sidecars{}, err
+	}
+
+	return s, nil
+}
+
+// FetchSidecarFromCluster will fetch the specified sidecar from the current PLANS_NAMESPACE namespace and parse it into Resources.
+// By default PLANS_NAMESPACE should be the same namespace where the controller pod is running.
+func FetchSidecarFromCluster(ctx context.Context, c client.Client, name, sidecar string) (Resources, error) {
+	s, err := FetchSidecarsFromCluster(ctx, c, name)
+	if err != nil {
+		return Resources{}, err
+	}
+
+	r, err := s.convertSidecarToResource(sidecar)
+
+	return r, err
+}
+
+func (s Sidecars) convertSidecarToResource(sidecar string) (Resources, error) {
+	r := Resources{}
+	var err error
+
+	sideCar := s[sidecar]
+
+	r.CPURequests, err = resource.ParseQuantity(sideCar.Requests.CPU)
+	if err != nil {
+		return Resources{}, err
+	}
+
+	r.CPULimits, err = resource.ParseQuantity(sideCar.Limits.CPU)
+	if err != nil {
+		return Resources{}, err
+	}
+
+	r.MemoryRequests, err = resource.ParseQuantity(sideCar.Requests.Memory)
+	if err != nil {
+		return Resources{}, err
+	}
+
+	r.MemoryLimits, err = resource.ParseQuantity(sideCar.Limits.Memory)
+	if err != nil {
+		return Resources{}, err
+	}
+
+	return r, nil
+}

--- a/pkg/common/utils/sidecars_test.go
+++ b/pkg/common/utils/sidecars_test.go
@@ -1,0 +1,193 @@
+package utils
+
+import (
+	"context"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/vshn/appcat/v4/pkg"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestFetchSidecarsFromCluster(t *testing.T) {
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "testns",
+		},
+		Data: map[string]string{
+			"sideCars": `
+			{
+				"clusterController": {
+					"limits": {
+						"cpu": "600m",
+						"memory": "768Mi"
+					},
+					"requests": {
+						"cpu": "32m",
+						"memory": "188Mi"
+					}
+				},
+				"createBackup": {
+					"limits": {
+						"cpu": "600m",
+						"memory": "768Mi"
+					},
+					"requests": {
+						"cpu": "250m",
+						"memory": "256Mi"
+					}
+				},
+				"envoy": {
+					"limits": {
+						"cpu": "600m",
+						"memory": "768Mi"
+					},
+					"requests": {
+						"cpu": "32m",
+						"memory": "64Mi"
+					}
+				},
+				"pgbouncer": {
+					"limits": {
+						"cpu": "600m",
+						"memory": "768Mi"
+					},
+					"requests": {
+						"cpu": "16m",
+						"memory": "32Mi"
+					}
+				},
+				"postgresUtil": {
+					"limits": {
+						"cpu": "600m",
+						"memory": "768Mi"
+					},
+					"requests": {
+						"cpu": "10m",
+						"memory": "4Mi"
+					}
+				},
+				"prometheusPostgresExporter": {
+					"limits": {
+						"cpu": "600m",
+						"memory": "768Mi"
+					},
+					"requests": {
+						"cpu": "10m",
+						"memory": "32Mi"
+					}
+				},
+				"runDbops": {
+					"limits": {
+						"cpu": "600m",
+						"memory": "768Mi"
+					},
+					"requests": {
+						"cpu": "250m",
+						"memory": "256Mi"
+					}
+				},
+				"setDbopsResult": {
+					"limits": {
+						"cpu": "600m",
+						"memory": "768Mi"
+					},
+					"requests": {
+						"cpu": "250m",
+						"memory": "256Mi"
+					}
+				}
+			}
+			`,
+		},
+	}
+
+	type args struct {
+		name    string
+		sideCar string
+		ns      string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    Resources
+		wantErr bool
+	}{
+		{
+			name: "GivenWrongNs_ThenGetError",
+			args: args{
+				name:    "test",
+				sideCar: "clusterController",
+				ns:      "wrong",
+			},
+			want:    Resources{},
+			wantErr: true,
+		},
+		{
+			name: "GivenWrongName_ThenGetError",
+			args: args{
+				name:    "wrong",
+				sideCar: "clusterController",
+				ns:      "testns",
+			},
+			want:    Resources{},
+			wantErr: true,
+		},
+		{
+			name: "GivenWrongSideCar_ThenGetError",
+			args: args{
+				name:    "test",
+				sideCar: "wrong",
+				ns:      "testns",
+			},
+			want:    Resources{},
+			wantErr: true,
+		},
+		{
+			name: "GivenCorrectSideCar_ThenGetCorrectResources",
+			args: args{
+				name:    "test",
+				sideCar: "clusterController",
+				ns:      "testns",
+			},
+			want: Resources{
+				CPURequests:    *resource.NewMilliQuantity(32, resource.DecimalSI),
+				CPULimits:      *resource.NewMilliQuantity(600, resource.DecimalSI),
+				Disk:           *resource.NewQuantity(0, resource.BinarySI),
+				MemoryRequests: *resource.NewQuantity(197132288, resource.BinarySI),
+				MemoryLimits:   *resource.NewQuantity(805306368, resource.BinarySI),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.TODO()
+			fclient := fake.NewClientBuilder().WithScheme(pkg.SetupScheme()).
+				WithObjects(cm).Build()
+			viper.Set("PLANS_NAMESPACE", tt.args.ns)
+			viper.AutomaticEnv()
+
+			got, err := FetchSidecarFromCluster(ctx, fclient, tt.args.name, tt.args.sideCar)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assertEqualRessource(t, tt.want, got)
+				s, err := FetchSidecarsFromCluster(ctx, fclient, "test")
+				assert.NoError(t, err)
+				r, err := GetAllSideCarsResources(s)
+				assert.NoError(t, err)
+				assert.Equal(t, r.CPULimits.MilliValue(), resource.NewMilliQuantity(4800, resource.DecimalSI).MilliValue())
+				assert.Equal(t, r.CPURequests.MilliValue(), resource.NewMilliQuantity(850, resource.DecimalSI).MilliValue())
+				assert.Equal(t, r.MemoryLimits.Value(), resource.NewQuantity(6442450944, resource.BinarySI).Value())
+				assert.Equal(t, r.MemoryRequests.Value(), resource.NewQuantity(1140850688, resource.BinarySI).Value())
+			}
+		})
+	}
+}

--- a/pkg/controller/webhooks/postgresql_test.go
+++ b/pkg/controller/webhooks/postgresql_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/go-logr/logr"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	vshnv1 "github.com/vshn/appcat/v4/apis/vshn/v1"
 	"github.com/vshn/appcat/v4/pkg"
@@ -24,13 +25,108 @@ func TestPostgreSQLWebhookHandler_ValidateCreate(t *testing.T) {
 			},
 		},
 	}
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "vshnpostgresqlplans",
+			Namespace: "testns",
+		},
+		Data: map[string]string{
+			"sideCars": `
+			{
+				"clusterController": {
+					"limits": {
+						"cpu": "600m",
+						"memory": "768Mi"
+					},
+					"requests": {
+						"cpu": "32m",
+						"memory": "188Mi"
+					}
+				},
+				"createBackup": {
+					"limits": {
+						"cpu": "600m",
+						"memory": "768Mi"
+					},
+					"requests": {
+						"cpu": "250m",
+						"memory": "256Mi"
+					}
+				},
+				"envoy": {
+					"limits": {
+						"cpu": "600m",
+						"memory": "768Mi"
+					},
+					"requests": {
+						"cpu": "32m",
+						"memory": "64Mi"
+					}
+				},
+				"pgbouncer": {
+					"limits": {
+						"cpu": "600m",
+						"memory": "768Mi"
+					},
+					"requests": {
+						"cpu": "16m",
+						"memory": "32Mi"
+					}
+				},
+				"postgresUtil": {
+					"limits": {
+						"cpu": "600m",
+						"memory": "768Mi"
+					},
+					"requests": {
+						"cpu": "10m",
+						"memory": "4Mi"
+					}
+				},
+				"prometheusPostgresExporter": {
+					"limits": {
+						"cpu": "600m",
+						"memory": "768Mi"
+					},
+					"requests": {
+						"cpu": "10m",
+						"memory": "32Mi"
+					}
+				},
+				"runDbops": {
+					"limits": {
+						"cpu": "600m",
+						"memory": "768Mi"
+					},
+					"requests": {
+						"cpu": "250m",
+						"memory": "256Mi"
+					}
+				},
+				"setDbopsResult": {
+					"limits": {
+						"cpu": "600m",
+						"memory": "768Mi"
+					},
+					"requests": {
+						"cpu": "250m",
+						"memory": "256Mi"
+					}
+				}
+			}
+			`,
+		},
+	}
 
 	ctx := context.TODO()
 
 	fclient := fake.NewClientBuilder().
 		WithScheme(pkg.SetupScheme()).
-		WithObjects(claimNS).
+		WithObjects(claimNS, cm).
 		Build()
+
+	viper.Set("PLANS_NAMESPACE", "testns")
+	viper.AutomaticEnv()
 
 	handler := PostgreSQLWebhookHandler{
 		client:    fclient,
@@ -49,6 +145,7 @@ func TestPostgreSQLWebhookHandler_ValidateCreate(t *testing.T) {
 					CPU:    "500m",
 					Memory: "1Gi",
 				},
+				Instances: 1,
 			},
 		},
 	}
@@ -62,13 +159,13 @@ func TestPostgreSQLWebhookHandler_ValidateCreate(t *testing.T) {
 	//When quota breached
 	// CPU Limits
 	pgInvalid := pgOrig.DeepCopy()
-	pgInvalid.Spec.Parameters.Size.CPU = "5000m"
+	pgInvalid.Spec.Parameters.Size.CPU = "15000m"
 	_, err = handler.ValidateCreate(ctx, pgInvalid)
 	assert.Error(t, err)
 
 	//CPU Requests
 	pgInvalid = pgOrig.DeepCopy()
-	pgInvalid.Spec.Parameters.Size.Requests.CPU = "5000m"
+	pgInvalid.Spec.Parameters.Size.Requests.CPU = "6500m"
 	_, err = handler.ValidateCreate(ctx, pgInvalid)
 	assert.Error(t, err)
 

--- a/pkg/controller/webhooks/redis.go
+++ b/pkg/controller/webhooks/redis.go
@@ -20,7 +20,7 @@ import (
 
 var (
 	redisGK = schema.GroupKind{Group: "vshn.appcat.vshn.io", Kind: "VSHNRedis"}
-	redisGR = schema.GroupResource{Group: pgGK.Group, Resource: "vshnredis"}
+	redisGR = schema.GroupResource{Group: redisGK.Group, Resource: "vshnredis"}
 )
 
 var _ webhook.CustomValidator = &RedisWebhookHandler{}
@@ -48,13 +48,13 @@ func SetupRedisWebhookHandlerWithManager(mgr ctrl.Manager, withQuota bool) error
 // ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type
 func (r *RedisWebhookHandler) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
 
-	pg, ok := obj.(*vshnv1.VSHNRedis)
+	redis, ok := obj.(*vshnv1.VSHNRedis)
 	if !ok {
 		return nil, fmt.Errorf("Provided manifest is not a valid VSHNRedis object")
 	}
 
 	if r.withQuota {
-		err := r.checkQuotas(ctx, pg, true)
+		err := r.checkQuotas(ctx, redis, true)
 		if err != nil {
 			return nil, err
 		}
@@ -95,6 +95,8 @@ func (r *RedisWebhookHandler) ValidateDelete(ctx context.Context, obj runtime.Ob
 func (r *RedisWebhookHandler) checkQuotas(ctx context.Context, redis *vshnv1.VSHNRedis, checkNamespaceQuota bool) *apierrors.StatusError {
 
 	var fieldErr *field.Error
+	// TODO: Fix once we support replicas
+	instances := int64(1)
 	allErrs := field.ErrorList{}
 	resources := utils.Resources{}
 
@@ -148,7 +150,7 @@ func (r *RedisWebhookHandler) checkQuotas(ctx context.Context, redis *vshnv1.VSH
 	// But at the same time, if any of these fail we cannot do proper quota checks anymore.
 	if len(allErrs) != 0 {
 		return apierrors.NewInvalid(
-			pgGK,
+			redisGK,
 			redis.GetName(),
 			allErrs,
 		)
@@ -163,9 +165,10 @@ func (r *RedisWebhookHandler) checkQuotas(ctx context.Context, redis *vshnv1.VSH
 		redis.GetNamespace(),
 		redis.Status.InstanceNamespace,
 		resources,
-		pgGR,
-		pgGK,
+		redisGR,
+		redisGK,
 		checkNamespaceQuota,
+		instances,
 	)
 
 	return checker.CheckQuotas(ctx)

--- a/pkg/controller/webhooks/redis.go
+++ b/pkg/controller/webhooks/redis.go
@@ -71,6 +71,10 @@ func (r *RedisWebhookHandler) ValidateUpdate(ctx context.Context, oldObj, newObj
 		return nil, fmt.Errorf("Provided manifest is not a valid VSHNRedis object")
 	}
 
+	if redis.DeletionTimestamp != nil {
+		return nil, nil
+	}
+
 	if r.withQuota {
 		err := r.checkQuotas(ctx, redis, false)
 		if err != nil {

--- a/test/transforms/common/quotas/01_default.yaml
+++ b/test/transforms/common/quotas/01_default.yaml
@@ -28,6 +28,27 @@ observed:
                 name: myns
               data:
 desired:
+  composite:
+    resource:
+      apiVersion: vshn.appcat.vshn.io/v1
+      kind: XVSHNPostgreSQL
+      metadata:
+        creationTimestamp: "2023-03-21T16:52:31Z"
+        finalizers:
+          - composite.apiextensions.crossplane.io
+        generateName: pgsql-
+        generation: 13
+        labels:
+          appuio.io/organization: vshn
+          crossplane.io/claim-name: pgsql
+          crossplane.io/claim-namespace: unit-test
+          crossplane.io/composite: pgsql-gc9x4
+        name: pgsql-gc9x4
+      spec:
+        parameters: null
+        writeConnectionSecretToRef: {}
+      status:
+        instanceNamespace: my-psql
   resources:
     - name: namespace
       resource:


### PR DESCRIPTION
## Summary

* The resources of the sidecars are not taken into account when calculating the quota for the instance namespace. This results in too low quotas for the instance namespace when deploying multiple instances of a PostgreSQL instance, as the namespace doesn't have high enough quota defined.
* This PR addresses this issue, by taking the resources of the sidecars into account when calculating the required quotas for the instance namespace.


## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
