### PR TITLE
block too long db names early

### DIFF
--- a/crds/stackgres.io_sgpoolingconfigs.yaml
+++ b/crds/stackgres.io_sgpoolingconfigs.yaml
@@ -32,7 +32,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: Spec defines the desired state of a VSHNPostgreSQL.
+            description: Spec contains the custom configurations for the pgbouncer.
             properties:
               pgBouncer:
                 description: Connection pooling configuration based on PgBouncer.
@@ -72,7 +72,7 @@ spec:
                 type: object
             type: object
           status:
-            description: Status reflects the observed state of a VSHNPostgreSQL.
+            description: Status contains the default settings for the pgbouncer.
             properties:
               pgBouncer:
                 description: Connection pooling configuration status based on PgBouncer.


### PR DESCRIPTION
## Summary

* Adding logic to catch too long Redis and PostgreSQL names early
* We add various postfixes to resource name and our limitation is https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names for cronjob resources 
* if we allow resource creation then VSHNRedis is created but underlying objects not, therefore customer would wait indefinitely for database to come up

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [ ] Update tests.
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
