### PR TITLE
Add automatic maintenance to Keycloak

### DIFF
--- a/apis/vshn/v1/dbaas_vshn_keycloak.go
+++ b/apis/vshn/v1/dbaas_vshn_keycloak.go
@@ -84,11 +84,11 @@ type VSHNKeycloakServiceSpec struct {
 	// +kubebuilder:default="/"
 	RelativePath string `json:"relativePath,omitempty"`
 
-	// +kubebuilder:validation:Enum="23"
-	// +kubebuilder:default="23"
+	// +kubebuilder:validation:Enum="23.0.5-202402021353-44-af6cea11"
+	// +kubebuilder:default="23.0.5-202402021353-44-af6cea11"
 
 	// Version contains supported version of keycloak.
-	// Multiple versions are supported. The latest version 22 is the default version.
+	// Multiple versions are supported. The latest version 23 is the default version.
 	Version string `json:"version,omitempty"`
 
 	// +kubebuilder:validation:Enum="besteffort";"guaranteed"

--- a/crds/stackgres.io_sgpoolingconfigs.yaml
+++ b/crds/stackgres.io_sgpoolingconfigs.yaml
@@ -32,7 +32,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: Spec defines the desired state of a VSHNPostgreSQL.
+            description: Spec contains the custom configurations for the pgbouncer.
             properties:
               pgBouncer:
                 description: Connection pooling configuration based on PgBouncer.
@@ -72,7 +72,7 @@ spec:
                 type: object
             type: object
           status:
-            description: Status reflects the observed state of a VSHNPostgreSQL.
+            description: Status contains the default settings for the pgbouncer.
             properties:
               pgBouncer:
                 description: Connection pooling configuration status based on PgBouncer.

--- a/crds/vshn.appcat.vshn.io_vshnkeycloaks.yaml
+++ b/crds/vshn.appcat.vshn.io_vshnkeycloaks.yaml
@@ -3707,10 +3707,10 @@ spec:
                             - guaranteed
                           type: string
                         version:
-                          default: "23"
-                          description: Version contains supported version of keycloak. Multiple versions are supported. The latest version 22 is the default version.
+                          default: 23.0.5-202402021353-44-af6cea11
+                          description: Version contains supported version of keycloak. Multiple versions are supported. The latest version 23 is the default version.
                           enum:
-                            - "23"
+                            - 23.0.5-202402021353-44-af6cea11
                           type: string
                       type: object
                       default: {}

--- a/crds/vshn.appcat.vshn.io_xvshnkeycloaks.yaml
+++ b/crds/vshn.appcat.vshn.io_xvshnkeycloaks.yaml
@@ -5933,12 +5933,12 @@ spec:
                         - guaranteed
                         type: string
                       version:
-                        default: "23"
+                        default: 23.0.5-202402021353-44-af6cea11
                         description: Version contains supported version of keycloak.
-                          Multiple versions are supported. The latest version 22 is
+                          Multiple versions are supported. The latest version 23 is
                           the default version.
                         enum:
-                        - "23"
+                        - 23.0.5-202402021353-44-af6cea11
                         type: string
                     type: object
                   size:

--- a/pkg/comp-functions/functions/vshnkeycloak/deploy.go
+++ b/pkg/comp-functions/functions/vshnkeycloak/deploy.go
@@ -2,6 +2,7 @@ package vshnkeycloak
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 
@@ -13,10 +14,13 @@ import (
 	vshnv1 "github.com/vshn/appcat/v4/apis/vshn/v1"
 	"github.com/vshn/appcat/v4/pkg/common/utils"
 	"github.com/vshn/appcat/v4/pkg/comp-functions/functions/common"
+	"github.com/vshn/appcat/v4/pkg/comp-functions/functions/common/maintenance"
 	"github.com/vshn/appcat/v4/pkg/comp-functions/functions/vshnpostgres"
 	"github.com/vshn/appcat/v4/pkg/comp-functions/runtime"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/yaml"
 )
 
 const (
@@ -28,6 +32,10 @@ const (
 	hostConnectionDetailsField    = "KEYCLOAK_HOST"
 	urlConnectionDetailsField     = "KEYCLOAK_URL"
 	serviceSuffix                 = "keycloakx-http"
+	pullsecretName                = "pullsecret"
+	registryURL                   = "docker-registry.inventage.com:10121/keycloak-competence-center/keycloak-managed"
+	providerInitName              = "copy-original-providers"
+	realmInitName                 = "copy-original-realm-setup"
 )
 
 // DeployKeycloak deploys a keycloak instance via the codecentric Helm Chart.
@@ -49,6 +57,12 @@ func DeployKeycloak(ctx context.Context, svc *runtime.ServiceRuntime) *xfnproto.
 	err = common.BootstrapInstanceNs(ctx, comp, comp.GetServiceName(), comp.GetName()+"-instanceNs", svc)
 	if err != nil {
 		return runtime.NewWarningResult(fmt.Sprintf("cannot bootstrap instance namespace: %s", err))
+	}
+
+	svc.Log.Info("Add pull secret")
+	err = addPullSecret(comp, svc)
+	if err != nil {
+		return runtime.NewWarningResult(fmt.Sprintf("cannot deploy pull secret: %s", err))
 	}
 
 	svc.Log.Info("Checking readiness of cluster")
@@ -216,13 +230,115 @@ func newValues(ctx context.Context, svc *runtime.ServiceRuntime, comp *vshnv1.VS
 		return values, fmt.Errorf("cannot fetch nodeSelector from the composition config: %w", err)
 	}
 
+	extraEnvMap := []map[string]any{
+		{
+			"name":  "KEYCLOAK_ADMIN",
+			"value": "admin",
+		},
+		{
+			"name": "KEYCLOAK_ADMIN_PASSWORD",
+			"valueFrom": map[string]any{
+				"secretKeyRef": map[string]any{
+					"name": adminSecret,
+					"key":  adminPWSecretField,
+				},
+			},
+		},
+		{
+			"name":  "KC_DB_URL_PROPERTIES",
+			"value": "?sslmode=verify-full&sslrootcert=/certs/ca.crt",
+		},
+		{
+			"name": "JAVA_OPTS_APPEND",
+			"value": `-Djava.awt.headless=true
+-Djgroups.dns.query={{ include "keycloak.fullname" . }}-headless`,
+		},
+	}
+
+	extraEnv, err := toYAML(extraEnvMap)
+	if err != nil {
+		return nil, err
+	}
+
+	extraVolumesMap := []map[string]any{
+		{
+			"name":     "custom-providers",
+			"emptyDir": nil,
+		},
+		{
+			"name":     "custom-setup",
+			"emptyDir": nil,
+		},
+		{
+			"name": "keycloak-dist",
+		},
+		{
+			"name": "postgresql-certs",
+			"secret": map[string]any{
+				"secretName":  pgSecretName,
+				"defaultMode": 420,
+			},
+		},
+	}
+
+	extraVolumes, err := toYAML(extraVolumesMap)
+	if err != nil {
+		return nil, err
+	}
+
+	extraVolumeMountsMap := []map[string]any{
+		{
+			"name":      "custom-providers",
+			"mountPath": "/opt/keycloak/providers",
+		},
+		{
+			"name":      "custom-setup",
+			"mountPath": "/opt/keycloak/setup",
+		},
+		{
+			"name":      "postgresql-certs",
+			"mountPath": "/certs/",
+		},
+	}
+
+	extraVolumeMounts, err := toYAML(extraVolumeMountsMap)
+	if err != nil {
+		return nil, err
+	}
+
 	values = map[string]any{
-		"replicaCount": "1",
-		"production":   false, // TODO: we can enable production mode with proper TLS only
-		"auth": map[string]any{
-			"adminUser":         "admin",
-			"existingSecret":    adminSecret,
-			"passwordSecretKey": adminPWSecretField,
+		"extraEnv":          extraEnv,
+		"extraVolumes":      extraVolumes,
+		"extraVolumeMounts": extraVolumeMounts,
+
+		"command": []string{
+			"/opt/keycloak/bin/kc-with-setup.sh",
+			"--verbose",
+			"start",
+			"--http-enabled=true",
+			"--http-port=8080",
+			"--hostname-strict=false",
+			"--hostname-strict-https=false",
+			"--spi-events-listener-jboss-logging-success-level=info",
+			"--spi-events-listener-jboss-logging-error-level=warn",
+		},
+		"image": map[string]any{
+			"repository": "docker-registry.inventage.com:10121/keycloak-competence-center/keycloak-managed",
+		},
+		"database": map[string]any{
+			"hostname": string(cd[vshnpostgres.PostgresqlHost]),
+			"port":     string(cd[vshnpostgres.PostgresqlPort]),
+			"database": string(cd[vshnpostgres.PostgresqlDb]),
+			"username": string(cd[vshnpostgres.PostgresqlUser]),
+			"password": string(cd[vshnpostgres.PostgresqlPassword]),
+		},
+		"serviceAccount": map[string]any{
+			"automountServiceAccountToken": "false",
+			"imagePullSecrets": []map[string]any{
+				{
+					"name": pullsecretName,
+				},
+			},
 		},
 		"resources": map[string]any{
 			"requests": map[string]any{
@@ -235,43 +351,21 @@ func newValues(ctx context.Context, svc *runtime.ServiceRuntime, comp *vshnv1.VS
 			},
 		},
 		"nodeSelector": nodeSelector,
-		"metrics": map[string]any{
+		"dbchecker": map[string]any{
 			"enabled": true,
-			"serviceMonitor": map[string]any{
-				"enabled": true,
-			},
 		},
-		"httpRelativePath": comp.Spec.Parameters.Service.RelativePath,
-		"postgresql": map[string]any{
-			"enabled": false,
-		},
-		"externalDatabase": map[string]any{
-			"host":     string(cd[vshnpostgres.PostgresqlHost]),
-			"port":     string(cd[vshnpostgres.PostgresqlPort]),
-			"database": string(cd[vshnpostgres.PostgresqlDb]),
-			"user":     string(cd[vshnpostgres.PostgresqlUser]),
-			"password": string(cd[vshnpostgres.PostgresqlPassword]),
-		},
-		"extraVolumeMounts": []map[string]string{
-			{
-				"name":      "postgresql-certs",
-				"mountPath": "/opt/bitnami/keycloak/certs/",
-			},
-		},
-		"extraVolumes": []map[string]any{
-			{
-				"name": "postgresql-certs",
-				"secret": map[string]any{
-					"secretName":  pgSecretName,
-					"defaultMode": 420,
+		// See https://github.com/keycloak/keycloak/issues/11286
+		// readOnlyRootFilesystem: true
+		"securityContext": map[string]any{
+			"allowPrivilegeEscalation": false,
+			"capabilities": map[string]any{
+				"drop": []string{
+					"ALL",
 				},
 			},
 		},
-		"extraEnvVars": []map[string]string{
-			{
-				"name":  "KEYCLOAK_JDBC_PARAMS",
-				"value": "sslmode=verify-full&sslrootcert=/opt/bitnami/keycloak/certs/ca.crt",
-			},
+		"http": map[string]any{
+			"relativePath": comp.Spec.Parameters.Service.RelativePath,
 		},
 	}
 
@@ -291,7 +385,120 @@ func newRelease(ctx context.Context, svc *runtime.ServiceRuntime, comp *vshnv1.V
 		return nil, err
 	}
 
+	observedValues, err := common.GetObservedReleaseValues(svc, comp.GetName())
+	if err != nil {
+		return nil, fmt.Errorf("cannot get observed release values: %w", err)
+	}
+
+	observedVersion, err := maintenance.SetReleaseVersion(ctx, comp.Spec.Parameters.Service.Version, values, observedValues, []string{"image", "tag"})
+	if err != nil {
+		return nil, fmt.Errorf("cannot set keycloak version for release: %w", err)
+	}
+
+	err = addInitContainer(values, observedVersion)
+	if err != nil {
+		return nil, err
+	}
+
 	release, err := common.NewRelease(ctx, svc, comp, values)
 
+	release.Spec.ForProvider.Chart.Name = "keycloakx"
+
 	return release, err
+}
+
+func toYAML(obj any) (string, error) {
+	yamlBytes, err := yaml.Marshal(obj)
+	return string(yamlBytes), err
+}
+
+func addPullSecret(comp *vshnv1.VSHNKeycloak, svc *runtime.ServiceRuntime) error {
+
+	username := svc.Config.Data["registry_username"]
+	password := svc.Config.Data["registry_password"]
+	auth := fmt.Sprintf("%s:%s", username, password)
+
+	authEncoded := base64.StdEncoding.EncodeToString([]byte(auth))
+
+	secretMap := map[string]any{
+		"auths": map[string]any{
+			"docker-registry.inventage.com:10121": map[string]any{
+				"username": username,
+				"password": password,
+				"auth":     authEncoded,
+			},
+		},
+	}
+
+	secretJSON, err := json.Marshal(secretMap)
+	if err != nil {
+		return err
+	}
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      pullsecretName,
+			Namespace: comp.GetInstanceNamespace(),
+		},
+		Type: corev1.SecretTypeDockerConfigJson,
+		Data: map[string][]byte{
+			".dockerconfigjson": secretJSON,
+		},
+	}
+
+	return svc.SetDesiredKubeObject(secret, comp.GetName()+"-pull-secret")
+}
+
+func addInitContainer(values map[string]any, version string) error {
+	extraInitContainersMap := []map[string]any{
+		{
+			"name":            providerInitName,
+			"image":           fmt.Sprintf("%s:%s", registryURL, version),
+			"imagePullPolicy": "IfNotPresent",
+			"command": []string{
+				"sh",
+			},
+			"args": []string{
+				"-c",
+				`echo "Copying original provider files..."
+cp -R /opt/keycloak/providers/*.jar /custom-providers
+ls -lh /custom-providers`,
+			},
+			"volumeMounts": []map[string]any{
+				{
+					"name":      "custom-providers",
+					"mountPath": "/custom-providers",
+				},
+			},
+		},
+		{
+			"name":            realmInitName,
+			"image":           fmt.Sprintf("%s:%s", registryURL, version),
+			"imagePullPolicy": "IfNotPresent",
+			"command": []string{
+				"sh",
+			},
+			"args": []string{
+				"-c",
+				`echo "Copying original setup files..."
+cp -R /opt/keycloak/setup/*.json /custom-setup
+ls -lh /custom-setup`,
+			},
+			"volumeMounts": []map[string]any{
+				{
+					"name":      "custom-setup",
+					"mountPath": "/custom-setup",
+				},
+			},
+		},
+	}
+
+	extraInitContainers, err := toYAML(extraInitContainersMap)
+	if err != nil {
+		return err
+	}
+
+	values["extraInitContainers"] = extraInitContainers
+
+	return nil
 }

--- a/pkg/comp-functions/functions/vshnkeycloak/deploy_test.go
+++ b/pkg/comp-functions/functions/vshnkeycloak/deploy_test.go
@@ -52,6 +52,13 @@ func Test_addRelease(t *testing.T) {
 			Name:      "mycloak",
 			Namespace: "default",
 		},
+		Spec: vshnv1.VSHNKeycloakSpec{
+			Parameters: vshnv1.VSHNKeycloakParameters{
+				Service: vshnv1.VSHNKeycloakServiceSpec{
+					Version: "23",
+				},
+			},
+		},
 	}
 
 	assert.NoError(t, addRelease(context.TODO(), svc, comp, "mysecret"))

--- a/pkg/comp-functions/functions/vshnkeycloak/maintenance.go
+++ b/pkg/comp-functions/functions/vshnkeycloak/maintenance.go
@@ -1,0 +1,45 @@
+package vshnkeycloak
+
+import (
+	"context"
+	"fmt"
+
+	xfnproto "github.com/crossplane/function-sdk-go/proto/v1beta1"
+	vshnv1 "github.com/vshn/appcat/v4/apis/vshn/v1"
+	"github.com/vshn/appcat/v4/pkg/comp-functions/functions/common"
+	"github.com/vshn/appcat/v4/pkg/comp-functions/functions/common/maintenance"
+	"github.com/vshn/appcat/v4/pkg/comp-functions/runtime"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// AddMaintenanceJob will add a job to do the maintenance for the instance
+func AddMaintenanceJob(ctx context.Context, svc *runtime.ServiceRuntime) *xfnproto.Result {
+
+	comp := &vshnv1.VSHNKeycloak{}
+	err := svc.GetObservedComposite(comp)
+	if err != nil {
+		return runtime.NewFatalResult(fmt.Errorf("can't get composite: %w", err))
+	}
+
+	common.SetRandomSchedules(comp, comp)
+
+	instanceNamespace := comp.GetInstanceNamespace()
+	schedule := comp.GetFullMaintenanceSchedule()
+
+	username := svc.Config.Data["registry_username"]
+	password := svc.Config.Data["registry_password"]
+
+	return maintenance.New(comp, svc, schedule, instanceNamespace, comp.GetServiceName()).
+		WithHelmBasedService().
+		WithExtraEnvs([]corev1.EnvVar{
+			{
+				Name:  "REGISTRY_USERNAME",
+				Value: username,
+			},
+			{
+				Name:  "REGISTRY_PASSWORD",
+				Value: password,
+			},
+		}...).
+		Run(ctx)
+}

--- a/pkg/comp-functions/functions/vshnkeycloak/register.go
+++ b/pkg/comp-functions/functions/vshnkeycloak/register.go
@@ -10,6 +10,10 @@ func init() {
 				Name:    "deploy",
 				Execute: DeployKeycloak,
 			},
+			{
+				Name:    "maintenance",
+				Execute: AddMaintenanceJob,
+			},
 		},
 	})
 }

--- a/pkg/comp-functions/functions/vshnmariadb/mariadb_deploy.go
+++ b/pkg/comp-functions/functions/vshnmariadb/mariadb_deploy.go
@@ -86,7 +86,7 @@ func createObjectHelmRelease(ctx context.Context, comp *vshnv1.VSHNMariaDB, svc 
 		return fmt.Errorf("cannot get observed release values: %w", err)
 	}
 
-	err = maintenance.SetReleaseVersion(ctx, comp.Spec.Parameters.Service.Version, values, observedValues, []string{"image", "tag"})
+	_, err = maintenance.SetReleaseVersion(ctx, comp.Spec.Parameters.Service.Version, values, observedValues, []string{"image", "tag"})
 	if err != nil {
 		return fmt.Errorf("cannot set mariadb version for release: %w", err)
 	}

--- a/pkg/comp-functions/functions/vshnredis/release.go
+++ b/pkg/comp-functions/functions/vshnredis/release.go
@@ -101,7 +101,7 @@ func updateRelease(ctx context.Context, comp *vshnv1.VSHNRedis, desired *xhelmv1
 	}
 
 	l.V(1).Info("Setting release version")
-	err = maintenance.SetReleaseVersion(ctx, comp.Spec.Parameters.Service.Version, values, observedValues, []string{"image", "tag"})
+	_, err = maintenance.SetReleaseVersion(ctx, comp.Spec.Parameters.Service.Version, values, observedValues, []string{"image", "tag"})
 	if err != nil {
 		return nil, fmt.Errorf("cannot set redis version for release %s: %v", releaseName, err)
 	}

--- a/pkg/maintenance/auth/http.go
+++ b/pkg/maintenance/auth/http.go
@@ -1,0 +1,16 @@
+package auth
+
+import (
+	"net/http"
+	"time"
+
+	"k8s.io/client-go/transport"
+)
+
+// GetAuthHTTPClient returns a HTTP client which is authenticated. It can be used to query private images.
+func GetAuthHTTPClient(username, password string) *http.Client {
+	return &http.Client{
+		Transport: transport.NewBasicAuthRoundTripper(username, password, http.DefaultTransport),
+		Timeout:   30 * time.Second,
+	}
+}

--- a/pkg/maintenance/helm/helmpatcher_test.go
+++ b/pkg/maintenance/helm/helmpatcher_test.go
@@ -212,7 +212,6 @@ func Test_compareSemanticVersion(t *testing.T) {
 				getResult("6.6.4", "inactive", "image"),
 				getResult("6.8", "active", "image"),
 				getResult("7.0", "active", "image"),
-				getResult("7.0.1", "active", "registry"),
 				getResult("7.1.4", "active", "image"),
 				getResult("7.2.4", "inactive", "image"),
 				getResult("7.1.12-alpha", "active", "image"),
@@ -281,7 +280,7 @@ func Test_compareSemanticVersion(t *testing.T) {
 			// WHEN
 			tag, err := r.getCurrentTagFromRelease(tt.release, []string{"image", "tag"})
 			assert.NoError(t, err)
-			version, err := SemVerPatchesOnly(tt.results, tag)
+			version, err := SemVerPatchesOnly(true)(&Payload{Results: tt.results}, tag)
 
 			// THEN
 			if tt.expectedErr != "" {
@@ -399,12 +398,12 @@ func Test_GetRelease(t *testing.T) {
 	}
 }
 
-func Test_GetVersions(t *testing.T) {
+func Test_GetHubVersions(t *testing.T) {
 	tests := []struct {
 		name              string
 		instanceNamespace string
 		server            *httptest.Server
-		expectedResults   []Result
+		expectedResults   *Payload
 	}{
 		{
 			name:              "WhenRelease_ThenReturnRelease",
@@ -423,9 +422,10 @@ func Test_GetVersions(t *testing.T) {
 				_, err = w.Write(payload)
 				assert.NoError(t, err)
 			})),
-			expectedResults: []Result{
+			expectedResults: &Payload{Results: []Result{
 				getResult("1.0.0", "active", "image"),
 				getResult("2.0.0", "inactive", "image"),
+			},
 			},
 		},
 	}
@@ -442,7 +442,7 @@ func Test_GetVersions(t *testing.T) {
 			defer tt.server.Close()
 
 			// WHEN
-			res, err := r.getVersions(tt.server.URL + "?size=100&")
+			res, err := r.getHubVersions(tt.server.URL + "?size=100&")
 
 			// THEN
 			assert.NoError(t, err)

--- a/pkg/maintenance/keycloak.go
+++ b/pkg/maintenance/keycloak.go
@@ -1,0 +1,39 @@
+package maintenance
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/go-logr/logr"
+	"github.com/vshn/appcat/v4/pkg/maintenance/helm"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	keycloakURL = "https://docker-registry.inventage.com:10121/v2/keycloak-competence-center/keycloak-managed/tags/list"
+)
+
+// Keycloak contains all necessary dependencies to successfully run a Keycloak maintenance
+type Keycloak struct {
+	k8sClient  client.Client
+	httpClient *http.Client
+	log        logr.Logger
+}
+
+// NewKeycloak returns a new Keycloak object
+func NewKeycloak(c client.Client, hc *http.Client) Keycloak {
+	return Keycloak{
+		k8sClient:  c,
+		httpClient: hc,
+	}
+}
+
+// DoMaintenance will run minios's maintenance script.
+func (m *Keycloak) DoMaintenance(ctx context.Context) error {
+	m.log = logr.FromContextOrDiscard(ctx).WithValues("type", "keycloak")
+	patcher := helm.NewImagePatcher(m.k8sClient, m.httpClient, m.log)
+
+	valuesPath := helm.NewValuePath("image", "tag")
+
+	return patcher.DoMaintenance(ctx, keycloakURL, valuesPath, helm.SemVerPatchesOnly(false))
+}

--- a/pkg/maintenance/mariadb.go
+++ b/pkg/maintenance/mariadb.go
@@ -31,5 +31,5 @@ func NewMariaDB(c client.Client, hc *http.Client) MariaDB {
 func (r *MariaDB) DoMaintenance(ctx context.Context) error {
 	patcher := helm.NewImagePatcher(r.k8sClient, r.httpClient, logr.FromContextOrDiscard(ctx).WithValues("type", "mariadb"))
 
-	return patcher.DoMaintenance(ctx, mariaDBURL, helm.NewValuePath("image", "tag"), helm.SemVerPatchesOnly)
+	return patcher.DoMaintenance(ctx, mariaDBURL, helm.NewValuePath("image", "tag"), helm.SemVerPatchesOnly(false))
 }

--- a/pkg/maintenance/minio.go
+++ b/pkg/maintenance/minio.go
@@ -57,7 +57,7 @@ func (m *Minio) DoMaintenance(ctx context.Context) error {
 // Minio has a pretty unique rolling release cycle which is based on the date.
 // Each Minio image tag contains the date when it was created.
 // The form of the tags is like this: `RELEASE.2023-09-16T01-01-47Z`
-func compareMinioVersions(results []helm.Result, currentTag string) (string, error) {
+func compareMinioVersions(results helm.VersionLister, currentTag string) (string, error) {
 
 	if currentTag == "" {
 		currentTag = minioTagPrefix + earliestTag
@@ -73,15 +73,13 @@ func compareMinioVersions(results []helm.Result, currentTag string) (string, err
 
 	newDate := currentDate
 
-	for _, res := range results {
-		if res.TagStatus == helm.ActiveTagStatus && res.ContentType == helm.ImageContentType {
-			v, err := parseMinioDate(res.Name)
-			if err != nil {
-				continue
-			}
-			if newDate.Before(v) {
-				newDate = v
-			}
+	for _, res := range results.GetVersions() {
+		v, err := parseMinioDate(res)
+		if err != nil {
+			continue
+		}
+		if newDate.Before(v) {
+			newDate = v
 		}
 	}
 

--- a/pkg/maintenance/minio_test.go
+++ b/pkg/maintenance/minio_test.go
@@ -82,7 +82,7 @@ func Test_compareMinioVersions(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tag, err := compareMinioVersions(tt.args.results, tt.args.currentTag)
+			tag, err := compareMinioVersions(&helm.Payload{Results: tt.args.results}, tt.args.currentTag)
 			if tt.wantErr {
 				assert.Error(t, err)
 			} else {

--- a/pkg/maintenance/redis.go
+++ b/pkg/maintenance/redis.go
@@ -31,5 +31,5 @@ func NewRedis(c client.Client, hc *http.Client) Redis {
 func (r *Redis) DoMaintenance(ctx context.Context) error {
 	patcher := helm.NewImagePatcher(r.k8sClient, r.httpClient, logr.FromContextOrDiscard(ctx).WithValues("type", "redis"))
 
-	return patcher.DoMaintenance(ctx, redisURL, helm.NewValuePath("image", "tag"), helm.SemVerPatchesOnly)
+	return patcher.DoMaintenance(ctx, redisURL, helm.NewValuePath("image", "tag"), helm.SemVerPatchesOnly(false))
 }

--- a/pkg/sliexporter/vshnpostgresql_controller/vshnpostgresql_controller_test.go
+++ b/pkg/sliexporter/vshnpostgresql_controller/vshnpostgresql_controller_test.go
@@ -130,7 +130,8 @@ func TestVSHNPostgreSQL_Multi(t *testing.T) {
 
 func TestVSHNPostgreSQL_Startup_NoCreds_Dont_Probe(t *testing.T) {
 	db := newTestVSHNPostgres("bar", "foo", "creds", 1)
-	db.SetCreationTimestamp(metav1.Now())
+	cd := metav1.Now().Add(time.Minute * -6)
+	db.SetCreationTimestamp(metav1.Time{Time: cd})
 	r, manager, _ := setupVSHNPostgreTest(t,
 		db,
 	)
@@ -144,7 +145,9 @@ func TestVSHNPostgreSQL_Startup_NoCreds_Dont_Probe(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Greater(t, res.RequeueAfter.Microseconds(), int64(0))
 
-	assert.False(t, manager.probers[getFakeKey(pi)])
+	// we now get a failing probe as the composite will always have
+	// connection details
+	assert.True(t, manager.probers[getFakeKey(pi)])
 }
 
 func TestVSHNPostgreSQL_NoRef_Dont_Probe(t *testing.T) {


### PR DESCRIPTION
## Summary

This commit adds automatic maintenance for Keycloak.
    
The automatic maintenance now supports private registries. It also now     supports any other registry apart from docker hub.
    
We've been using the docker hub's rich API until now. But that is exclusive to docker hub. Normal v2 registries have another API. The maintenance now supports that API as well and will automatically fall back to it, if the URL isn't from `https://hub.docker.com`.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
