### PR TITLE
Adjust terminating quotas for our jobs

### DIFF
--- a/pkg/common/quotas/quotas.go
+++ b/pkg/common/quotas/quotas.go
@@ -185,6 +185,11 @@ func AddInitalNamespaceQuotas(ctx context.Context, ns *corev1.Namespace, s *util
 		added = true
 	}
 
+	if _, ok := annotations[utils.CpuRequestTerminationQuota]; !ok {
+		annotations[utils.CpuRequestTerminationQuota] = "1000m"
+		added = true
+	}
+
 	ns.SetAnnotations(annotations)
 	return added
 }

--- a/pkg/common/utils/resources.go
+++ b/pkg/common/utils/resources.go
@@ -63,11 +63,12 @@ const (
 
 var (
 	// Now all the permutations for the annotations
-	CpuRequestAnnotation    = fmt.Sprintf("%s%s.%s", quotaAnnotationPrefix, resourceQuotaNameCompute, quotaResourceCPURequests)
-	CpuLimitAnnotation      = fmt.Sprintf("%s%s.%s", quotaAnnotationPrefix, resourceQuotaNameCompute, quotaResourceCPULimits)
-	MemoryRequestAnnotation = fmt.Sprintf("%s%s.%s", quotaAnnotationPrefix, resourceQuotaNameCompute, quotaResourceMemoryRequests)
-	MemoryLimitAnnotation   = fmt.Sprintf("%s%s.%s", quotaAnnotationPrefix, resourceQuotaNameCompute, quotaResourceMemoryLimits)
-	DiskAnnotation          = fmt.Sprintf("%s%s.%s", quotaAnnotationPrefix, resourceQuotaNameObjects, quotaResourceDisk)
+	CpuRequestAnnotation       = fmt.Sprintf("%s%s.%s", quotaAnnotationPrefix, resourceQuotaNameCompute, quotaResourceCPURequests)
+	CpuLimitAnnotation         = fmt.Sprintf("%s%s.%s", quotaAnnotationPrefix, resourceQuotaNameCompute, quotaResourceCPULimits)
+	MemoryRequestAnnotation    = fmt.Sprintf("%s%s.%s", quotaAnnotationPrefix, resourceQuotaNameCompute, quotaResourceMemoryRequests)
+	MemoryLimitAnnotation      = fmt.Sprintf("%s%s.%s", quotaAnnotationPrefix, resourceQuotaNameCompute, quotaResourceMemoryLimits)
+	DiskAnnotation             = fmt.Sprintf("%s%s.%s", quotaAnnotationPrefix, resourceQuotaNameObjects, quotaResourceDisk)
+	CpuRequestTerminationQuota = fmt.Sprintf("%s%s.%s", quotaAnnotationPrefix, resourceQuotaNameCompute+"-terminating", quotaResourceCPURequests)
 
 	ErrNSLimitReached = fmt.Errorf("creating a new instance will violate the namespace quota." +
 		"Please contact VSHN support to increase the amounts of namespaces you can create.")


### PR DESCRIPTION
APPUiO's definition of a terminating pod is `.spec.activeDeadlineSeconds >= 0`. It also enforces a `.spec.activeDeadlineSeconds` for all jobs. So essentially all jobs are measured against the terminating quota.

The pgrepack job from StackGres has a hardcoded resource request for CPUs of 1000m which is higher than the default 500m quota for terminating pods. This causes the pgrepack jobs to be stuck because the pods can't be scheduled.

With this commit we set the initial quota for terminating pods to 1000m.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
