### PR TITLE
Ability to disable billing for selected services

### DIFF
--- a/docs/modules/ROOT/assets/images/disable-billing-flow.drawio.svg
+++ b/docs/modules/ROOT/assets/images/disable-billing-flow.drawio.svg
@@ -1,0 +1,138 @@
+<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="421px" height="202px" viewBox="-0.5 -0.5 421 202" content="&lt;mxfile&gt;&lt;diagram id=&quot;Wiaj3occ8NXPDOTq4_C3&quot; name=&quot;Page-1&quot;&gt;1VffU9swDP5r+giXH21IH4HCdje2Y9eHsUc3URLfnDjnuDTlr5/cyE0zhw0oB+Opliyp1ifpszMJL8v2k2J18VWmICaBl7aTcDEJAj/wPPwxmm2nmcZRp8gVT8moVyz5A5CS/PI1T6EZGGopheb1UJnIqoJED3RMKbkZmmVSDP+1Zjk4imXChKv9wVNddNo4OOv1n4Hnhf1nP5p3OyWzxpRJU7BUbg5U4dUkvFRS6m5VtpcgDHgWl87v+pHd/cEUVPopDrPO4Z6JNeVG59JbmyykmDuJlazw56LQpUDJx2VnbmwePQGpGrlWCVmFVDSmciCr6T57bBuQJWi1RRMFgml+P4zOqH753q5PEReU5XjGkZNxCjVUaYNKWY1mf8NW2MCDtJngeYXrBLMEhYp7UJpjh5zTRsnT1MS4UNDwB7baxfNQriWv9O78s4vJbLGH0ASAdqx9yblvmkNwZ+OwUaAT79Q/m1NNadhIejKwFPzWnPvARGZZg7X7E/n9GZ5UjNApxhfYJkKyX04hlFxXKaSE4qbgGpY12zXUBllmrCtHIHX60oVu00+0bxEvDqY58o5vwqmT961sdK5g+f3m/TKnBvGnlOFbIHHmIPGNldDs8sPIdZ0wfYKDoJUUxyFjR1ZApkcGVsv6SPjIIbDw2cttBM14BE3/NeD0w2fyN7Rc3xGAZv3TrE9nJC3ag63F1gpYje2dDWCEAy8j9m47yfo1yPf63Ny/hjkFaxqeWPU1F8ddKfH7XSm+O84KWHejKMPjKGl8rwSRMJ23Ql2UmxXPcLeShlYR4AavhY92/XT99ugseKf7aDQNJ/5/dP3ETt0w54znu5da7RTjXwTT1N1jM+OtIaVXIZP5dABf7JLJGJfEr0Al8xcyif8SJvGexyQvo4iRV2f8VhThua1mWeGDjfz8rw1rXpxRGA6a9h1fnCj2H1Odef9JGl79Bg==&lt;/diagram&gt;&lt;/mxfile&gt;">
+    <defs/>
+    <g>
+        <path d="M 60 60 L 60 133.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 60 138.88 L 56.5 131.88 L 60 133.63 L 63.5 131.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 93px; margin-left: 62px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                depends on
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="62" y="97" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    depends on
+                </text>
+            </switch>
+        </g>
+        <rect x="0" y="0" width="120" height="60" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 30px; margin-left: 1px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Keycloak
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="60" y="34" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Keycloak
+                </text>
+            </switch>
+        </g>
+        <rect x="0" y="140" width="120" height="60" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 170px; margin-left: 1px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                PostgreSQL
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="60" y="174" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    PostgreSQL
+                </text>
+            </switch>
+        </g>
+        <rect x="240" y="40" width="180" height="160" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-start; justify-content: unsafe flex-start; width: 178px; height: 1px; padding-top: 47px; margin-left: 242px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: left;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Namespace appcat-control
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="242" y="59" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px">
+                    Namespace appcat-control
+                </text>
+            </switch>
+        </g>
+        <path d="M 287.88 121.76 L 126.12 168.24" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 292.93 120.31 L 287.16 125.61 L 287.88 121.76 L 285.23 118.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 121.07 169.69 L 126.84 164.39 L 126.12 168.24 L 128.77 171.12 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 150px; margin-left: 188px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                reads or creates
+                                <br/>
+                                if not exists
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="188" y="153" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    reads or creates...
+                </text>
+            </switch>
+        </g>
+        <rect x="294" y="80" width="80" height="80" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 120px; margin-left: 295px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                config map
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="334" y="124" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    config map
+                </text>
+            </switch>
+        </g>
+        <path d="M 120 30 L 288.34 117.07" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 293.01 119.49 L 285.18 119.38 L 288.34 117.07 L 288.4 113.16 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 66px; margin-left: 194px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                creates
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="194" y="70" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    creates
+                </text>
+            </switch>
+        </g>
+    </g>
+    <switch>
+        <g requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"/>
+        <a transform="translate(0,-5)" xlink:href="https://www.diagrams.net/doc/faq/svg-export-text-problems" target="_blank">
+            <text text-anchor="middle" font-size="10px" x="50%" y="100%">
+                Text is not SVG - cannot display
+            </text>
+        </a>
+    </switch>
+</svg>

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -22,3 +22,4 @@
 * xref:explanations/webhooks.adoc[]
 * xref:explanations/connectiondetails.adoc[]
 * xref:explanations/helm-maintenance.adoc[]
+* xref:explanations/disable-billing.adoc[]

--- a/docs/modules/ROOT/pages/explanations/disable-billing.adoc
+++ b/docs/modules/ROOT/pages/explanations/disable-billing.adoc
@@ -1,0 +1,23 @@
+= How Disabling Billing Works
+
+For services that depend on other services, like Keycloak -> PostgreSQL, we don't want to bill the customer with both services.
+
+In order to achieve that, we need a mechanism with which we can disable the billing for any given service, but in such a way that it's not possible for the user to manipulate it.
+
+As all settings between the claim and the composite are synced, we can't expose any configuration regarding this in the claim. Otherwise, the user would be able to simply disable the billing for any service. In order to prevent that, the configuration to disable billing should be passed via means that are inaccessible for the end-user but accessible to the composition functions.
+
+There's already a namespace for such things: `appcat-control`. That's a namespace specifically used for things that the end-user should not be able to see or manipulate.
+
+== Flow
+
+When a dependency service is deployed, which should not have any billing, then the service depending on it should deploy a specific config map at the same time. This config map should have the same name as the instance namespace of the dependency service. It should also be deployed in the `appcat-control` namespace. This config map should contain a key called billingDisabled. If that key is not set, the billing is enabled as usual.
+
+*Note:* due to some limitations of Crossplane, each service will always create an empty such config map. Because it's not possible to determine if an object exists or not via provider-kubernetes.
+
+image::disable-billing-flow.drawio.svg[]
+
+== Code
+
+There's a function `DisableBilling(namespace string, svc *runtime.ServiceRuntime)` which will create the config map for the given instance namespace. This needs to be called by the parent composition function, in the example above Keycloak, at the same time the dependency (PostgreSQL) composite is applied.
+
+On the dependency side, in our example PostgreSQL, nothing special needs to be done. The `BootstrapInstanceNs()` automatically determines if the config map exists and if the key to disable the billing is set. If the config map doesn't exist it will be automatically created. This ensures that provider-kubernetes can actually resolve the observed object.

--- a/pkg/comp-functions/functions/common/instance_namespace.go
+++ b/pkg/comp-functions/functions/common/instance_namespace.go
@@ -16,6 +16,7 @@ const (
 	roleBindingName       = "appcat:services:read"
 	claimNsObserverSuffix = "-claim-ns-observer"
 	claimNameLabel        = "crossplane.io/claim-name"
+	disableBillingCMKey   = "billingDisabled"
 )
 
 func BootstrapInstanceNs(ctx context.Context, comp InstanceNamespaceInfo, serviceName, namespaceResName string, svc *runtime.ServiceRuntime) error {
@@ -93,6 +94,19 @@ func createInstanceNamespace(ctx context.Context, serviceName, compName, claimNa
 		},
 	}
 
+	controlNS, ok := svc.Config.Data["controlNamespace"]
+	if !ok {
+		return fmt.Errorf("controlNamespace not specified")
+	}
+
+	disabled, err := isBillingDisabled(controlNS, instanceNamespace, compName, svc)
+	if err != nil {
+		return err
+	}
+	if disabled {
+		ns.ObjectMeta.Labels["appuio.io/billing-name"] = ""
+	}
+
 	return svc.SetDesiredKubeObjectWithName(ns, instanceNamespace, namespaceResName)
 }
 
@@ -138,4 +152,71 @@ func createNamespacePermissions(ctx context.Context, instance string, instanceNs
 		},
 	}
 	return svc.SetDesiredKubeObjectWithName(roleBinding, instance+"-service-rolebinding", "namespace-permissions")
+}
+
+// DisableBilling deploys a special config map to the appcat control namespace.
+// This configMap contains a key that specifies if a given namespace should be billed or not.
+// The configMap can also be used for other configurations in the future.
+func DisableBilling(instanceNamespace string, svc *runtime.ServiceRuntime) error {
+	controlNS, ok := svc.Config.Data["controlNamespace"]
+	if !ok {
+		return fmt.Errorf("controlNamespace not specified in composition input")
+	}
+
+	objName := instanceNamespace + "-config"
+
+	checkCM := &corev1.ConfigMap{}
+	err := svc.GetDesiredKubeObject(checkCM, objName)
+	if err != nil && err != runtime.ErrNotFound {
+		return err
+	}
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      instanceNamespace,
+			Namespace: controlNS,
+		},
+		Data: map[string]string{
+			disableBillingCMKey: "true",
+		},
+	}
+
+	err = svc.SetDesiredKubeObject(cm, objName)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// isBillingDisabled checks the given namespace for the configMap and key that disable billing.
+func isBillingDisabled(controlNS, instanceNamespace, compName string, svc *runtime.ServiceRuntime) (bool, error) {
+
+	objSuffix := "-ns-conf-observer"
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      instanceNamespace,
+			Namespace: controlNS,
+		},
+	}
+
+	err := svc.SetDesiredKubeObject(cm, compName+objSuffix)
+	if err != nil {
+		return false, err
+	}
+
+	err = svc.GetObservedKubeObject(cm, compName+objSuffix)
+	if err != nil {
+		if err == runtime.ErrNotFound {
+			return false, nil
+		}
+		return false, err
+	}
+
+	if _, ok := cm.Data[disableBillingCMKey]; ok {
+		return true, nil
+	}
+
+	return false, nil
 }

--- a/pkg/comp-functions/functions/vshnkeycloak/deploy.go
+++ b/pkg/comp-functions/functions/vshnkeycloak/deploy.go
@@ -189,6 +189,11 @@ func addPostgreSQL(svc *runtime.ServiceRuntime, comp *vshnv1.VSHNKeycloak) error
 		return err
 	}
 
+	err = common.DisableBilling(pg.GetInstanceNamespace(), svc)
+	if err != nil {
+		return err
+	}
+
 	return svc.SetDesiredComposedResource(pg)
 }
 

--- a/pkg/comp-functions/functions/vshnkeycloak/deploy_test.go
+++ b/pkg/comp-functions/functions/vshnkeycloak/deploy_test.go
@@ -13,7 +13,7 @@ import (
 
 func Test_addPostgreSQL(t *testing.T) {
 
-	svc := commontest.LoadRuntimeFromFile(t, "empty.yaml")
+	svc := commontest.LoadRuntimeFromFile(t, "vshn-postgres/empty.yaml")
 
 	comp := &vshnv1.VSHNKeycloak{}
 

--- a/test/functions/vshn-postgres/empty.yaml
+++ b/test/functions/vshn-postgres/empty.yaml
@@ -1,0 +1,12 @@
+desired: {}
+input:
+  apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    annotations: {}
+    labels:
+      name: xfn-config
+    name: xfn-config
+  data:
+    controlNamespace: appcat-control
+observed: {}

--- a/test/functions/vshnkeycloak/01_default.yaml
+++ b/test/functions/vshnkeycloak/01_default.yaml
@@ -9,6 +9,7 @@ input:
     name: xfn-config
   data:
     defaultPlan: standard-2
+    controlNamespace: appcat-control
     plans: '{"standard-2": {"size": {"cpu": "500m", "disk": "16Gi", "enabled":
             true, "memory": "2Gi"}}, "standard-4": {"size": {"cpu": "1", "disk": "16Gi",
             "enabled": true, "memory": "4Gi"}}, "standard-8": {"size": {"cpu": "2",

--- a/test/functions/vshnmariadb/deploy/01_default.yaml
+++ b/test/functions/vshnmariadb/deploy/01_default.yaml
@@ -29,6 +29,7 @@ input:
     defaultPlan: standard-1
     mariadbChartRepo: https://charts.bitnami.com/bitnami
     mariadbChartVersion: 10.1.3
+    controlNamespace: appcat-control
     plans:
       '{"standard-1": {"size": {"cpu": "250m", "disk": "16Gi", "enabled": true,
       "memory": "1Gi"}}}'


### PR DESCRIPTION
With this commit it's possible to disable the billing for selected services.

It works by deploying a separate config map containing this information in the `appcat-control` namespace. This config map is then read by the service composition function and removes the billing accordingly.

For more detailed information please have a look at the docs in the commit.

## Summary

* Short summary of what's included in the PR
* Give special note to breaking changes

## Checklist

- [ ] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [ ] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
