### PR TITLE
Add redis sla reports and fix wrong service key for redis and postgresql

### DIFF
--- a/cmd/slareport.go
+++ b/cmd/slareport.go
@@ -56,7 +56,7 @@ upload them to an S3 bucket.`,
 	command.Flags().StringVar(&endpointURL, "endpointurl", viper.GetString("ENDPOINT_URL"), "S3 endpoint url for uploading the reports. ENV: ENDPOINT_URL")
 	command.Flags().StringVar(&bucket, "bucket", viper.GetString("BUCKET_NAME"), "S3 bucketname for uploading the reports. ENV: BUCKET_NAME")
 	command.Flags().StringVar(&mimirOrg, "mimirorg", "", "Set the X-Scope-OrgID header for mimir queries")
-	command.Flags().StringToStringVar(&serviceSlas, "sla", nil, "Set SLA for each service comma separated. Ex. 's1=sla1,s2=sla2'. Available services: vshnpostgresql")
+	command.Flags().StringToStringVar(&serviceSlas, "sla", nil, "Set SLA for each service comma separated. Ex. 's1=sla1,s2=sla2'. Available services: vshnpostgresql, vshnredis")
 	command.Flags().BoolVar(&previousMonth, "previousmonth", false, "Run the report for the previous month. Sets the date to the last day of the previous month and range to 30d. This takes precedence over date and range.")
 
 	return command

--- a/pkg/slareport/prom.go
+++ b/pkg/slareport/prom.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"k8s.io/utils/strings/slices"
 	"strings"
 	"time"
+
+	"k8s.io/utils/strings/slices"
 
 	"github.com/appuio/appuio-cloud-reporting/pkg/thanos"
 	"github.com/prometheus/client_golang/api"
@@ -23,7 +24,7 @@ var (
 	promClientFunc   = getPrometheusAPIClient
 	getMetricsFunc   = getSLAMetrics
 	getTargetSLAFunc = getTargetSLA
-	allowedServices  = []string{"vshnpostgresql"}
+	allowedServices  = []string{"vshnpostgresql", "vshnredis"}
 )
 
 func getPrometheusAPIClient(promURL string, thanosAllowPartialResponses bool, orgID string) (apiv1.API, error) {

--- a/pkg/slareport/prom_test.go
+++ b/pkg/slareport/prom_test.go
@@ -92,6 +92,15 @@ func TestRunQuery(t *testing.T) {
 						Service:    "vshnpostgresql",
 						Color:      "green",
 					},
+					{
+						Namespace:  "myns",
+						Instance:   "test-2",
+						TargetSLA:  99.9,
+						OutcomeSLA: 99.99,
+						Cluster:    "mycluster",
+						Service:    "vshnredis",
+						Color:      "green",
+					},
 				},
 			},
 			metrics: model.Matrix{

--- a/pkg/sliexporter/vshnpostgresql_controller/vshnpostgresql_controller.go
+++ b/pkg/sliexporter/vshnpostgresql_controller/vshnpostgresql_controller.go
@@ -37,7 +37,7 @@ import (
 )
 
 var (
-	vshnpostgresqlsServiceKey = "XVSHNPostgreSQL"
+	vshnpostgresqlsServiceKey = "VSHNPostgreSQL"
 	claimNamespaceLabel       = "crossplane.io/claim-namespace"
 	claimNameLabel            = "crossplane.io/claim-name"
 )

--- a/pkg/sliexporter/vshnpostgresql_controller/vshnpostgresql_controller_test.go
+++ b/pkg/sliexporter/vshnpostgresql_controller/vshnpostgresql_controller_test.go
@@ -39,7 +39,7 @@ func TestVSHNPostgreSQL_StartStop(t *testing.T) {
 		},
 	}
 	pi := probes.ProbeInfo{
-		Service: "XVSHNPostgreSQL",
+		Service: "VSHNPostgreSQL",
 		Name:    "foo",
 	}
 
@@ -68,7 +68,7 @@ func TestVSHNPostgreSQL_StartStop_WithFinalizer(t *testing.T) {
 		},
 	}
 	pi := probes.ProbeInfo{
-		Service: "XVSHNPostgreSQL",
+		Service: "VSHNPostgreSQL",
 		Name:    "foo",
 	}
 
@@ -96,15 +96,15 @@ func TestVSHNPostgreSQL_Multi(t *testing.T) {
 	)
 
 	barPi := probes.ProbeInfo{
-		Service: "XVSHNPostgreSQL",
+		Service: "VSHNPostgreSQL",
 		Name:    "foo",
 	}
 	barerPi := probes.ProbeInfo{
-		Service: "XVSHNPostgreSQL",
+		Service: "VSHNPostgreSQL",
 		Name:    "fooer",
 	}
 	buzzPi := probes.ProbeInfo{
-		Service: "XVSHNPostgreSQL",
+		Service: "VSHNPostgreSQL",
 		Name:    "foobar",
 	}
 
@@ -171,7 +171,7 @@ func TestVSHNPostgreSQL_Started_NoCreds_Probe_Failure(t *testing.T) {
 		db,
 	)
 	pi := probes.ProbeInfo{
-		Service: "XVSHNPostgreSQL",
+		Service: "VSHNPostgreSQL",
 		Name:    "foo",
 	}
 
@@ -208,7 +208,7 @@ func TestVSHNPostgreSQL_PassCredentials(t *testing.T) {
 	)
 	r.PostgreDialer = func(service, name, namespace, dsn, organization, sla string, ha bool, ops ...func(*pgxpool.Config) error) (*probes.PostgreSQL, error) {
 
-		assert.Equal(t, "XVSHNPostgreSQL", service)
+		assert.Equal(t, "VSHNPostgreSQL", service)
 		assert.Equal(t, "foo", name)
 		assert.Equal(t, "bar", namespace)
 		assert.Equal(t, "postgresql://userfoo:password@foo.bar:5433/pg?sslmode=verify-ca", dsn)
@@ -225,7 +225,7 @@ func TestVSHNPostgreSQL_PassCredentials(t *testing.T) {
 		},
 	}
 	pi := probes.ProbeInfo{
-		Service: "XVSHNPostgreSQL",
+		Service: "VSHNPostgreSQL",
 		Name:    "foo",
 	}
 

--- a/pkg/sliexporter/vshnredis_controller/vshnredis_controller.go
+++ b/pkg/sliexporter/vshnredis_controller/vshnredis_controller.go
@@ -24,7 +24,7 @@ import (
 )
 
 var (
-	vshnRedisServiceKey = "XVSHNRedis"
+	vshnRedisServiceKey = "VSHNRedis"
 	claimNamespaceLabel = "crossplane.io/claim-namespace"
 	claimNameLabel      = "crossplane.io/claim-name"
 )

--- a/pkg/sliexporter/vshnredis_controller/vshnredis_controller_test.go
+++ b/pkg/sliexporter/vshnredis_controller/vshnredis_controller_test.go
@@ -166,7 +166,7 @@ func TestVSHNRedis_StartStop(t *testing.T) {
 		},
 	}
 	pi := probes.ProbeInfo{
-		Service:   "XVSHNRedis",
+		Service:   "VSHNRedis",
 		Name:      "foo",
 		Namespace: "bar",
 	}
@@ -196,7 +196,7 @@ func TestVSHNRedis_StartStop_WithFinalizer(t *testing.T) {
 		},
 	}
 	pi := probes.ProbeInfo{
-		Service:   "XVSHNRedis",
+		Service:   "VSHNRedis",
 		Name:      "foo",
 		Namespace: "bar",
 	}
@@ -225,17 +225,17 @@ func TestVSHNRedis_Multi(t *testing.T) {
 	)
 
 	barPi := probes.ProbeInfo{
-		Service:   "XVSHNRedis",
+		Service:   "VSHNRedis",
 		Name:      "foo",
 		Namespace: "bar",
 	}
 	barerPi := probes.ProbeInfo{
-		Service:   "XVSHNRedis",
+		Service:   "VSHNRedis",
 		Name:      "fooer",
 		Namespace: "bar",
 	}
 	buzzPi := probes.ProbeInfo{
-		Service:   "XVSHNRedis",
+		Service:   "VSHNRedis",
 		Name:      "fooz",
 		Namespace: "buzz",
 	}
@@ -267,7 +267,7 @@ func TestVSHNRedis_Startup_NoCreds_Dont_Probe(t *testing.T) {
 		db,
 	)
 	pi := probes.ProbeInfo{
-		Service:   "XVSHNRedis",
+		Service:   "VSHNRedis",
 		Name:      "foo",
 		Namespace: "bar",
 	}
@@ -286,7 +286,7 @@ func TestVSHNRedis_NoRef_Dont_Probe(t *testing.T) {
 		db,
 	)
 	pi := probes.ProbeInfo{
-		Service:   "XVSHNRedis",
+		Service:   "VSHNRedis",
 		Name:      "foo",
 		Namespace: "bar",
 	}
@@ -303,7 +303,7 @@ func TestVSHNRedis_Started_NoCreds_Probe_Failure(t *testing.T) {
 		db,
 	)
 	pi := probes.ProbeInfo{
-		Service:   "XVSHNRedis",
+		Service:   "VSHNRedis",
 		Name:      "foo",
 		Namespace: "bar",
 	}
@@ -343,7 +343,7 @@ func TestVSHNRedis_PassCerdentials(t *testing.T) {
 	)
 	r.RedisDialer = func(service, name, namespace, organization string, ha bool, opts redis.Options) (*probes.VSHNRedis, error) {
 
-		assert.Equal(t, "XVSHNRedis", service)
+		assert.Equal(t, "VSHNRedis", service)
 		assert.Equal(t, "foo", name)
 		assert.Equal(t, "bar", namespace)
 		assert.Equal(t, "bar", organization)
@@ -374,7 +374,7 @@ func TestVSHNRedis_PassCerdentials(t *testing.T) {
 		},
 	}
 	pi := probes.ProbeInfo{
-		Service:   "XVSHNRedis",
+		Service:   "VSHNRedis",
 		Name:      "foo",
 		Namespace: "bar",
 	}


### PR DESCRIPTION
## Summary

* Add support for redis sla reports
* Fix wrong service key for Redis and PostgreSQL

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [ ] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
