### PR TITLE
Use Bitnami Redis image to check for newer tags

### DIFF
--- a/pkg/maintenance/redis.go
+++ b/pkg/maintenance/redis.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"strconv"
+
 	"github.com/blang/semver/v4"
 	"github.com/crossplane-contrib/provider-helm/apis/release/v1beta1"
 	"github.com/go-logr/logr"
@@ -11,12 +14,10 @@ import (
 	"github.com/vshn/appcat/v4/pkg/controller/postgres"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
-	"net/http"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"strconv"
 )
 
-var redisURL = "https://hub.docker.com/v2/namespaces/library/repositories/redis/tags?page_size=100"
+var redisURL = "https://hub.docker.com/v2/repositories/bitnami/redis/tags/?page_size=100"
 var imageContentType = "image"
 var activeTagStatus = "active"
 


### PR DESCRIPTION
## Summary
Previously it checked against the offial Redis image. Which may be further ahead than Bitnami, causing issues.


## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
