### PR TITLE
Add serviceMonitor for minio to scrape minio relevant metrics

### DIFF
--- a/pkg/comp-functions/functions/vshnminio/minio_deploy_test.go
+++ b/pkg/comp-functions/functions/vshnminio/minio_deploy_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	xhelmbeta1 "github.com/crossplane-contrib/provider-helm/apis/release/v1beta1"
+	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/stretchr/testify/assert"
 	vshnv1 "github.com/vshn/appcat/v4/apis/vshn/v1"
 	"github.com/vshn/appcat/v4/pkg/comp-functions/functions/commontest"
@@ -37,6 +38,11 @@ func TestMinioDeploy(t *testing.T) {
 	assert.Equal(t, rootUser, cd[0].Value)
 	assert.Equal(t, rootPassword, cd[1].Value)
 	assert.Equal(t, minioHost, cd[2].Value)
+
+	sm := &promv1.ServiceMonitor{}
+	assert.NoError(t, iof.Desired.GetFromObject(ctx, sm, comp.Name+"-service-monitor"))
+	assert.Equal(t, "/minio/v2/metrics/node", sm.Spec.Endpoints[0].Path)
+	assert.Equal(t, "/minio/v2/metrics/cluster", sm.Spec.Endpoints[1].Path)
 }
 
 func getMinioComp(t *testing.T) (*runtime.Runtime, *vshnv1.VSHNMinio) {


### PR DESCRIPTION
## Summary

* Add serviceMonitor for minio to scrape minio metrics

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
