### PR TITLE
Override the Minio fullname

### DIFF
--- a/pkg/comp-functions/functions/vshnminio/minio_deploy.go
+++ b/pkg/comp-functions/functions/vshnminio/minio_deploy.go
@@ -107,8 +107,9 @@ func createObjectHelmRelease(ctx context.Context, comp *vshnv1.VSHNMinio, iof *r
 	}
 
 	values := map[string]interface{}{
-		"mode":     comp.Spec.Parameters.Service.Mode,
-		"replicas": comp.Spec.Parameters.Instances,
+		"fullnameOverride": comp.GetName(),
+		"mode":             comp.Spec.Parameters.Service.Mode,
+		"replicas":         comp.Spec.Parameters.Instances,
 		"networkPolicy": map[string]interface{}{
 			"enabled": true,
 		},


### PR DESCRIPTION
The Minio helm chart has some funky logic that changes the fullname variable depending on wheter it contains the string `minio` or not.

This commit will simply set the fullname to the composite name.

Ref:
https://github.com/minio/minio/blob/22ee67813618351ca8a983eee65f6460af7d9afe/helm/minio/templates/_helpers.tpl#L19C22-L19C26

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
