### PR TITLE
Don't handle the organization label in quotas

### DIFF
--- a/pkg/comp-functions/functions/vshnpostgres/postgresql_deploy.go
+++ b/pkg/comp-functions/functions/vshnpostgres/postgresql_deploy.go
@@ -24,7 +24,7 @@ func DeployPostgreSQL(ctx context.Context, svc *runtime.ServiceRuntime) *xfnprot
 	err = common.BootstrapInstanceNs(ctx, comp, "postgresql", "namespace-conditions", svc)
 	if err != nil {
 		err = fmt.Errorf("cannot bootstrap instance namespace: %w", err)
-		return runtime.NewFatalResult(err)
+		return runtime.NewWarningResult(err.Error())
 	}
 
 	return nil


### PR DESCRIPTION
## Summary
The quota handling still assumes that the org label is patched onto the composite, but that isn't true anymore. Also the organization creation is handled in the `BootstrapInstanceNs()` function. This generates an racecondition between those two functions.

Additionally:
* Don't return fatal in the quota function, this can lead to deadlocks
* Cleaned up some dropped errors


## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
