### PR TITLE
Fix pg_repack extension not installing correcltly

### DIFF
--- a/pkg/comp-functions/functions/vshnpostgres/extensions.go
+++ b/pkg/comp-functions/functions/vshnpostgres/extensions.go
@@ -10,6 +10,7 @@ import (
 	stackgresv1 "github.com/vshn/appcat/v4/apis/stackgres/v1"
 	vshnv1 "github.com/vshn/appcat/v4/apis/vshn/v1"
 	"github.com/vshn/appcat/v4/pkg/comp-functions/runtime"
+	"k8s.io/utils/ptr"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 )
 
@@ -42,7 +43,8 @@ func AddExtensions(ctx context.Context, svc *runtime.ServiceRuntime) *xfnproto.R
 
 	// ensure pg_repack is always enabled
 	extensionsMap["pg_repack"] = stackgresv1.SGClusterSpecPostgresExtensionsItem{
-		Name: "pg_repack",
+		Name:    "pg_repack",
+		Version: ptr.To("1.5.0"),
 	}
 
 	if _, ok := extensionsMap["timescaledb"]; ok {


### PR DESCRIPTION
## Summary

For some reason as of 7.3.2024 the installation of the pg_repack extension doesn't work anymore without providing a version string as well.


## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
