### PR TITLE
Add additional scrape configs for getting minio relevant metrics

### DIFF
--- a/pkg/comp-functions/functions/vshnminio/minio_deploy.go
+++ b/pkg/comp-functions/functions/vshnminio/minio_deploy.go
@@ -267,6 +267,16 @@ func createServiceMonitor(ctx context.Context, comp *vshnv1.VSHNMinio, iof *runt
 					Scheme: "http",
 					Path:   "/minio/v2/metrics/cluster",
 				},
+				{
+					Port:   "http",
+					Scheme: "http",
+					Path:   "/minio/v2/metrics/bucket",
+				},
+				{
+					Port:   "http",
+					Scheme: "http",
+					Path:   "/minio/v2/metrics/resource",
+				},
 			},
 			Selector: metav1.LabelSelector{
 				MatchLabels: map[string]string{

--- a/pkg/comp-functions/functions/vshnminio/minio_deploy_test.go
+++ b/pkg/comp-functions/functions/vshnminio/minio_deploy_test.go
@@ -43,6 +43,8 @@ func TestMinioDeploy(t *testing.T) {
 	assert.NoError(t, iof.Desired.GetFromObject(ctx, sm, comp.Name+"-service-monitor"))
 	assert.Equal(t, "/minio/v2/metrics/node", sm.Spec.Endpoints[0].Path)
 	assert.Equal(t, "/minio/v2/metrics/cluster", sm.Spec.Endpoints[1].Path)
+	assert.Equal(t, "/minio/v2/metrics/bucket", sm.Spec.Endpoints[2].Path)
+	assert.Equal(t, "/minio/v2/metrics/resource", sm.Spec.Endpoints[3].Path)
 }
 
 func getMinioComp(t *testing.T) (*runtime.Runtime, *vshnv1.VSHNMinio) {


### PR DESCRIPTION
## Summary

* MinIO scrapes metrics from four different endpoints depending on what the metrics are (cluster, node, bucket, resource)
* We want to scrape all of them to ensure we can effectively monitor the instances as well as the buckets

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
