### PR TITLE
Increase memory limit of the controller

### DIFF
--- a/config/controller/deployment.yaml
+++ b/config/controller/deployment.yaml
@@ -38,7 +38,7 @@ spec:
           resources:
             limits:
               cpu: 100m
-              memory: 30Mi
+              memory: 100Mi
             requests:
               cpu: 100m
               memory: 20Mi


### PR DESCRIPTION
## Summary

The new event-forwarding feature requires more memory, we therefore need to increase the memory limit for the deployment to not run into oom kills

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [ ] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
