### PR TITLE
Add external admin account

### DIFF
--- a/apis/vshn/v1/dbaas_vshn_keycloak.go
+++ b/apis/vshn/v1/dbaas_vshn_keycloak.go
@@ -85,8 +85,8 @@ type VSHNKeycloakServiceSpec struct {
 	// +kubebuilder:default="/"
 	RelativePath string `json:"relativePath,omitempty"`
 
-	// +kubebuilder:validation:Enum="23.0.5-202402021353-44-af6cea11"
-	// +kubebuilder:default="23.0.5-202402021353-44-af6cea11"
+	// +kubebuilder:validation:Enum="23"
+	// +kubebuilder:default="23"
 
 	// Version contains supported version of keycloak.
 	// Multiple versions are supported. The latest version 23 is the default version.

--- a/crds/vshn.appcat.vshn.io_vshnkeycloaks.yaml
+++ b/crds/vshn.appcat.vshn.io_vshnkeycloaks.yaml
@@ -3725,10 +3725,10 @@ spec:
                             - guaranteed
                           type: string
                         version:
-                          default: 23.0.5-202402021353-44-af6cea11
+                          default: "23"
                           description: Version contains supported version of keycloak. Multiple versions are supported. The latest version 23 is the default version.
                           enum:
-                            - 23.0.5-202402021353-44-af6cea11
+                            - "23"
                           type: string
                       type: object
                       default: {}

--- a/crds/vshn.appcat.vshn.io_xvshnkeycloaks.yaml
+++ b/crds/vshn.appcat.vshn.io_xvshnkeycloaks.yaml
@@ -5957,12 +5957,12 @@ spec:
                         - guaranteed
                         type: string
                       version:
-                        default: 23.0.5-202402021353-44-af6cea11
+                        default: "23"
                         description: Version contains supported version of keycloak.
                           Multiple versions are supported. The latest version 23 is
                           the default version.
                         enum:
-                        - 23.0.5-202402021353-44-af6cea11
+                        - "23"
                         type: string
                     type: object
                   size:

--- a/pkg/comp-functions/functions/common/maintenance/maintenance.go
+++ b/pkg/comp-functions/functions/common/maintenance/maintenance.go
@@ -337,7 +337,7 @@ func SetReleaseVersion(ctx context.Context, version string, desiredValues map[st
 
 	if observedVersion.GTE(desiredVersion) {
 		// In case the overved tag is valid and greater than the desired version, keep the observed version
-		return observedVersion.String(), unstructured.SetNestedField(desiredValues, tag, fields...)
+		return tag, unstructured.SetNestedField(desiredValues, tag, fields...)
 	}
 	// In case the observed tag is smaller than the desired version,  then set the version from the claim
 	return version, unstructured.SetNestedField(desiredValues, version, fields...)

--- a/pkg/maintenance/keycloak.go
+++ b/pkg/maintenance/keycloak.go
@@ -35,5 +35,5 @@ func (m *Keycloak) DoMaintenance(ctx context.Context) error {
 
 	valuesPath := helm.NewValuePath("image", "tag")
 
-	return patcher.DoMaintenance(ctx, keycloakURL, valuesPath, helm.SemVerPatchesOnly(false))
+	return patcher.DoMaintenance(ctx, keycloakURL, valuesPath, helm.SemVerPatchesOnly(true))
 }


### PR DESCRIPTION
## Summary

This commit adds an admin account which is intended to be exposed to the user. This enables the user to change the password of the admin user without breaking the internal scripts of the image.

However, there are no safeguards available to prevent the user from changing the password of the internal admin as well.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
