### PR TITLE
Delay creation of the cluster object

### DIFF
--- a/pkg/comp-functions/functions/vshnpostgres/delay_cluster.go
+++ b/pkg/comp-functions/functions/vshnpostgres/delay_cluster.go
@@ -1,0 +1,79 @@
+package vshnpostgres
+
+import (
+	"context"
+	"fmt"
+
+	xkube "github.com/crossplane-contrib/provider-kubernetes/apis/object/v1alpha1"
+	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
+	xfnproto "github.com/crossplane/function-sdk-go/proto/v1beta1"
+	stackgresv1 "github.com/vshn/appcat/v4/apis/stackgres/v1"
+	vshnv1 "github.com/vshn/appcat/v4/apis/vshn/v1"
+	"github.com/vshn/appcat/v4/pkg/comp-functions/runtime"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// DelayClusterDeployment adds the dependencies on the sgcluster object, so that the provider-kubernetes doesn't loop anymore.
+// The actual cluster object will only be deployed once the dependencies are deployed, synced and ready.
+func DelayClusterDeployment(_ context.Context, svc *runtime.ServiceRuntime) *xfnproto.Result {
+
+	comp := &vshnv1.VSHNPostgreSQL{}
+	err := svc.GetObservedComposite(comp)
+
+	if err != nil {
+		return runtime.NewFatalResult(fmt.Errorf("Cannot get composite: %w", err))
+	}
+
+	clusterObject := &xkube.Object{}
+	err = svc.GetObservedComposedResource(clusterObject, "cluster")
+	if err == nil {
+		// We're done here, the sgcluster has been applied.
+		return nil
+	} else if err != runtime.ErrNotFound {
+		return runtime.NewFatalResult(fmt.Errorf("Cannot get cluster: %w", err))
+	}
+
+	desiredCluster := &stackgresv1.SGCluster{}
+	err = svc.GetDesiredKubeObject(desiredCluster, "cluster")
+	if err != nil {
+		return runtime.NewFatalResult(fmt.Errorf("cannot get desired cluster: %w", err))
+	}
+
+	svc.DeleteDesiredCompososedResource("cluster")
+
+	if !kubeObjectSyncedAndReady("profile", svc) {
+		return runtime.NewWarningResult("sgProfile is not yet ready, skipping creation of cluster")
+	}
+
+	if !kubeObjectSyncedAndReady("sg-backup", svc) {
+		return runtime.NewWarningResult("SGObjectStorage is not yet ready, skipping creation of cluster")
+	}
+
+	if !kubeObjectSyncedAndReady("pg-conf", svc) {
+		return runtime.NewWarningResult("SGPostgresConfig is not yet ready, skipping creation of cluster")
+	}
+
+	err = svc.SetDesiredKubeObjectWithName(desiredCluster, comp.GetName()+"-cluster", "cluster")
+	if err != nil {
+		return runtime.NewFatalResult(fmt.Errorf("Cannot set SgCluster object: %w", err))
+	}
+
+	return nil
+}
+
+func kubeObjectSyncedAndReady(name string, svc *runtime.ServiceRuntime) bool {
+
+	obj := &xkube.Object{}
+	err := svc.GetObservedComposedResource(obj, name)
+	if err != nil {
+		return false
+	}
+	ready := obj.GetCondition(xpv1.TypeReady)
+	if ready.Status == corev1.ConditionFalse {
+		return false
+	}
+
+	synced := obj.GetCondition(xpv1.TypeSynced)
+
+	return synced.Status == corev1.ConditionTrue
+}

--- a/pkg/comp-functions/functions/vshnpostgres/delay_cluster_test.go
+++ b/pkg/comp-functions/functions/vshnpostgres/delay_cluster_test.go
@@ -1,0 +1,30 @@
+package vshnpostgres
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	stackgresv1 "github.com/vshn/appcat/v4/apis/stackgres/v1"
+	"github.com/vshn/appcat/v4/pkg/comp-functions/functions/commontest"
+	"github.com/vshn/appcat/v4/pkg/comp-functions/runtime"
+)
+
+func TestDelayClusterDeployment(t *testing.T) {
+	svc := commontest.LoadRuntimeFromFile(t, "vshn-postgres/delay_cluster/01_GivenNoDependency.yaml")
+
+	res := DelayClusterDeployment(context.TODO(), svc)
+	assert.Equal(t, runtime.NewWarningResult("sgProfile is not yet ready, skipping creation of cluster"), res)
+
+	cluster := &stackgresv1.SGCluster{}
+	err := svc.GetDesiredKubeObject(cluster, "cluster")
+	assert.ErrorIs(t, err, runtime.ErrNotFound)
+
+	svc = commontest.LoadRuntimeFromFile(t, "vshn-postgres/delay_cluster/01_GivenAllDependencies.yaml")
+
+	res = DelayClusterDeployment(context.TODO(), svc)
+	assert.Nil(t, res)
+
+	err = svc.GetDesiredKubeObject(cluster, "cluster")
+	assert.Nil(t, err)
+}

--- a/pkg/comp-functions/functions/vshnpostgres/register.go
+++ b/pkg/comp-functions/functions/vshnpostgres/register.go
@@ -57,6 +57,10 @@ func init() {
 				Name:    "namespaceQuotas",
 				Execute: common.AddInitialNamespaceQuotas("namespace-conditions"),
 			},
+			{
+				Name:    "delay-cluster-deployment",
+				Execute: DelayClusterDeployment,
+			},
 		},
 	})
 }

--- a/pkg/comp-functions/runtime/function_mgr.go
+++ b/pkg/comp-functions/runtime/function_mgr.go
@@ -361,8 +361,12 @@ func (s *ServiceRuntime) putIntoObject(observeOnly bool, o client.Object, kon st
 					Name: providerConfigRefName,
 				},
 			},
-			References: refs,
 		},
+	}
+
+	// Only set the refs if they are actually set.
+	if len(refs) > 0 {
+		ko.Spec.References = refs
 	}
 
 	if observeOnly {
@@ -688,4 +692,10 @@ func (s *ServiceRuntime) GetDesiredComposite(obj client.Object) error {
 	}
 
 	return json.Unmarshal(jsonBytes, obj)
+}
+
+// DeleteDesiredCompososedResource removes a composite resource from the desired objects.
+// If the object is existing on the cluster, it will be deleted!
+func (s *ServiceRuntime) DeleteDesiredCompososedResource(name string) {
+	delete(s.desirdResources, resource.Name(name))
 }

--- a/test/functions/vshn-postgres/delay_cluster/01_GivenAllDependencies.yaml
+++ b/test/functions/vshn-postgres/delay_cluster/01_GivenAllDependencies.yaml
@@ -1,0 +1,139 @@
+desired:
+  resources:
+    cluster:
+      resource:
+        apiVersion: kubernetes.crossplane.io/v1alpha1
+        kind: Object
+        metadata:
+          name: pgsql-gc9x4-cluster
+        spec:
+          forProvider:
+            manifest:
+              apiVersion: stackgres.io/v1
+              kind: SGCluster
+              metadata:
+                name: psql-gc9x4
+                namespace: vshn-postgresql-psql-gc9x4
+              spec:
+                configurations:
+                  backups:
+                  - cronSchedule: 44 20 * * *
+                    retention: 6
+                    sgObjectStorage: sgbackup-psql-gc9x4
+                  sgPostgresConfig: psql-gc9x4
+                instances: 1
+                nonProductionOptions:
+                  enableSetPatroniCpuRequests: true
+                  enableSetPatroniMemoryRequests: true
+                pods:
+                  persistentVolume:
+                    size: 20Gi
+                  scheduling:
+                    nodeSelector: {}
+                postgres:
+                  ssl:
+                    certificateSecretKeySelector:
+                      key: tls.crt
+                      name: tls-certificate
+                    enabled: true
+                    privateKeySecretKeySelector:
+                      key: tls.key
+                      name: tls-certificate
+                  version: "15"
+                sgInstanceProfile: psql-gc9x4
+          managementPolicy: Default
+          providerConfigRef:
+            name: kubernetes
+  composite:
+    resource:
+      apiVersion: vshn.appcat.vshn.io/v1
+      kind: XVSHNPostgreSQL
+      metadata:
+        creationTimestamp: "2023-03-21T16:52:31Z"
+        finalizers:
+        - composite.apiextensions.crossplane.io
+        generateName: pgsql-
+        generation: 13
+        labels:
+          appuio.io/organization: vshn
+          crossplane.io/claim-name: pgsql
+          crossplane.io/claim-namespace: unit-test
+          crossplane.io/composite: pgsql-gc9x4
+        name: pgsql-gc9x4
+      spec:
+        parameters: null
+        writeConnectionSecretToRef: {}
+      status: {}
+observed:
+  resources:
+    sg-backup:
+      resource:
+        apiVersion: kubernetes.crossplane.io/v1alpha1
+        kind: Object
+        metadata:
+          generateName: pgsql-app1-prod-wdhkp-
+          name: pgsql-app1-prod-wdhkp-pgconf
+        status:
+          conditions:
+            - lastTransitionTime: '2023-12-08T08:46:27Z'
+              reason: Available
+              status: 'True'
+              type: Ready
+            - lastTransitionTime: '2023-12-08T08:46:27Z'
+              reason: ReconcileSuccess
+              status: 'True'
+              type: Synced
+    profile:
+      resource:
+        apiVersion: kubernetes.crossplane.io/v1alpha1
+        kind: Object
+        metadata:
+          generateName: pgsql-app1-prod-wdhkp-
+          name: pgsql-app1-prod-wdhkp-pgconf
+        status:
+          conditions:
+            - lastTransitionTime: '2023-12-08T08:46:27Z'
+              reason: Available
+              status: 'True'
+              type: Ready
+            - lastTransitionTime: '2023-12-08T08:46:27Z'
+              reason: ReconcileSuccess
+              status: 'True'
+              type: Synced
+    pg-conf:
+      resource:
+        apiVersion: kubernetes.crossplane.io/v1alpha1
+        kind: Object
+        metadata:
+          generateName: pgsql-app1-prod-wdhkp-
+          name: pgsql-app1-prod-wdhkp-pgconf
+        status:
+          conditions:
+            - lastTransitionTime: '2023-12-08T08:46:27Z'
+              reason: Available
+              status: 'True'
+              type: Ready
+            - lastTransitionTime: '2023-12-08T08:46:27Z'
+              reason: ReconcileSuccess
+              status: 'True'
+              type: Synced
+  composite:
+    resource:
+      apiVersion: vshn.appcat.vshn.io/v1
+      kind: XVSHNPostgreSQL
+      metadata:
+        creationTimestamp: "2023-03-21T16:52:31Z"
+        finalizers:
+        - composite.apiextensions.crossplane.io
+        generateName: pgsql-
+        generation: 13
+        labels:
+          appuio.io/organization: vshn
+          crossplane.io/claim-name: pgsql
+          crossplane.io/claim-namespace: unit-test
+          crossplane.io/composite: pgsql-gc9x4
+        name: pgsql-gc9x4
+      spec:
+        parameters: null
+        writeConnectionSecretToRef: {}
+      status: {}

--- a/test/functions/vshn-postgres/delay_cluster/01_GivenNoDependency.yaml
+++ b/test/functions/vshn-postgres/delay_cluster/01_GivenNoDependency.yaml
@@ -1,0 +1,87 @@
+desired:
+  resources:
+    cluster:
+      resource:
+        apiVersion: kubernetes.crossplane.io/v1alpha1
+        kind: Object
+        metadata:
+          name: pgsql-gc9x4-cluster
+        spec:
+          forProvider:
+            manifest:
+              apiVersion: stackgres.io/v1
+              kind: SGCluster
+              metadata:
+                name: psql-gc9x4
+                namespace: vshn-postgresql-psql-gc9x4
+              spec:
+                configurations:
+                  backups:
+                  - cronSchedule: 44 20 * * *
+                    retention: 6
+                    sgObjectStorage: sgbackup-psql-gc9x4
+                  sgPostgresConfig: psql-gc9x4
+                instances: 1
+                nonProductionOptions:
+                  enableSetPatroniCpuRequests: true
+                  enableSetPatroniMemoryRequests: true
+                pods:
+                  persistentVolume:
+                    size: 20Gi
+                  scheduling:
+                    nodeSelector: {}
+                postgres:
+                  ssl:
+                    certificateSecretKeySelector:
+                      key: tls.crt
+                      name: tls-certificate
+                    enabled: true
+                    privateKeySecretKeySelector:
+                      key: tls.key
+                      name: tls-certificate
+                  version: "15"
+                sgInstanceProfile: psql-gc9x4
+          managementPolicy: Default
+          providerConfigRef:
+            name: kubernetes
+  composite:
+    resource:
+      apiVersion: vshn.appcat.vshn.io/v1
+      kind: XVSHNPostgreSQL
+      metadata:
+        creationTimestamp: "2023-03-21T16:52:31Z"
+        finalizers:
+        - composite.apiextensions.crossplane.io
+        generateName: pgsql-
+        generation: 13
+        labels:
+          appuio.io/organization: vshn
+          crossplane.io/claim-name: pgsql
+          crossplane.io/claim-namespace: unit-test
+          crossplane.io/composite: pgsql-gc9x4
+        name: pgsql-gc9x4
+      spec:
+        parameters: null
+        writeConnectionSecretToRef: {}
+      status: {}
+observed:
+  composite:
+    resource:
+      apiVersion: vshn.appcat.vshn.io/v1
+      kind: XVSHNPostgreSQL
+      metadata:
+        creationTimestamp: "2023-03-21T16:52:31Z"
+        finalizers:
+        - composite.apiextensions.crossplane.io
+        generateName: pgsql-
+        generation: 13
+        labels:
+          appuio.io/organization: vshn
+          crossplane.io/claim-name: pgsql
+          crossplane.io/claim-namespace: unit-test
+          crossplane.io/composite: pgsql-gc9x4
+        name: pgsql-gc9x4
+      spec:
+        parameters: null
+        writeConnectionSecretToRef: {}
+      status: {}


### PR DESCRIPTION
## Summary

This change will delay the creation of the cluster object in such a way that its dependencies need to be deployed first.

This will avoid some reconcile loops in provider-kubernetes, as it will go into a feedback loop and only try to deploy a failed object, while not reconciling the others.


## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
