### PR TITLE
Fix nilpointer panic when provisioning an instance

### DIFF
--- a/pkg/sliexporter/vshnminio_controller/vshnminio_controller.go
+++ b/pkg/sliexporter/vshnminio_controller/vshnminio_controller.go
@@ -71,7 +71,7 @@ func (r *VSHNMinioReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return ctrl.Result{}, err
 	}
 
-	if inst.Spec.WriteConnectionSecretToReference.Name == "" {
+	if inst.Spec.WriteConnectionSecretToReference == nil || inst.Spec.WriteConnectionSecretToReference.Name == "" {
 		l.Info("No connection secret requested. Skipping.")
 		return ctrl.Result{}, nil
 	}

--- a/pkg/sliexporter/vshnpostgresql_controller/vshnpostgresql_controller.go
+++ b/pkg/sliexporter/vshnpostgresql_controller/vshnpostgresql_controller.go
@@ -84,7 +84,7 @@ func (r *VSHNPostgreSQLReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		return ctrl.Result{}, err
 	}
 
-	if inst.Spec.WriteConnectionSecretToReference.Name == "" {
+	if inst.Spec.WriteConnectionSecretToReference == nil || inst.Spec.WriteConnectionSecretToReference.Name == "" {
 		l.Info("No connection secret requested. Skipping.")
 		return ctrl.Result{}, nil
 	}

--- a/pkg/sliexporter/vshnredis_controller/vshnredis_controller.go
+++ b/pkg/sliexporter/vshnredis_controller/vshnredis_controller.go
@@ -68,7 +68,7 @@ func (r *VSHNRedisReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return ctrl.Result{}, err
 	}
 
-	if inst.Spec.WriteConnectionSecretToReference.Name == "" {
+	if inst.Spec.WriteConnectionSecretToReference == nil || inst.Spec.WriteConnectionSecretToReference.Name == "" {
 		l.Info("No connection secret requested. Skipping.")
 		return ctrl.Result{}, nil
 	}


### PR DESCRIPTION


## Summary

This fixes a nilpointer when a new instance is deployed. The `Spec.WriteConnectionSecretToReference` is not populated on the first reconcile.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
