### PR TITLE
Remove any excess finalizers

### DIFF
--- a/pkg/controller/postgres/deletion_protection.go
+++ b/pkg/controller/postgres/deletion_protection.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strconv"
 	"time"
 
@@ -83,17 +84,20 @@ func getRequeueTime(ctx context.Context, inst client.Object, deletionTime *metav
 }
 
 func getPatchObjectFinalizer(log logr.Logger, inst client.Object, op jsonpatch.JSONop) (client.Patch, error) {
-	if op == jsonpatch.JSONopNone {
-		return nil, nil
-	}
-
 	// handle the case if crossplane or something else decides to add more finalizers, or if
 	// the finalizer is already there.
 	index := len(inst.GetFinalizers())
+	dupes := []int{}
 	for i, finalizer := range inst.GetFinalizers() {
 		if finalizer == finalizerName {
 			index = i
+			dupes = append(dupes, i)
 		}
+	}
+
+	// if this is a noop and we have exactly one or no dupe, then we're done here
+	if op == jsonpatch.JSONopNone && (len(dupes) == 1 || len(dupes) == 0) {
+		return nil, nil
 	}
 
 	log.V(1).Info("Index size", "size", index, "found finalizers", inst.GetFinalizers())
@@ -103,12 +107,32 @@ func getPatchObjectFinalizer(log logr.Logger, inst client.Object, op jsonpatch.J
 		strIndex = "-"
 	}
 
-	patchOps := []jsonpatch.JSONpatch{
-		{
+	patchOps := []jsonpatch.JSONpatch{}
+	if op != jsonpatch.JSONopNone {
+		patchOps = append(patchOps, jsonpatch.JSONpatch{
 			Op:    op,
 			Path:  "/metadata/finalizers/" + strIndex,
 			Value: finalizerName,
-		},
+		})
+	}
+
+	// if we have more than one of our finalizers, we need to remove the excess ones
+	if len(dupes) > 1 {
+		// Jsonpatch doesn't specify how deletion of multiple indices in an array is handled.
+		// When starting with the lowest first, it could be that the indices all shift and not match anymore.
+		// We reverse sort, so that the patch contains the largest index first.
+		// This way we avoid any index shifting during the deletion and are on the safe side.
+		sort.Sort(sort.Reverse(sort.IntSlice(dupes)))
+		for _, v := range dupes {
+			// We skip the first one, so we don't remove all of them
+			if v == 0 {
+				continue
+			}
+			patchOps = append(patchOps, jsonpatch.JSONpatch{
+				Op:   jsonpatch.JSONopRemove,
+				Path: "/metadata/finalizers/" + strconv.Itoa(v),
+			})
+		}
 	}
 
 	patch, err := json.Marshal(patchOps)


### PR DESCRIPTION
## Summary

The controller now checks if there are more than 1 appcat finalizers on the composite and remove all except one if it's the case.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
