### PR TITLE
Mitigate namespace deletion race-condition

### DIFF
--- a/pkg/comp-functions/functions/common/instance_namespace.go
+++ b/pkg/comp-functions/functions/common/instance_namespace.go
@@ -76,7 +76,8 @@ func createInstanceNamespace(ctx context.Context, serviceName, compName, claimNa
 
 	org, err := getOrg(compName, svc)
 	if err != nil {
-		return fmt.Errorf("cannot get claim namespace: %w", err)
+		svc.Log.Info("cannot get claim namespace")
+		svc.AddResult(runtime.NewWarningResult("cannot get claim namespace"))
 	}
 
 	ns := &corev1.Namespace{
@@ -96,7 +97,8 @@ func createInstanceNamespace(ctx context.Context, serviceName, compName, claimNa
 
 	controlNS, ok := svc.Config.Data["controlNamespace"]
 	if !ok {
-		return fmt.Errorf("controlNamespace not specified")
+		svc.Log.Info("no control namespace defined, please make sure that it's defined in the composition inputs")
+		svc.AddResult(runtime.NewWarningResult("no control namespace defined, please make sure that it's defined in the composition inputs"))
 	}
 
 	disabled, err := isBillingDisabled(controlNS, instanceNamespace, compName, svc)

--- a/pkg/comp-functions/functions/common/instance_namespace.go
+++ b/pkg/comp-functions/functions/common/instance_namespace.go
@@ -208,9 +208,9 @@ func isBillingDisabled(controlNS, instanceNamespace, compName string, svc *runti
 
 	err = svc.GetObservedKubeObject(cm, compName+objSuffix)
 	if err != nil {
-		if err == runtime.ErrNotFound {
-			return false, nil
-		}
+		// if err == runtime.ErrNotFound {
+		// 	return false, nil
+		// }
 		return false, err
 	}
 

--- a/pkg/comp-functions/functions/vshnpostgres/extensions_test.go
+++ b/pkg/comp-functions/functions/vshnpostgres/extensions_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	stackgresv1 "github.com/vshn/appcat/v4/apis/stackgres/v1"
 	"github.com/vshn/appcat/v4/pkg/comp-functions/functions/commontest"
+	"k8s.io/utils/ptr"
 )
 
 func Test_enableTimescaleDB(t *testing.T) {
@@ -97,7 +98,8 @@ func TestAddExtensions(t *testing.T) {
 			want:    nil,
 			wantExensions: []stackgresv1.SGClusterSpecPostgresExtensionsItem{
 				{
-					Name: "pg_repack",
+					Name:    "pg_repack",
+					Version: ptr.To("1.5.0"),
 				},
 			},
 		},
@@ -108,7 +110,8 @@ func TestAddExtensions(t *testing.T) {
 			want:    nil,
 			wantExensions: []stackgresv1.SGClusterSpecPostgresExtensionsItem{
 				{
-					Name: "pg_repack",
+					Name:    "pg_repack",
+					Version: ptr.To("1.5.0"),
 				},
 			},
 		},


### PR DESCRIPTION
## Summary

* There was a race condition which could re-create the instance namespace during the upgrade of the appcat function
* Also fixed the tests that broke during a hotfix deployment yesterday

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
