### PR TITLE
Fix Keycloak securityContext for OpenShift

### DIFF
--- a/pkg/comp-functions/functions/vshnkeycloak/deploy.go
+++ b/pkg/comp-functions/functions/vshnkeycloak/deploy.go
@@ -374,11 +374,13 @@ func newValues(ctx context.Context, svc *runtime.ServiceRuntime, comp *vshnv1.VS
 		},
 		"nodeSelector": nodeSelector,
 		"dbchecker": map[string]any{
-			"enabled": true,
+			"enabled":         true,
+			"securityContext": nil,
 		},
 		// See https://github.com/keycloak/keycloak/issues/11286
 		// readOnlyRootFilesystem: true
 		"securityContext": map[string]any{
+			"runAsUser":                nil,
 			"allowPrivilegeEscalation": false,
 			"capabilities": map[string]any{
 				"drop": []string{
@@ -389,6 +391,7 @@ func newValues(ctx context.Context, svc *runtime.ServiceRuntime, comp *vshnv1.VS
 		"http": map[string]any{
 			"relativePath": comp.Spec.Parameters.Service.RelativePath,
 		},
+		"podSecurityContext": nil,
 	}
 
 	fqdn := comp.Spec.Parameters.Service.FQDN


### PR DESCRIPTION
## Summary

* The helm chart sets some securityContext by default, this PR removes that

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
