### PR TITLE
Redis prober handles TLS correctly

### DIFF
--- a/pkg/sliexporter/vshnredis_controller/vshnredis_controller_test.go
+++ b/pkg/sliexporter/vshnredis_controller/vshnredis_controller_test.go
@@ -453,8 +453,7 @@ func TestVSHNRedis_NoTls(t *testing.T) {
 	)
 	r.RedisDialer = func(service, name, namespace, organization, sla string, ha bool, opts redis.Options) (*probes.VSHNRedis, error) {
 
-		assert.Equal(t, []tls.Certificate(nil), opts.TLSConfig.Certificates)
-		assert.Equal(t, []tls.Certificate(nil), opts.TLSConfig.Certificates)
+		assert.Nil(t, opts.TLSConfig, "TLS config MUST be nil")
 
 		return fakeRedisDialer(service, name, namespace, organization, "besteffort", false, redis.Options{
 			Addr:     string(cred.Data["REDIS_HOST"]) + ":" + string(cred.Data["REDIS_PORT"]),


### PR DESCRIPTION
## Summary

* We need to set up TLSConfig only when we're going to use that, otherwise it should remain nil field in our Redis Client Opts. If it's set to even completely empty `&tls.Config{}` it fails to probe non-tls Redises

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [x] Link this PR to related issues.


