### PR TITLE
Fix quota namespace not found

### DIFF
--- a/package/package.mk
+++ b/package/package.mk
@@ -3,6 +3,7 @@ package-function: docker-build
 	yq e '.spec.image="${GHCR_IMG}"' package/crossplane.yaml.template > package/crossplane.yaml
 	rm -f package/*.xpkg
 	go run github.com/crossplane/crossplane/cmd/crank xpkg build -f package --verbose --embed-runtime-image=${GHCR_IMG} -o package/package-function-appcat.xpkg
+	git checkout package/crossplane.yaml
 
 .PHONY: install-proxy
 install-proxy:


### PR DESCRIPTION
This fixes a bug where the quota namespace was not found. It also fixes a bug that would override the namespace with a wrong name.

There's also now an additional check to see if the name of the namespace is empty or not. This helps mitigating wrong patches from the PnT function.

Also found a bug with the release action, goreleaser was failing due to a dirty repository.

## Summary

* Short summary of what's included in the PR
* Give special note to breaking changes

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
