### PR TITLE
 Don't handle events we don't care about 

### DIFF
--- a/pkg/controller/events/event_forwarder.go
+++ b/pkg/controller/events/event_forwarder.go
@@ -38,6 +38,17 @@ func (e *EventHandler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Re
 		log.Error(err, "Can't read the event", "event", event)
 		return ctrl.Result{}, err
 	}
+	// We might get events without a name. We don't care about those.
+	// Return and don't requeue
+	if strings.HasPrefix(event.Name, ".") {
+		return ctrl.Result{}, nil
+	}
+
+	// We don't care about events of events without a `Kind` or `apiVersion`
+	// Return and don't requeue
+	if event.InvolvedObject.Kind == "" || event.InvolvedObject.APIVersion == "" {
+		return ctrl.Result{}, nil
+	}
 
 	// Get the object the event is about
 	obj := &unstructured.Unstructured{}


### PR DESCRIPTION
## Summary

Some events don't set the `kind` or `apiVersion` of the involvedObject
and some events don't have a proper name.
In all those cases, we don't care about those events and don't process
them.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [ ] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
