### PR TITLE
Adjust stackgres rest-api secret name for stackgres 1.7 upgrade

### DIFF
--- a/pkg/comp-functions/functions/common/maintenance/maintenance_test.go
+++ b/pkg/comp-functions/functions/common/maintenance/maintenance_test.go
@@ -193,7 +193,7 @@ func createMaintenanceSecretTest(instanceNamespace, sgNamespace, resourceName st
 			DependsOn: xkubev1.DependsOn{
 				APIVersion: "v1",
 				Kind:       "Secret",
-				Name:       "stackgres-restapi",
+				Name:       "stackgres-restapi-admin",
 				Namespace:  sgNamespace,
 			},
 			FieldPath: pointer.String("data"),

--- a/pkg/comp-functions/functions/vshnpostgres/maintenance.go
+++ b/pkg/comp-functions/functions/vshnpostgres/maintenance.go
@@ -149,7 +149,7 @@ func createMaintenanceSecret(instanceNamespace, sgNamespace, resourceName string
 			DependsOn: xkubev1.DependsOn{
 				APIVersion: "v1",
 				Kind:       "Secret",
-				Name:       "stackgres-restapi",
+				Name:       "stackgres-restapi-admin",
 				Namespace:  sgNamespace,
 			},
 			FieldPath: ptr.To("data"),

--- a/test/functions/vshn-postgres/loadbalancer/02-ServiceObserverPresent.yaml
+++ b/test/functions/vshn-postgres/loadbalancer/02-ServiceObserverPresent.yaml
@@ -867,7 +867,7 @@ desired:
               apiVersion: v1
               fieldPath: data
               kind: Secret
-              name: stackgres-restapi
+              name: stackgres-restapi-admin
               namespace: stackgres
             toFieldPath: data
         status:
@@ -4577,7 +4577,7 @@ observed:
               apiVersion: v1
               fieldPath: data
               kind: Secret
-              name: stackgres-restapi
+              name: stackgres-restapi-admin
               namespace: stackgres
             toFieldPath: data
         status:


### PR DESCRIPTION
## Summary

* This is BREAKING change and requires Stackgres version >= 1.6
* Stackgres changed secret name, so I'm adjusting it

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
