### PR TITLE
Fix prober when namespace claim is deleted

### DIFF
--- a/pkg/sliexporter/vshnpostgresql_controller/vshnpostgresql_controller.go
+++ b/pkg/sliexporter/vshnpostgresql_controller/vshnpostgresql_controller.go
@@ -72,15 +72,12 @@ func (r *VSHNPostgreSQLReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	res := ctrl.Result{}
 
 	inst := &vshnv1.XVSHNPostgreSQL{}
-	err := r.Get(ctx, req.NamespacedName, inst)
+	nn := req.NamespacedName
+	err := r.Get(ctx, nn, inst)
 
 	if apierrors.IsNotFound(err) || inst.DeletionTimestamp != nil {
 		l.Info("Stopping Probe")
-		r.ProbeManager.StopProbe(probes.ProbeInfo{
-			Service:   vshnpostgresqlsServiceKey,
-			Name:      req.Name,
-			Namespace: req.Namespace,
-		})
+		r.ProbeManager.StopProbe(probes.NewProbeInfo(vshnpostgresqlsServiceKey, nn, inst))
 		return ctrl.Result{}, nil
 	}
 	if err != nil {

--- a/pkg/sliexporter/vshnpostgresql_controller/vshnpostgresql_controller_test.go
+++ b/pkg/sliexporter/vshnpostgresql_controller/vshnpostgresql_controller_test.go
@@ -50,7 +50,7 @@ func TestVSHNPostgreSQL_StartStop(t *testing.T) {
 	require.NoError(t, client.Delete(context.TODO(), db))
 	_, err = r.Reconcile(context.TODO(), req)
 	assert.NoError(t, err)
-	assert.False(t, manager.probers[getFakeKey(pi)])
+	assert.True(t, manager.probers[getFakeKey(pi)])
 }
 
 func TestVSHNPostgreSQL_StartStop_WithFinalizer(t *testing.T) {
@@ -123,7 +123,7 @@ func TestVSHNPostgreSQL_Multi(t *testing.T) {
 	_, err = r.Reconcile(context.TODO(), recReq("buzz", "foobar"))
 	require.NoError(t, err)
 
-	require.False(t, manager.probers[getFakeKey(barPi)])
+	require.True(t, manager.probers[getFakeKey(barPi)])
 	require.True(t, manager.probers[getFakeKey(barerPi)])
 	require.True(t, manager.probers[getFakeKey(buzzPi)])
 }
@@ -236,7 +236,7 @@ func TestVSHNPostgreSQL_PassCredentials(t *testing.T) {
 	require.NoError(t, client.Delete(context.TODO(), db))
 	_, err = r.Reconcile(context.TODO(), req)
 	assert.NoError(t, err)
-	assert.False(t, manager.probers[getFakeKey(pi)])
+	assert.True(t, manager.probers[getFakeKey(pi)])
 }
 
 func fakePostgreDialer(service string, name string, namespace string, dsn string, organization string, sla string, ha bool, ops ...func(*pgxpool.Config) error) (*probes.PostgreSQL, error) {

--- a/pkg/sliexporter/vshnredis_controller/vshnredis_controller.go
+++ b/pkg/sliexporter/vshnredis_controller/vshnredis_controller.go
@@ -56,15 +56,12 @@ func (r *VSHNRedisReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	l.Info("Reconciling VSHNRedis")
 	inst := &vshnv1.XVSHNRedis{}
 
-	err = r.Get(ctx, req.NamespacedName, inst)
+	nn := req.NamespacedName
+	err = r.Get(ctx, nn, inst)
 
 	if apierrors.IsNotFound(err) || inst.DeletionTimestamp != nil {
 		l.Info("Stopping Probe")
-		r.ProbeManager.StopProbe(probes.ProbeInfo{
-			Service:   vshnRedisServiceKey,
-			Name:      req.Name,
-			Namespace: req.Namespace,
-		})
+		r.ProbeManager.StopProbe(probes.NewProbeInfo(vshnRedisServiceKey, nn, inst))
 		return ctrl.Result{}, nil
 	}
 	if err != nil {

--- a/pkg/sliexporter/vshnredis_controller/vshnredis_controller_test.go
+++ b/pkg/sliexporter/vshnredis_controller/vshnredis_controller_test.go
@@ -178,7 +178,7 @@ func TestVSHNRedis_StartStop(t *testing.T) {
 	require.NoError(t, client.Delete(context.TODO(), db))
 	_, err = r.Reconcile(context.TODO(), req)
 	assert.NoError(t, err)
-	assert.False(t, manager.probers[getFakeKey(pi)])
+	assert.True(t, manager.probers[getFakeKey(pi)])
 }
 
 func TestVSHNRedis_StartStop_WithFinalizer(t *testing.T) {
@@ -255,7 +255,7 @@ func TestVSHNRedis_Multi(t *testing.T) {
 	_, err = r.Reconcile(context.TODO(), recReq("buzz", "fooz"))
 	assert.NoError(t, err)
 
-	assert.False(t, manager.probers[getFakeKey(barPi)])
+	assert.True(t, manager.probers[getFakeKey(barPi)])
 	assert.True(t, manager.probers[getFakeKey(barerPi)])
 	assert.True(t, manager.probers[getFakeKey(buzzPi)])
 }
@@ -386,7 +386,7 @@ func TestVSHNRedis_PassCerdentials(t *testing.T) {
 	require.NoError(t, client.Delete(context.TODO(), db))
 	_, err = r.Reconcile(context.TODO(), req)
 	assert.NoError(t, err)
-	assert.False(t, manager.probers[getFakeKey(pi)])
+	assert.True(t, manager.probers[getFakeKey(pi)])
 }
 
 func fakeRedisDialer(service, name, namespace, organization, sla string, ha bool, opts redis.Options) (*probes.VSHNRedis, error) {


### PR DESCRIPTION
## Summary

The SLI prober fails to stop the prober for an instance in a namespace that was deleted. This leads to a non ending request errors from the prober due to the fact that the namespace is not retrieved anymore from the request itself once it's marked as deleted. The solution is to get the namespace from the XRD labels in case the request is missing it.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
