### PR TITLE
Fix deployment strategy for Minio standalone setups

### DIFF
--- a/pkg/comp-functions/functions/vshnminio/minio_deploy.go
+++ b/pkg/comp-functions/functions/vshnminio/minio_deploy.go
@@ -113,6 +113,9 @@ func createObjectHelmRelease(ctx context.Context, comp *vshnv1.VSHNMinio, iof *r
 		"networkPolicy": map[string]interface{}{
 			"enabled": true,
 		},
+		"deploymentUpdate": map[string]interface{}{
+			"type": "Recreate",
+		},
 		"resources": map[string]interface{}{
 			"requests": map[string]interface{}{
 				"memory": reqMem,


### PR DESCRIPTION
## Summary

The default deployment strategy for minio `standalone` setups is to use the `RollingUpdate` strategy. However, this strategy won't work when using RWO volumes as the `standalone` strategy is hardcoded to 1 replica.
We therefore enforce the `Recreate` strategy on the standalone mode.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [ ] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
