### PR TITLE
Fix wrong JSON tag

### DIFF
--- a/apis/vshn/v1/vshn_minio.go
+++ b/apis/vshn/v1/vshn_minio.go
@@ -121,7 +121,7 @@ type XVSHNMinioSpec struct {
 	// Parameters are the configurable fields of a VSHNMinio.
 	Parameters VSHNMinioParameters `json:"parameters,omitempty"`
 
-	xpv1.ResourceSpec `json:"spec"`
+	xpv1.ResourceSpec `json:",inline"`
 }
 
 type XVSHNMinioStatus struct {

--- a/crds/appcat.vshn.io_objectbuckets.yaml
+++ b/crds/appcat.vshn.io_objectbuckets.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: objectbuckets.appcat.vshn.io
 spec:
   group: appcat.vshn.io
@@ -27,14 +27,19 @@ spec:
         description: ObjectBucket is the API for creating S3 buckets.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -56,20 +61,22 @@ spec:
                 properties:
                   bucketDeletionPolicy:
                     default: DeleteAll
-                    description: BucketDeletionPolicy determines how buckets should
-                      be deleted when Bucket is deleted. `DeleteIfEmpty` only deletes
-                      the bucket if the bucket is empty. `DeleteAll` recursively deletes
-                      all objects in the bucket and then removes it.
+                    description: |-
+                      BucketDeletionPolicy determines how buckets should be deleted when Bucket is deleted.
+                       `DeleteIfEmpty` only deletes the bucket if the bucket is empty.
+                       `DeleteAll` recursively deletes all objects in the bucket and then removes it.
                     type: string
                   bucketName:
-                    description: BucketName is the name of the bucket to create. Cannot
-                      be changed after bucket is created. Name must be acceptable
-                      by the S3 protocol, which follows RFC 1123. Be aware that S3
-                      providers may require a unique name across the platform or region.
+                    description: |-
+                      BucketName is the name of the bucket to create.
+                      Cannot be changed after bucket is created.
+                      Name must be acceptable by the S3 protocol, which follows RFC 1123.
+                      Be aware that S3 providers may require a unique name across the platform or region.
                     type: string
                   region:
-                    description: Region is the name of the region where the bucket
-                      shall be created. The region must be available in the S3 endpoint.
+                    description: |-
+                      Region is the name of the region where the bucket shall be created.
+                      The region must be available in the S3 endpoint.
                     type: string
                 required:
                 - bucketName
@@ -80,7 +87,9 @@ spec:
                   the connection details will be written.
                 properties:
                   name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                     type: string
                   namespace:
                     type: string
@@ -106,11 +115,9 @@ spec:
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: ObservedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
+                      description: |-
+                        ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
@@ -150,11 +157,9 @@ spec:
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: ObservedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
+                      description: |-
+                        ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
@@ -184,13 +189,15 @@ spec:
                   description: A Condition that may apply to a resource.
                   properties:
                     lastTransitionTime:
-                      description: LastTransitionTime is the last time this condition
-                        transitioned from one status to another.
+                      description: |-
+                        LastTransitionTime is the last time this condition transitioned from one
+                        status to another.
                       format: date-time
                       type: string
                     message:
-                      description: A Message containing details about this condition's
-                        last transition from one status to another, if any.
+                      description: |-
+                        A Message containing details about this condition's last transition from
+                        one status to another, if any.
                       type: string
                     reason:
                       description: A Reason for this condition's last transition from
@@ -201,8 +208,9 @@ spec:
                         False, or Unknown?
                       type: string
                     type:
-                      description: Type of this condition. At most one of each condition
-                        type may apply to a resource at any point in time.
+                      description: |-
+                        Type of this condition. At most one of each condition type may apply to
+                        a resource at any point in time.
                       type: string
                   required:
                   - lastTransitionTime

--- a/crds/appcat.vshn.io_xobjectbuckets.yaml
+++ b/crds/appcat.vshn.io_xobjectbuckets.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: xobjectbuckets.appcat.vshn.io
 spec:
   group: appcat.vshn.io
@@ -20,14 +20,19 @@ spec:
         description: XObjectBucket represents the internal composite of this claim
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -36,13 +41,14 @@ spec:
             properties:
               deletionPolicy:
                 default: Delete
-                description: 'DeletionPolicy specifies what will happen to the underlying
-                  external when this managed resource is deleted - either "Delete"
-                  or "Orphan" the external resource. This field is planned to be deprecated
-                  in favor of the ManagementPolicies field in a future release. Currently,
-                  both could be set independently and non-default values would be
-                  honored if the feature flag is enabled. See the design doc for more
-                  information: https://github.com/crossplane/crossplane/blob/499895a25d1a1a0ba1604944ef98ac7a1a71f197/design/design-doc-observe-only-resources.md?plain=1#L223'
+                description: |-
+                  DeletionPolicy specifies what will happen to the underlying external
+                  when this managed resource is deleted - either "Delete" or "Orphan" the
+                  external resource.
+                  This field is planned to be deprecated in favor of the ManagementPolicies
+                  field in a future release. Currently, both could be set independently and
+                  non-default values would be honored if the feature flag is enabled.
+                  See the design doc for more information: https://github.com/crossplane/crossplane/blob/499895a25d1a1a0ba1604944ef98ac7a1a71f197/design/design-doc-observe-only-resources.md?plain=1#L223
                 enum:
                 - Orphan
                 - Delete
@@ -50,19 +56,21 @@ spec:
               managementPolicies:
                 default:
                 - '*'
-                description: 'THIS IS A BETA FIELD. It is on by default but can be
-                  opted out through a Crossplane feature flag. ManagementPolicies
-                  specify the array of actions Crossplane is allowed to take on the
-                  managed and external resources. This field is planned to replace
-                  the DeletionPolicy field in a future release. Currently, both could
-                  be set independently and non-default values would be honored if
-                  the feature flag is enabled. If both are custom, the DeletionPolicy
-                  field will be ignored. See the design doc for more information:
-                  https://github.com/crossplane/crossplane/blob/499895a25d1a1a0ba1604944ef98ac7a1a71f197/design/design-doc-observe-only-resources.md?plain=1#L223
-                  and this one: https://github.com/crossplane/crossplane/blob/444267e84783136daa93568b364a5f01228cacbe/design/one-pager-ignore-changes.md'
+                description: |-
+                  THIS IS A BETA FIELD. It is on by default but can be opted out
+                  through a Crossplane feature flag.
+                  ManagementPolicies specify the array of actions Crossplane is allowed to
+                  take on the managed and external resources.
+                  This field is planned to replace the DeletionPolicy field in a future
+                  release. Currently, both could be set independently and non-default
+                  values would be honored if the feature flag is enabled. If both are
+                  custom, the DeletionPolicy field will be ignored.
+                  See the design doc for more information: https://github.com/crossplane/crossplane/blob/499895a25d1a1a0ba1604944ef98ac7a1a71f197/design/design-doc-observe-only-resources.md?plain=1#L223
+                  and this one: https://github.com/crossplane/crossplane/blob/444267e84783136daa93568b364a5f01228cacbe/design/one-pager-ignore-changes.md
                 items:
-                  description: A ManagementAction represents an action that the Crossplane
-                    controllers can take on an external resource.
+                  description: |-
+                    A ManagementAction represents an action that the Crossplane controllers
+                    can take on an external resource.
                   enum:
                   - Observe
                   - Create
@@ -78,20 +86,22 @@ spec:
                 properties:
                   bucketDeletionPolicy:
                     default: DeleteAll
-                    description: BucketDeletionPolicy determines how buckets should
-                      be deleted when Bucket is deleted. `DeleteIfEmpty` only deletes
-                      the bucket if the bucket is empty. `DeleteAll` recursively deletes
-                      all objects in the bucket and then removes it.
+                    description: |-
+                      BucketDeletionPolicy determines how buckets should be deleted when Bucket is deleted.
+                       `DeleteIfEmpty` only deletes the bucket if the bucket is empty.
+                       `DeleteAll` recursively deletes all objects in the bucket and then removes it.
                     type: string
                   bucketName:
-                    description: BucketName is the name of the bucket to create. Cannot
-                      be changed after bucket is created. Name must be acceptable
-                      by the S3 protocol, which follows RFC 1123. Be aware that S3
-                      providers may require a unique name across the platform or region.
+                    description: |-
+                      BucketName is the name of the bucket to create.
+                      Cannot be changed after bucket is created.
+                      Name must be acceptable by the S3 protocol, which follows RFC 1123.
+                      Be aware that S3 providers may require a unique name across the platform or region.
                     type: string
                   region:
-                    description: Region is the name of the region where the bucket
-                      shall be created. The region must be available in the S3 endpoint.
+                    description: |-
+                      Region is the name of the region where the bucket shall be created.
+                      The region must be available in the S3 endpoint.
                     type: string
                 required:
                 - bucketName
@@ -100,9 +110,10 @@ spec:
               providerConfigRef:
                 default:
                   name: default
-                description: ProviderConfigReference specifies how the provider that
-                  will be used to create, observe, update, and delete this managed
-                  resource should be configured.
+                description: |-
+                  ProviderConfigReference specifies how the provider that will be used to
+                  create, observe, update, and delete this managed resource should be
+                  configured.
                 properties:
                   name:
                     description: Name of the referenced object.
@@ -112,21 +123,21 @@ spec:
                     properties:
                       resolution:
                         default: Required
-                        description: Resolution specifies whether resolution of this
-                          reference is required. The default is 'Required', which
-                          means the reconcile will fail if the reference cannot be
-                          resolved. 'Optional' means this reference will be a no-op
-                          if it cannot be resolved.
+                        description: |-
+                          Resolution specifies whether resolution of this reference is required.
+                          The default is 'Required', which means the reconcile will fail if the
+                          reference cannot be resolved. 'Optional' means this reference will be
+                          a no-op if it cannot be resolved.
                         enum:
                         - Required
                         - Optional
                         type: string
                       resolve:
-                        description: Resolve specifies when this reference should
-                          be resolved. The default is 'IfNotPresent', which will attempt
-                          to resolve the reference only when the corresponding field
-                          is not present. Use 'Always' to resolve the reference on
-                          every reconcile.
+                        description: |-
+                          Resolve specifies when this reference should be resolved. The default
+                          is 'IfNotPresent', which will attempt to resolve the reference only when
+                          the corresponding field is not present. Use 'Always' to resolve the
+                          reference on every reconcile.
                         enum:
                         - Always
                         - IfNotPresent
@@ -136,17 +147,19 @@ spec:
                 - name
                 type: object
               publishConnectionDetailsTo:
-                description: PublishConnectionDetailsTo specifies the connection secret
-                  config which contains a name, metadata and a reference to secret
-                  store config to which any connection details for this managed resource
-                  should be written. Connection details frequently include the endpoint,
-                  username, and password required to connect to the managed resource.
+                description: |-
+                  PublishConnectionDetailsTo specifies the connection secret config which
+                  contains a name, metadata and a reference to secret store config to
+                  which any connection details for this managed resource should be written.
+                  Connection details frequently include the endpoint, username,
+                  and password required to connect to the managed resource.
                 properties:
                   configRef:
                     default:
                       name: default
-                    description: SecretStoreConfigRef specifies which secret store
-                      config should be used for this ConnectionSecret.
+                    description: |-
+                      SecretStoreConfigRef specifies which secret store config should be used
+                      for this ConnectionSecret.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -156,21 +169,21 @@ spec:
                         properties:
                           resolution:
                             default: Required
-                            description: Resolution specifies whether resolution of
-                              this reference is required. The default is 'Required',
-                              which means the reconcile will fail if the reference
-                              cannot be resolved. 'Optional' means this reference
-                              will be a no-op if it cannot be resolved.
+                            description: |-
+                              Resolution specifies whether resolution of this reference is required.
+                              The default is 'Required', which means the reconcile will fail if the
+                              reference cannot be resolved. 'Optional' means this reference will be
+                              a no-op if it cannot be resolved.
                             enum:
                             - Required
                             - Optional
                             type: string
                           resolve:
-                            description: Resolve specifies when this reference should
-                              be resolved. The default is 'IfNotPresent', which will
-                              attempt to resolve the reference only when the corresponding
-                              field is not present. Use 'Always' to resolve the reference
-                              on every reconcile.
+                            description: |-
+                              Resolve specifies when this reference should be resolved. The default
+                              is 'IfNotPresent', which will attempt to resolve the reference only when
+                              the corresponding field is not present. Use 'Always' to resolve the
+                              reference on every reconcile.
                             enum:
                             - Always
                             - IfNotPresent
@@ -185,21 +198,22 @@ spec:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Annotations are the annotations to be added to
-                          connection secret. - For Kubernetes secrets, this will be
-                          used as "metadata.annotations". - It is up to Secret Store
-                          implementation for others store types.
+                        description: |-
+                          Annotations are the annotations to be added to connection secret.
+                          - For Kubernetes secrets, this will be used as "metadata.annotations".
+                          - It is up to Secret Store implementation for others store types.
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Labels are the labels/tags to be added to connection
-                          secret. - For Kubernetes secrets, this will be used as "metadata.labels".
-                          - It is up to Secret Store implementation for others store
-                          types.
+                        description: |-
+                          Labels are the labels/tags to be added to connection secret.
+                          - For Kubernetes secrets, this will be used as "metadata.labels".
+                          - It is up to Secret Store implementation for others store types.
                         type: object
                       type:
-                        description: Type is the SecretType for the connection secret.
+                        description: |-
+                          Type is the SecretType for the connection secret.
                           - Only valid for Kubernetes Secret Stores.
                         type: string
                     type: object
@@ -210,14 +224,15 @@ spec:
                 - name
                 type: object
               writeConnectionSecretToRef:
-                description: WriteConnectionSecretToReference specifies the namespace
-                  and name of a Secret to which any connection details for this managed
-                  resource should be written. Connection details frequently include
-                  the endpoint, username, and password required to connect to the
-                  managed resource. This field is planned to be replaced in a future
-                  release in favor of PublishConnectionDetailsTo. Currently, both
-                  could be set independently and connection details would be published
-                  to both without affecting each other.
+                description: |-
+                  WriteConnectionSecretToReference specifies the namespace and name of a
+                  Secret to which any connection details for this managed resource should
+                  be written. Connection details frequently include the endpoint, username,
+                  and password required to connect to the managed resource.
+                  This field is planned to be replaced in a future release in favor of
+                  PublishConnectionDetailsTo. Currently, both could be set independently
+                  and connection details would be published to both without affecting
+                  each other.
                 properties:
                   name:
                     description: Name of the secret.
@@ -249,11 +264,9 @@ spec:
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: ObservedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
+                      description: |-
+                        ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
@@ -293,11 +306,9 @@ spec:
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: ObservedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
+                      description: |-
+                        ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
@@ -327,13 +338,15 @@ spec:
                   description: A Condition that may apply to a resource.
                   properties:
                     lastTransitionTime:
-                      description: LastTransitionTime is the last time this condition
-                        transitioned from one status to another.
+                      description: |-
+                        LastTransitionTime is the last time this condition transitioned from one
+                        status to another.
                       format: date-time
                       type: string
                     message:
-                      description: A Message containing details about this condition's
-                        last transition from one status to another, if any.
+                      description: |-
+                        A Message containing details about this condition's last transition from
+                        one status to another, if any.
                       type: string
                     reason:
                       description: A Reason for this condition's last transition from
@@ -344,8 +357,9 @@ spec:
                         False, or Unknown?
                       type: string
                     type:
-                      description: Type of this condition. At most one of each condition
-                        type may apply to a resource at any point in time.
+                      description: |-
+                        Type of this condition. At most one of each condition type may apply to
+                        a resource at any point in time.
                       type: string
                   required:
                   - lastTransitionTime

--- a/crds/exoscale.appcat.vshn.io_exoscalekafkas.yaml
+++ b/crds/exoscale.appcat.vshn.io_exoscalekafkas.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: exoscalekafkas.exoscale.appcat.vshn.io
 spec:
   group: exoscale.appcat.vshn.io
@@ -30,10 +30,19 @@ spec:
           description: ExoscaleKafka is the API for creating Kafka instances on Exoscale.
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -48,7 +57,9 @@ spec:
                       properties:
                         dayOfWeek:
                           default: tuesday
-                          description: DayOfWeek specifies at which weekday the maintenance is held place. Allowed values are [monday, tuesday, wednesday, thursday, friday, saturday, sunday, never]
+                          description: |-
+                            DayOfWeek specifies at which weekday the maintenance is held place.
+                            Allowed values are [monday, tuesday, wednesday, thursday, friday, saturday, sunday, never]
                           enum:
                             - monday
                             - tuesday
@@ -61,7 +72,9 @@ spec:
                           type: string
                         timeOfDay:
                           default: "22:30:00"
-                          description: 'TimeOfDay for installing updates in UTC. Format: "hh:mm:ss".'
+                          description: |-
+                            TimeOfDay for installing updates in UTC.
+                            Format: "hh:mm:ss".
                           pattern: ^([0-1]?[0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9])$
                           type: string
                       type: object
@@ -72,7 +85,10 @@ spec:
                         ipFilter:
                           default:
                             - 0.0.0.0/0
-                          description: IPFilter is a list of allowed IPv4 CIDR ranges that can access the service. If no IP Filter is set, you may not be able to reach the service. A value of `0.0.0.0/0` will open the service to all addresses on the public internet.
+                          description: |-
+                            IPFilter is a list of allowed IPv4 CIDR ranges that can access the service.
+                            If no IP Filter is set, you may not be able to reach the service.
+                            A value of `0.0.0.0/0` will open the service to all addresses on the public internet.
                           items:
                             type: string
                           type: array
@@ -87,7 +103,9 @@ spec:
                           x-kubernetes-preserve-unknown-fields: true
                         version:
                           default: "3.4"
-                          description: Version contains the minor version for Kafka. Currently only "3.4" is supported. Leave it empty to always get the latest supported version.
+                          description: |-
+                            Version contains the minor version for Kafka.
+                            Currently only "3.4" is supported. Leave it empty to always get the latest supported version.
                           enum:
                             - "3.4"
                           type: string
@@ -119,7 +137,9 @@ spec:
                   description: WriteConnectionSecretToRef references a secret to which the connection details will be written.
                   properties:
                     name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      description: |-
+                        Name of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                       type: string
                     namespace:
                       type: string
@@ -142,7 +162,9 @@ spec:
                         maxLength: 32768
                         type: string
                       observedGeneration:
-                        description: ObservedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        description: |-
+                          ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                         format: int64
                         minimum: 0
                         type: integer

--- a/crds/exoscale.appcat.vshn.io_exoscalemysqls.yaml
+++ b/crds/exoscale.appcat.vshn.io_exoscalemysqls.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: exoscalemysqls.exoscale.appcat.vshn.io
 spec:
   group: exoscale.appcat.vshn.io
@@ -27,10 +27,19 @@ spec:
           description: ExoscaleMySQL is the API for creating MySQL on Exoscale.
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -45,7 +54,9 @@ spec:
                       properties:
                         timeOfDay:
                           default: "21:30:00"
-                          description: 'TimeOfDay for doing daily backups, in UTC. Format: "hh:mm:ss".'
+                          description: |-
+                            TimeOfDay for doing daily backups, in UTC.
+                            Format: "hh:mm:ss".
                           pattern: ^([0-1]?[0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9])$
                           type: string
                       type: object
@@ -55,7 +66,9 @@ spec:
                       properties:
                         dayOfWeek:
                           default: tuesday
-                          description: DayOfWeek specifies at which weekday the maintenance is held place. Allowed values are [monday, tuesday, wednesday, thursday, friday, saturday, sunday, never]
+                          description: |-
+                            DayOfWeek specifies at which weekday the maintenance is held place.
+                            Allowed values are [monday, tuesday, wednesday, thursday, friday, saturday, sunday, never]
                           enum:
                             - monday
                             - tuesday
@@ -68,7 +81,9 @@ spec:
                           type: string
                         timeOfDay:
                           default: "22:30:00"
-                          description: 'TimeOfDay for installing updates in UTC. Format: "hh:mm:ss".'
+                          description: |-
+                            TimeOfDay for installing updates in UTC.
+                            Format: "hh:mm:ss".
                           pattern: ^([0-1]?[0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9])$
                           type: string
                       type: object
@@ -79,7 +94,10 @@ spec:
                         ipFilter:
                           default:
                             - 0.0.0.0/0
-                          description: IPFilter is a list of allowed IPv4 CIDR ranges that can access the service. If no IP Filter is set, you may not be able to reach the service. A value of `0.0.0.0/0` will open the service to all addresses on the public internet.
+                          description: |-
+                            IPFilter is a list of allowed IPv4 CIDR ranges that can access the service.
+                            If no IP Filter is set, you may not be able to reach the service.
+                            A value of `0.0.0.0/0` will open the service to all addresses on the public internet.
                           items:
                             type: string
                           type: array
@@ -90,7 +108,9 @@ spec:
                       properties:
                         majorVersion:
                           default: "8"
-                          description: MajorVersion contains the major version for MySQL. Currently only "8" is supported. Leave it empty to always get the latest supported version.
+                          description: |-
+                            MajorVersion contains the major version for MySQL.
+                            Currently only "8" is supported. Leave it empty to always get the latest supported version.
                           enum:
                             - "8"
                           type: string
@@ -126,7 +146,9 @@ spec:
                   description: WriteConnectionSecretToRef references a secret to which the connection details will be written.
                   properties:
                     name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      description: |-
+                        Name of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                       type: string
                     namespace:
                       type: string
@@ -149,7 +171,9 @@ spec:
                         maxLength: 32768
                         type: string
                       observedGeneration:
-                        description: ObservedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        description: |-
+                          ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                         format: int64
                         minimum: 0
                         type: integer

--- a/crds/exoscale.appcat.vshn.io_exoscaleopensearches.yaml
+++ b/crds/exoscale.appcat.vshn.io_exoscaleopensearches.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: exoscaleopensearches.exoscale.appcat.vshn.io
 spec:
   group: exoscale.appcat.vshn.io
@@ -27,10 +27,19 @@ spec:
           description: ExoscaleOpenSearch is the api for creating OpenSearch on Exoscale
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -45,7 +54,9 @@ spec:
                       properties:
                         timeOfDay:
                           default: "21:30:00"
-                          description: 'TimeOfDay for doing daily backups, in UTC. Format: "hh:mm:ss".'
+                          description: |-
+                            TimeOfDay for doing daily backups, in UTC.
+                            Format: "hh:mm:ss".
                           pattern: ^([0-1]?[0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9])$
                           type: string
                       type: object
@@ -55,7 +66,9 @@ spec:
                       properties:
                         dayOfWeek:
                           default: tuesday
-                          description: DayOfWeek specifies at which weekday the maintenance is held place. Allowed values are [monday, tuesday, wednesday, thursday, friday, saturday, sunday, never]
+                          description: |-
+                            DayOfWeek specifies at which weekday the maintenance is held place.
+                            Allowed values are [monday, tuesday, wednesday, thursday, friday, saturday, sunday, never]
                           enum:
                             - monday
                             - tuesday
@@ -68,7 +81,9 @@ spec:
                           type: string
                         timeOfDay:
                           default: "22:30:00"
-                          description: 'TimeOfDay for installing updates in UTC. Format: "hh:mm:ss".'
+                          description: |-
+                            TimeOfDay for installing updates in UTC.
+                            Format: "hh:mm:ss".
                           pattern: ^([0-1]?[0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9])$
                           type: string
                       type: object
@@ -79,7 +94,10 @@ spec:
                         ipFilter:
                           default:
                             - 0.0.0.0/0
-                          description: IPFilter is a list of allowed IPv4 CIDR ranges that can access the service. If no IP Filter is set, you may not be able to reach the service. A value of `0.0.0.0/0` will open the service to all addresses on the public internet.
+                          description: |-
+                            IPFilter is a list of allowed IPv4 CIDR ranges that can access the service.
+                            If no IP Filter is set, you may not be able to reach the service.
+                            A value of `0.0.0.0/0` will open the service to all addresses on the public internet.
                           items:
                             type: string
                           type: array
@@ -90,7 +108,9 @@ spec:
                       properties:
                         majorVersion:
                           default: "2"
-                          description: MajorVersion contains the version for OpenSearch. Currently only "2" and "1" is supported. Leave it empty to always get the latest supported version.
+                          description: |-
+                            MajorVersion contains the version for OpenSearch.
+                            Currently only "2" and "1" is supported. Leave it empty to always get the latest supported version.
                           enum:
                             - "1"
                             - "2"
@@ -127,7 +147,9 @@ spec:
                   description: WriteConnectionSecretToRef references a secret to which the connection details will be written.
                   properties:
                     name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      description: |-
+                        Name of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                       type: string
                     namespace:
                       type: string
@@ -150,7 +172,9 @@ spec:
                         maxLength: 32768
                         type: string
                       observedGeneration:
-                        description: ObservedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        description: |-
+                          ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                         format: int64
                         minimum: 0
                         type: integer

--- a/crds/exoscale.appcat.vshn.io_exoscalepostgresqls.yaml
+++ b/crds/exoscale.appcat.vshn.io_exoscalepostgresqls.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: exoscalepostgresqls.exoscale.appcat.vshn.io
 spec:
   group: exoscale.appcat.vshn.io
@@ -27,10 +27,19 @@ spec:
           description: ExoscalePostgreSQL is the API for creating PostgreSQL on Exoscale.
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -45,7 +54,9 @@ spec:
                       properties:
                         timeOfDay:
                           default: "21:30:00"
-                          description: 'TimeOfDay for doing daily backups, in UTC. Format: "hh:mm:ss".'
+                          description: |-
+                            TimeOfDay for doing daily backups, in UTC.
+                            Format: "hh:mm:ss".
                           pattern: ^([0-1]?[0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9])$
                           type: string
                       type: object
@@ -55,7 +66,9 @@ spec:
                       properties:
                         dayOfWeek:
                           default: tuesday
-                          description: DayOfWeek specifies at which weekday the maintenance is held place. Allowed values are [monday, tuesday, wednesday, thursday, friday, saturday, sunday, never]
+                          description: |-
+                            DayOfWeek specifies at which weekday the maintenance is held place.
+                            Allowed values are [monday, tuesday, wednesday, thursday, friday, saturday, sunday, never]
                           enum:
                             - monday
                             - tuesday
@@ -68,7 +81,9 @@ spec:
                           type: string
                         timeOfDay:
                           default: "22:30:00"
-                          description: 'TimeOfDay for installing updates in UTC. Format: "hh:mm:ss".'
+                          description: |-
+                            TimeOfDay for installing updates in UTC.
+                            Format: "hh:mm:ss".
                           pattern: ^([0-1]?[0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9])$
                           type: string
                       type: object
@@ -79,7 +94,10 @@ spec:
                         ipFilter:
                           default:
                             - 0.0.0.0/0
-                          description: IPFilter is a list of allowed IPv4 CIDR ranges that can access the service. If no IP Filter is set, you may not be able to reach the service. A value of `0.0.0.0/0` will open the service to all addresses on the public internet.
+                          description: |-
+                            IPFilter is a list of allowed IPv4 CIDR ranges that can access the service.
+                            If no IP Filter is set, you may not be able to reach the service.
+                            A value of `0.0.0.0/0` will open the service to all addresses on the public internet.
                           items:
                             type: string
                           type: array
@@ -90,7 +108,9 @@ spec:
                       properties:
                         majorVersion:
                           default: "14"
-                          description: MajorVersion contains the major version for PostgreSQL. Currently only "14" is supported. Leave it empty to always get the latest supported version.
+                          description: |-
+                            MajorVersion contains the major version for PostgreSQL.
+                            Currently only "14" is supported. Leave it empty to always get the latest supported version.
                           enum:
                             - "14"
                           type: string
@@ -126,7 +146,9 @@ spec:
                   description: WriteConnectionSecretToRef references a secret to which the connection details will be written.
                   properties:
                     name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      description: |-
+                        Name of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                       type: string
                     namespace:
                       type: string
@@ -149,7 +171,9 @@ spec:
                         maxLength: 32768
                         type: string
                       observedGeneration:
-                        description: ObservedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        description: |-
+                          ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                         format: int64
                         minimum: 0
                         type: integer

--- a/crds/exoscale.appcat.vshn.io_exoscaleredis.yaml
+++ b/crds/exoscale.appcat.vshn.io_exoscaleredis.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: exoscaleredis.exoscale.appcat.vshn.io
 spec:
   group: exoscale.appcat.vshn.io
@@ -27,10 +27,19 @@ spec:
           description: ExoscaleRedis is the API for creating Redis instances on Exoscale.
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -45,7 +54,9 @@ spec:
                       properties:
                         dayOfWeek:
                           default: tuesday
-                          description: DayOfWeek specifies at which weekday the maintenance is held place. Allowed values are [monday, tuesday, wednesday, thursday, friday, saturday, sunday, never]
+                          description: |-
+                            DayOfWeek specifies at which weekday the maintenance is held place.
+                            Allowed values are [monday, tuesday, wednesday, thursday, friday, saturday, sunday, never]
                           enum:
                             - monday
                             - tuesday
@@ -58,7 +69,9 @@ spec:
                           type: string
                         timeOfDay:
                           default: "22:30:00"
-                          description: 'TimeOfDay for installing updates in UTC. Format: "hh:mm:ss".'
+                          description: |-
+                            TimeOfDay for installing updates in UTC.
+                            Format: "hh:mm:ss".
                           pattern: ^([0-1]?[0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9])$
                           type: string
                       type: object
@@ -69,7 +82,10 @@ spec:
                         ipFilter:
                           default:
                             - 0.0.0.0/0
-                          description: IPFilter is a list of allowed IPv4 CIDR ranges that can access the service. If no IP Filter is set, you may not be able to reach the service. A value of `0.0.0.0/0` will open the service to all addresses on the public internet.
+                          description: |-
+                            IPFilter is a list of allowed IPv4 CIDR ranges that can access the service.
+                            If no IP Filter is set, you may not be able to reach the service.
+                            A value of `0.0.0.0/0` will open the service to all addresses on the public internet.
                           items:
                             type: string
                           type: array
@@ -110,7 +126,9 @@ spec:
                   description: WriteConnectionSecretToRef references a secret to which the connection details will be written.
                   properties:
                     name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      description: |-
+                        Name of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                       type: string
                     namespace:
                       type: string
@@ -133,7 +151,9 @@ spec:
                         maxLength: 32768
                         type: string
                       observedGeneration:
-                        description: ObservedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        description: |-
+                          ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                         format: int64
                         minimum: 0
                         type: integer

--- a/crds/helm.crossplane.io_releases.yaml
+++ b/crds/helm.crossplane.io_releases.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: releases.helm.crossplane.io
 spec:
   group: helm.crossplane.io
@@ -49,14 +49,19 @@ spec:
         description: A Release is an example API type
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -65,13 +70,14 @@ spec:
             properties:
               deletionPolicy:
                 default: Delete
-                description: 'DeletionPolicy specifies what will happen to the underlying
-                  external when this managed resource is deleted - either "Delete"
-                  or "Orphan" the external resource. This field is planned to be deprecated
-                  in favor of the ManagementPolicies field in a future release. Currently,
-                  both could be set independently and non-default values would be
-                  honored if the feature flag is enabled. See the design doc for more
-                  information: https://github.com/crossplane/crossplane/blob/499895a25d1a1a0ba1604944ef98ac7a1a71f197/design/design-doc-observe-only-resources.md?plain=1#L223'
+                description: |-
+                  DeletionPolicy specifies what will happen to the underlying external
+                  when this managed resource is deleted - either "Delete" or "Orphan" the
+                  external resource.
+                  This field is planned to be deprecated in favor of the ManagementPolicies
+                  field in a future release. Currently, both could be set independently and
+                  non-default values would be honored if the feature flag is enabled.
+                  See the design doc for more information: https://github.com/crossplane/crossplane/blob/499895a25d1a1a0ba1604944ef98ac7a1a71f197/design/design-doc-observe-only-resources.md?plain=1#L223
                 enum:
                 - Orphan
                 - Delete
@@ -245,19 +251,21 @@ spec:
               managementPolicies:
                 default:
                 - '*'
-                description: 'THIS IS A BETA FIELD. It is on by default but can be
-                  opted out through a Crossplane feature flag. ManagementPolicies
-                  specify the array of actions Crossplane is allowed to take on the
-                  managed and external resources. This field is planned to replace
-                  the DeletionPolicy field in a future release. Currently, both could
-                  be set independently and non-default values would be honored if
-                  the feature flag is enabled. If both are custom, the DeletionPolicy
-                  field will be ignored. See the design doc for more information:
-                  https://github.com/crossplane/crossplane/blob/499895a25d1a1a0ba1604944ef98ac7a1a71f197/design/design-doc-observe-only-resources.md?plain=1#L223
-                  and this one: https://github.com/crossplane/crossplane/blob/444267e84783136daa93568b364a5f01228cacbe/design/one-pager-ignore-changes.md'
+                description: |-
+                  THIS IS A BETA FIELD. It is on by default but can be opted out
+                  through a Crossplane feature flag.
+                  ManagementPolicies specify the array of actions Crossplane is allowed to
+                  take on the managed and external resources.
+                  This field is planned to replace the DeletionPolicy field in a future
+                  release. Currently, both could be set independently and non-default
+                  values would be honored if the feature flag is enabled. If both are
+                  custom, the DeletionPolicy field will be ignored.
+                  See the design doc for more information: https://github.com/crossplane/crossplane/blob/499895a25d1a1a0ba1604944ef98ac7a1a71f197/design/design-doc-observe-only-resources.md?plain=1#L223
+                  and this one: https://github.com/crossplane/crossplane/blob/444267e84783136daa93568b364a5f01228cacbe/design/one-pager-ignore-changes.md
                 items:
-                  description: A ManagementAction represents an action that the Crossplane
-                    controllers can take on an external resource.
+                  description: |-
+                    A ManagementAction represents an action that the Crossplane controllers
+                    can take on an external resource.
                   enum:
                   - Observe
                   - Create
@@ -270,9 +278,10 @@ spec:
               providerConfigRef:
                 default:
                   name: default
-                description: ProviderConfigReference specifies how the provider that
-                  will be used to create, observe, update, and delete this managed
-                  resource should be configured.
+                description: |-
+                  ProviderConfigReference specifies how the provider that will be used to
+                  create, observe, update, and delete this managed resource should be
+                  configured.
                 properties:
                   name:
                     description: Name of the referenced object.
@@ -282,21 +291,21 @@ spec:
                     properties:
                       resolution:
                         default: Required
-                        description: Resolution specifies whether resolution of this
-                          reference is required. The default is 'Required', which
-                          means the reconcile will fail if the reference cannot be
-                          resolved. 'Optional' means this reference will be a no-op
-                          if it cannot be resolved.
+                        description: |-
+                          Resolution specifies whether resolution of this reference is required.
+                          The default is 'Required', which means the reconcile will fail if the
+                          reference cannot be resolved. 'Optional' means this reference will be
+                          a no-op if it cannot be resolved.
                         enum:
                         - Required
                         - Optional
                         type: string
                       resolve:
-                        description: Resolve specifies when this reference should
-                          be resolved. The default is 'IfNotPresent', which will attempt
-                          to resolve the reference only when the corresponding field
-                          is not present. Use 'Always' to resolve the reference on
-                          every reconcile.
+                        description: |-
+                          Resolve specifies when this reference should be resolved. The default
+                          is 'IfNotPresent', which will attempt to resolve the reference only when
+                          the corresponding field is not present. Use 'Always' to resolve the
+                          reference on every reconcile.
                         enum:
                         - Always
                         - IfNotPresent
@@ -306,17 +315,19 @@ spec:
                 - name
                 type: object
               publishConnectionDetailsTo:
-                description: PublishConnectionDetailsTo specifies the connection secret
-                  config which contains a name, metadata and a reference to secret
-                  store config to which any connection details for this managed resource
-                  should be written. Connection details frequently include the endpoint,
-                  username, and password required to connect to the managed resource.
+                description: |-
+                  PublishConnectionDetailsTo specifies the connection secret config which
+                  contains a name, metadata and a reference to secret store config to
+                  which any connection details for this managed resource should be written.
+                  Connection details frequently include the endpoint, username,
+                  and password required to connect to the managed resource.
                 properties:
                   configRef:
                     default:
                       name: default
-                    description: SecretStoreConfigRef specifies which secret store
-                      config should be used for this ConnectionSecret.
+                    description: |-
+                      SecretStoreConfigRef specifies which secret store config should be used
+                      for this ConnectionSecret.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -326,21 +337,21 @@ spec:
                         properties:
                           resolution:
                             default: Required
-                            description: Resolution specifies whether resolution of
-                              this reference is required. The default is 'Required',
-                              which means the reconcile will fail if the reference
-                              cannot be resolved. 'Optional' means this reference
-                              will be a no-op if it cannot be resolved.
+                            description: |-
+                              Resolution specifies whether resolution of this reference is required.
+                              The default is 'Required', which means the reconcile will fail if the
+                              reference cannot be resolved. 'Optional' means this reference will be
+                              a no-op if it cannot be resolved.
                             enum:
                             - Required
                             - Optional
                             type: string
                           resolve:
-                            description: Resolve specifies when this reference should
-                              be resolved. The default is 'IfNotPresent', which will
-                              attempt to resolve the reference only when the corresponding
-                              field is not present. Use 'Always' to resolve the reference
-                              on every reconcile.
+                            description: |-
+                              Resolve specifies when this reference should be resolved. The default
+                              is 'IfNotPresent', which will attempt to resolve the reference only when
+                              the corresponding field is not present. Use 'Always' to resolve the
+                              reference on every reconcile.
                             enum:
                             - Always
                             - IfNotPresent
@@ -355,21 +366,22 @@ spec:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Annotations are the annotations to be added to
-                          connection secret. - For Kubernetes secrets, this will be
-                          used as "metadata.annotations". - It is up to Secret Store
-                          implementation for others store types.
+                        description: |-
+                          Annotations are the annotations to be added to connection secret.
+                          - For Kubernetes secrets, this will be used as "metadata.annotations".
+                          - It is up to Secret Store implementation for others store types.
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Labels are the labels/tags to be added to connection
-                          secret. - For Kubernetes secrets, this will be used as "metadata.labels".
-                          - It is up to Secret Store implementation for others store
-                          types.
+                        description: |-
+                          Labels are the labels/tags to be added to connection secret.
+                          - For Kubernetes secrets, this will be used as "metadata.labels".
+                          - It is up to Secret Store implementation for others store types.
                         type: object
                       type:
-                        description: Type is the SecretType for the connection secret.
+                        description: |-
+                          Type is the SecretType for the connection secret.
                           - Only valid for Kubernetes Secret Stores.
                         type: string
                     type: object
@@ -385,14 +397,15 @@ spec:
                 format: int32
                 type: integer
               writeConnectionSecretToRef:
-                description: WriteConnectionSecretToReference specifies the namespace
-                  and name of a Secret to which any connection details for this managed
-                  resource should be written. Connection details frequently include
-                  the endpoint, username, and password required to connect to the
-                  managed resource. This field is planned to be replaced in a future
-                  release in favor of PublishConnectionDetailsTo. Currently, both
-                  could be set independently and connection details would be published
-                  to both without affecting each other.
+                description: |-
+                  WriteConnectionSecretToReference specifies the namespace and name of a
+                  Secret to which any connection details for this managed resource should
+                  be written. Connection details frequently include the endpoint, username,
+                  and password required to connect to the managed resource.
+                  This field is planned to be replaced in a future release in favor of
+                  PublishConnectionDetailsTo. Currently, both could be set independently
+                  and connection details would be published to both without affecting
+                  each other.
                 properties:
                   name:
                     description: Name of the secret.
@@ -427,13 +440,15 @@ spec:
                   description: A Condition that may apply to a resource.
                   properties:
                     lastTransitionTime:
-                      description: LastTransitionTime is the last time this condition
-                        transitioned from one status to another.
+                      description: |-
+                        LastTransitionTime is the last time this condition transitioned from one
+                        status to another.
                       format: date-time
                       type: string
                     message:
-                      description: A Message containing details about this condition's
-                        last transition from one status to another, if any.
+                      description: |-
+                        A Message containing details about this condition's last transition from
+                        one status to another, if any.
                       type: string
                     reason:
                       description: A Reason for this condition's last transition from
@@ -444,8 +459,9 @@ spec:
                         False, or Unknown?
                       type: string
                     type:
-                      description: Type of this condition. At most one of each condition
-                        type may apply to a resource at any point in time.
+                      description: |-
+                        Type of this condition. At most one of each condition type may apply to
+                        a resource at any point in time.
                       type: string
                   required:
                   - lastTransitionTime
@@ -503,14 +519,19 @@ spec:
         description: A Release is an example API type
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -525,30 +546,35 @@ spec:
                       description: API version of the referent.
                       type: string
                     fieldPath:
-                      description: 'If referring to a piece of an object instead of
-                        an entire object, this string should contain a valid JSON/Go
-                        field access statement, such as desiredState.manifest.containers[2].
-                        For example, if the object reference is to a container within
-                        a pod, this would take on a value like: "spec.containers{name}"
-                        (where "name" refers to the name of the container that triggered
-                        the event) or if no container name is specified "spec.containers[2]"
-                        (container with index 2 in this pod). This syntax is chosen
-                        only to have some well-defined way of referencing a part of
-                        an object. TODO: this design is not final and this field is
-                        subject to change in the future.'
+                      description: |-
+                        If referring to a piece of an object instead of an entire object, this string
+                        should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                        For example, if the object reference is to a container within a pod, this would take on a value like:
+                        "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                        the event) or if no container name is specified "spec.containers[2]" (container with
+                        index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                        referencing a part of an object.
+                        TODO: this design is not final and this field is subject to change in the future.
                       type: string
                     kind:
-                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      description: |-
+                        Kind of the referent.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
                       type: string
                     name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      description: |-
+                        Name of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                       type: string
                     namespace:
-                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      description: |-
+                        Namespace of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
                       type: string
                     resourceVersion:
-                      description: 'Specific resourceVersion to which this reference
-                        is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                      description: |-
+                        Specific resourceVersion to which this reference is made, if any.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
                       type: string
                     skipPartOfReleaseCheck:
                       description: SkipPartOfReleaseCheck skips check for meta.helm.sh/release-name
@@ -557,20 +583,23 @@ spec:
                     toConnectionSecretKey:
                       type: string
                     uid:
-                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                      description: |-
+                        UID of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
                       type: string
                   type: object
                   x-kubernetes-map-type: atomic
                 type: array
               deletionPolicy:
                 default: Delete
-                description: 'DeletionPolicy specifies what will happen to the underlying
-                  external when this managed resource is deleted - either "Delete"
-                  or "Orphan" the external resource. This field is planned to be deprecated
-                  in favor of the ManagementPolicies field in a future release. Currently,
-                  both could be set independently and non-default values would be
-                  honored if the feature flag is enabled. See the design doc for more
-                  information: https://github.com/crossplane/crossplane/blob/499895a25d1a1a0ba1604944ef98ac7a1a71f197/design/design-doc-observe-only-resources.md?plain=1#L223'
+                description: |-
+                  DeletionPolicy specifies what will happen to the underlying external
+                  when this managed resource is deleted - either "Delete" or "Orphan" the
+                  external resource.
+                  This field is planned to be deprecated in favor of the ManagementPolicies
+                  field in a future release. Currently, both could be set independently and
+                  non-default values would be honored if the feature flag is enabled.
+                  See the design doc for more information: https://github.com/crossplane/crossplane/blob/499895a25d1a1a0ba1604944ef98ac7a1a71f197/design/design-doc-observe-only-resources.md?plain=1#L223
                 enum:
                 - Orphan
                 - Delete
@@ -759,9 +788,9 @@ spec:
                     description: Wait for the release to become ready.
                     type: boolean
                   waitTimeout:
-                    description: WaitTimeout is the duration Helm will wait for the
-                      release to become ready. Only applies if wait is also set. Defaults
-                      to 5m.
+                    description: |-
+                      WaitTimeout is the duration Helm will wait for the release to become
+                      ready. Only applies if wait is also set. Defaults to 5m.
                     type: string
                 required:
                 - chart
@@ -770,19 +799,21 @@ spec:
               managementPolicies:
                 default:
                 - '*'
-                description: 'THIS IS A BETA FIELD. It is on by default but can be
-                  opted out through a Crossplane feature flag. ManagementPolicies
-                  specify the array of actions Crossplane is allowed to take on the
-                  managed and external resources. This field is planned to replace
-                  the DeletionPolicy field in a future release. Currently, both could
-                  be set independently and non-default values would be honored if
-                  the feature flag is enabled. If both are custom, the DeletionPolicy
-                  field will be ignored. See the design doc for more information:
-                  https://github.com/crossplane/crossplane/blob/499895a25d1a1a0ba1604944ef98ac7a1a71f197/design/design-doc-observe-only-resources.md?plain=1#L223
-                  and this one: https://github.com/crossplane/crossplane/blob/444267e84783136daa93568b364a5f01228cacbe/design/one-pager-ignore-changes.md'
+                description: |-
+                  THIS IS A BETA FIELD. It is on by default but can be opted out
+                  through a Crossplane feature flag.
+                  ManagementPolicies specify the array of actions Crossplane is allowed to
+                  take on the managed and external resources.
+                  This field is planned to replace the DeletionPolicy field in a future
+                  release. Currently, both could be set independently and non-default
+                  values would be honored if the feature flag is enabled. If both are
+                  custom, the DeletionPolicy field will be ignored.
+                  See the design doc for more information: https://github.com/crossplane/crossplane/blob/499895a25d1a1a0ba1604944ef98ac7a1a71f197/design/design-doc-observe-only-resources.md?plain=1#L223
+                  and this one: https://github.com/crossplane/crossplane/blob/444267e84783136daa93568b364a5f01228cacbe/design/one-pager-ignore-changes.md
                 items:
-                  description: A ManagementAction represents an action that the Crossplane
-                    controllers can take on an external resource.
+                  description: |-
+                    A ManagementAction represents an action that the Crossplane controllers
+                    can take on an external resource.
                   enum:
                   - Observe
                   - Create
@@ -795,9 +826,10 @@ spec:
               providerConfigRef:
                 default:
                   name: default
-                description: ProviderConfigReference specifies how the provider that
-                  will be used to create, observe, update, and delete this managed
-                  resource should be configured.
+                description: |-
+                  ProviderConfigReference specifies how the provider that will be used to
+                  create, observe, update, and delete this managed resource should be
+                  configured.
                 properties:
                   name:
                     description: Name of the referenced object.
@@ -807,21 +839,21 @@ spec:
                     properties:
                       resolution:
                         default: Required
-                        description: Resolution specifies whether resolution of this
-                          reference is required. The default is 'Required', which
-                          means the reconcile will fail if the reference cannot be
-                          resolved. 'Optional' means this reference will be a no-op
-                          if it cannot be resolved.
+                        description: |-
+                          Resolution specifies whether resolution of this reference is required.
+                          The default is 'Required', which means the reconcile will fail if the
+                          reference cannot be resolved. 'Optional' means this reference will be
+                          a no-op if it cannot be resolved.
                         enum:
                         - Required
                         - Optional
                         type: string
                       resolve:
-                        description: Resolve specifies when this reference should
-                          be resolved. The default is 'IfNotPresent', which will attempt
-                          to resolve the reference only when the corresponding field
-                          is not present. Use 'Always' to resolve the reference on
-                          every reconcile.
+                        description: |-
+                          Resolve specifies when this reference should be resolved. The default
+                          is 'IfNotPresent', which will attempt to resolve the reference only when
+                          the corresponding field is not present. Use 'Always' to resolve the
+                          reference on every reconcile.
                         enum:
                         - Always
                         - IfNotPresent
@@ -831,17 +863,19 @@ spec:
                 - name
                 type: object
               publishConnectionDetailsTo:
-                description: PublishConnectionDetailsTo specifies the connection secret
-                  config which contains a name, metadata and a reference to secret
-                  store config to which any connection details for this managed resource
-                  should be written. Connection details frequently include the endpoint,
-                  username, and password required to connect to the managed resource.
+                description: |-
+                  PublishConnectionDetailsTo specifies the connection secret config which
+                  contains a name, metadata and a reference to secret store config to
+                  which any connection details for this managed resource should be written.
+                  Connection details frequently include the endpoint, username,
+                  and password required to connect to the managed resource.
                 properties:
                   configRef:
                     default:
                       name: default
-                    description: SecretStoreConfigRef specifies which secret store
-                      config should be used for this ConnectionSecret.
+                    description: |-
+                      SecretStoreConfigRef specifies which secret store config should be used
+                      for this ConnectionSecret.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -851,21 +885,21 @@ spec:
                         properties:
                           resolution:
                             default: Required
-                            description: Resolution specifies whether resolution of
-                              this reference is required. The default is 'Required',
-                              which means the reconcile will fail if the reference
-                              cannot be resolved. 'Optional' means this reference
-                              will be a no-op if it cannot be resolved.
+                            description: |-
+                              Resolution specifies whether resolution of this reference is required.
+                              The default is 'Required', which means the reconcile will fail if the
+                              reference cannot be resolved. 'Optional' means this reference will be
+                              a no-op if it cannot be resolved.
                             enum:
                             - Required
                             - Optional
                             type: string
                           resolve:
-                            description: Resolve specifies when this reference should
-                              be resolved. The default is 'IfNotPresent', which will
-                              attempt to resolve the reference only when the corresponding
-                              field is not present. Use 'Always' to resolve the reference
-                              on every reconcile.
+                            description: |-
+                              Resolve specifies when this reference should be resolved. The default
+                              is 'IfNotPresent', which will attempt to resolve the reference only when
+                              the corresponding field is not present. Use 'Always' to resolve the
+                              reference on every reconcile.
                             enum:
                             - Always
                             - IfNotPresent
@@ -880,21 +914,22 @@ spec:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Annotations are the annotations to be added to
-                          connection secret. - For Kubernetes secrets, this will be
-                          used as "metadata.annotations". - It is up to Secret Store
-                          implementation for others store types.
+                        description: |-
+                          Annotations are the annotations to be added to connection secret.
+                          - For Kubernetes secrets, this will be used as "metadata.annotations".
+                          - It is up to Secret Store implementation for others store types.
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Labels are the labels/tags to be added to connection
-                          secret. - For Kubernetes secrets, this will be used as "metadata.labels".
-                          - It is up to Secret Store implementation for others store
-                          types.
+                        description: |-
+                          Labels are the labels/tags to be added to connection secret.
+                          - For Kubernetes secrets, this will be used as "metadata.labels".
+                          - It is up to Secret Store implementation for others store types.
                         type: object
                       type:
-                        description: Type is the SecretType for the connection secret.
+                        description: |-
+                          Type is the SecretType for the connection secret.
                           - Only valid for Kubernetes Secret Stores.
                         type: string
                     type: object
@@ -910,14 +945,15 @@ spec:
                 format: int32
                 type: integer
               writeConnectionSecretToRef:
-                description: WriteConnectionSecretToReference specifies the namespace
-                  and name of a Secret to which any connection details for this managed
-                  resource should be written. Connection details frequently include
-                  the endpoint, username, and password required to connect to the
-                  managed resource. This field is planned to be replaced in a future
-                  release in favor of PublishConnectionDetailsTo. Currently, both
-                  could be set independently and connection details would be published
-                  to both without affecting each other.
+                description: |-
+                  WriteConnectionSecretToReference specifies the namespace and name of a
+                  Secret to which any connection details for this managed resource should
+                  be written. Connection details frequently include the endpoint, username,
+                  and password required to connect to the managed resource.
+                  This field is planned to be replaced in a future release in favor of
+                  PublishConnectionDetailsTo. Currently, both could be set independently
+                  and connection details would be published to both without affecting
+                  each other.
                 properties:
                   name:
                     description: Name of the secret.
@@ -952,13 +988,15 @@ spec:
                   description: A Condition that may apply to a resource.
                   properties:
                     lastTransitionTime:
-                      description: LastTransitionTime is the last time this condition
-                        transitioned from one status to another.
+                      description: |-
+                        LastTransitionTime is the last time this condition transitioned from one
+                        status to another.
                       format: date-time
                       type: string
                     message:
-                      description: A Message containing details about this condition's
-                        last transition from one status to another, if any.
+                      description: |-
+                        A Message containing details about this condition's last transition from
+                        one status to another, if any.
                       type: string
                     reason:
                       description: A Reason for this condition's last transition from
@@ -969,8 +1007,9 @@ spec:
                         False, or Unknown?
                       type: string
                     type:
-                      description: Type of this condition. At most one of each condition
-                        type may apply to a resource at any point in time.
+                      description: |-
+                        Type of this condition. At most one of each condition type may apply to
+                        a resource at any point in time.
                       type: string
                   required:
                   - lastTransitionTime

--- a/crds/minio.crossplane.io_buckets.yaml
+++ b/crds/minio.crossplane.io_buckets.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: buckets.minio.crossplane.io
 spec:
   group: minio.crossplane.io
@@ -44,14 +44,19 @@ spec:
       openAPIV3Schema:
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -59,13 +64,14 @@ spec:
             properties:
               deletionPolicy:
                 default: Delete
-                description: 'DeletionPolicy specifies what will happen to the underlying
-                  external when this managed resource is deleted - either "Delete"
-                  or "Orphan" the external resource. This field is planned to be deprecated
-                  in favor of the ManagementPolicies field in a future release. Currently,
-                  both could be set independently and non-default values would be
-                  honored if the feature flag is enabled. See the design doc for more
-                  information: https://github.com/crossplane/crossplane/blob/499895a25d1a1a0ba1604944ef98ac7a1a71f197/design/design-doc-observe-only-resources.md?plain=1#L223'
+                description: |-
+                  DeletionPolicy specifies what will happen to the underlying external
+                  when this managed resource is deleted - either "Delete" or "Orphan" the
+                  external resource.
+                  This field is planned to be deprecated in favor of the ManagementPolicies
+                  field in a future release. Currently, both could be set independently and
+                  non-default values would be honored if the feature flag is enabled.
+                  See the design doc for more information: https://github.com/crossplane/crossplane/blob/499895a25d1a1a0ba1604944ef98ac7a1a71f197/design/design-doc-observe-only-resources.md?plain=1#L223
                 enum:
                 - Orphan
                 - Delete
@@ -73,42 +79,46 @@ spec:
               forProvider:
                 properties:
                   bucketDeletionPolicy:
-                    description: BucketDeletionPolicy determines how buckets should
-                      be deleted when Bucket is deleted. `DeleteIfEmpty` only deletes
-                      the bucket if the bucket is empty. `DeleteAll` recursively deletes
-                      all objects in the bucket and then removes it. To skip deletion
-                      of the bucket (orphan it) set `spec.deletionPolicy=Orphan`.
+                    description: |-
+                      BucketDeletionPolicy determines how buckets should be deleted when Bucket is deleted.
+                       `DeleteIfEmpty` only deletes the bucket if the bucket is empty.
+                       `DeleteAll` recursively deletes all objects in the bucket and then removes it.
+                      To skip deletion of the bucket (orphan it) set `spec.deletionPolicy=Orphan`.
                     type: string
                   bucketName:
-                    description: BucketName is the name of the bucket to create. Defaults
-                      to `metadata.name` if unset. Cannot be changed after bucket
-                      is created. Name must be acceptable by the S3 protocol, which
-                      follows RFC 1123. Be aware that S3 providers may require a unique
-                      name across the platform or zone.
+                    description: |-
+                      BucketName is the name of the bucket to create.
+                      Defaults to `metadata.name` if unset.
+                      Cannot be changed after bucket is created.
+                      Name must be acceptable by the S3 protocol, which follows RFC 1123.
+                      Be aware that S3 providers may require a unique name across the platform or zone.
                     type: string
                   region:
                     default: us-east-1
-                    description: Region is the name of the region where the bucket
-                      shall be created. The region must be available in the S3 endpoint.
+                    description: |-
+                      Region is the name of the region where the bucket shall be created.
+                      The region must be available in the S3 endpoint.
                       Cannot be changed after bucket is created.
                     type: string
                 type: object
               managementPolicies:
                 default:
                 - '*'
-                description: 'THIS IS A BETA FIELD. It is on by default but can be
-                  opted out through a Crossplane feature flag. ManagementPolicies
-                  specify the array of actions Crossplane is allowed to take on the
-                  managed and external resources. This field is planned to replace
-                  the DeletionPolicy field in a future release. Currently, both could
-                  be set independently and non-default values would be honored if
-                  the feature flag is enabled. If both are custom, the DeletionPolicy
-                  field will be ignored. See the design doc for more information:
-                  https://github.com/crossplane/crossplane/blob/499895a25d1a1a0ba1604944ef98ac7a1a71f197/design/design-doc-observe-only-resources.md?plain=1#L223
-                  and this one: https://github.com/crossplane/crossplane/blob/444267e84783136daa93568b364a5f01228cacbe/design/one-pager-ignore-changes.md'
+                description: |-
+                  THIS IS A BETA FIELD. It is on by default but can be opted out
+                  through a Crossplane feature flag.
+                  ManagementPolicies specify the array of actions Crossplane is allowed to
+                  take on the managed and external resources.
+                  This field is planned to replace the DeletionPolicy field in a future
+                  release. Currently, both could be set independently and non-default
+                  values would be honored if the feature flag is enabled. If both are
+                  custom, the DeletionPolicy field will be ignored.
+                  See the design doc for more information: https://github.com/crossplane/crossplane/blob/499895a25d1a1a0ba1604944ef98ac7a1a71f197/design/design-doc-observe-only-resources.md?plain=1#L223
+                  and this one: https://github.com/crossplane/crossplane/blob/444267e84783136daa93568b364a5f01228cacbe/design/one-pager-ignore-changes.md
                 items:
-                  description: A ManagementAction represents an action that the Crossplane
-                    controllers can take on an external resource.
+                  description: |-
+                    A ManagementAction represents an action that the Crossplane controllers
+                    can take on an external resource.
                   enum:
                   - Observe
                   - Create
@@ -121,9 +131,10 @@ spec:
               providerConfigRef:
                 default:
                   name: default
-                description: ProviderConfigReference specifies how the provider that
-                  will be used to create, observe, update, and delete this managed
-                  resource should be configured.
+                description: |-
+                  ProviderConfigReference specifies how the provider that will be used to
+                  create, observe, update, and delete this managed resource should be
+                  configured.
                 properties:
                   name:
                     description: Name of the referenced object.
@@ -133,21 +144,21 @@ spec:
                     properties:
                       resolution:
                         default: Required
-                        description: Resolution specifies whether resolution of this
-                          reference is required. The default is 'Required', which
-                          means the reconcile will fail if the reference cannot be
-                          resolved. 'Optional' means this reference will be a no-op
-                          if it cannot be resolved.
+                        description: |-
+                          Resolution specifies whether resolution of this reference is required.
+                          The default is 'Required', which means the reconcile will fail if the
+                          reference cannot be resolved. 'Optional' means this reference will be
+                          a no-op if it cannot be resolved.
                         enum:
                         - Required
                         - Optional
                         type: string
                       resolve:
-                        description: Resolve specifies when this reference should
-                          be resolved. The default is 'IfNotPresent', which will attempt
-                          to resolve the reference only when the corresponding field
-                          is not present. Use 'Always' to resolve the reference on
-                          every reconcile.
+                        description: |-
+                          Resolve specifies when this reference should be resolved. The default
+                          is 'IfNotPresent', which will attempt to resolve the reference only when
+                          the corresponding field is not present. Use 'Always' to resolve the
+                          reference on every reconcile.
                         enum:
                         - Always
                         - IfNotPresent
@@ -157,17 +168,19 @@ spec:
                 - name
                 type: object
               publishConnectionDetailsTo:
-                description: PublishConnectionDetailsTo specifies the connection secret
-                  config which contains a name, metadata and a reference to secret
-                  store config to which any connection details for this managed resource
-                  should be written. Connection details frequently include the endpoint,
-                  username, and password required to connect to the managed resource.
+                description: |-
+                  PublishConnectionDetailsTo specifies the connection secret config which
+                  contains a name, metadata and a reference to secret store config to
+                  which any connection details for this managed resource should be written.
+                  Connection details frequently include the endpoint, username,
+                  and password required to connect to the managed resource.
                 properties:
                   configRef:
                     default:
                       name: default
-                    description: SecretStoreConfigRef specifies which secret store
-                      config should be used for this ConnectionSecret.
+                    description: |-
+                      SecretStoreConfigRef specifies which secret store config should be used
+                      for this ConnectionSecret.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -177,21 +190,21 @@ spec:
                         properties:
                           resolution:
                             default: Required
-                            description: Resolution specifies whether resolution of
-                              this reference is required. The default is 'Required',
-                              which means the reconcile will fail if the reference
-                              cannot be resolved. 'Optional' means this reference
-                              will be a no-op if it cannot be resolved.
+                            description: |-
+                              Resolution specifies whether resolution of this reference is required.
+                              The default is 'Required', which means the reconcile will fail if the
+                              reference cannot be resolved. 'Optional' means this reference will be
+                              a no-op if it cannot be resolved.
                             enum:
                             - Required
                             - Optional
                             type: string
                           resolve:
-                            description: Resolve specifies when this reference should
-                              be resolved. The default is 'IfNotPresent', which will
-                              attempt to resolve the reference only when the corresponding
-                              field is not present. Use 'Always' to resolve the reference
-                              on every reconcile.
+                            description: |-
+                              Resolve specifies when this reference should be resolved. The default
+                              is 'IfNotPresent', which will attempt to resolve the reference only when
+                              the corresponding field is not present. Use 'Always' to resolve the
+                              reference on every reconcile.
                             enum:
                             - Always
                             - IfNotPresent
@@ -206,21 +219,22 @@ spec:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Annotations are the annotations to be added to
-                          connection secret. - For Kubernetes secrets, this will be
-                          used as "metadata.annotations". - It is up to Secret Store
-                          implementation for others store types.
+                        description: |-
+                          Annotations are the annotations to be added to connection secret.
+                          - For Kubernetes secrets, this will be used as "metadata.annotations".
+                          - It is up to Secret Store implementation for others store types.
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Labels are the labels/tags to be added to connection
-                          secret. - For Kubernetes secrets, this will be used as "metadata.labels".
-                          - It is up to Secret Store implementation for others store
-                          types.
+                        description: |-
+                          Labels are the labels/tags to be added to connection secret.
+                          - For Kubernetes secrets, this will be used as "metadata.labels".
+                          - It is up to Secret Store implementation for others store types.
                         type: object
                       type:
-                        description: Type is the SecretType for the connection secret.
+                        description: |-
+                          Type is the SecretType for the connection secret.
                           - Only valid for Kubernetes Secret Stores.
                         type: string
                     type: object
@@ -231,14 +245,15 @@ spec:
                 - name
                 type: object
               writeConnectionSecretToRef:
-                description: WriteConnectionSecretToReference specifies the namespace
-                  and name of a Secret to which any connection details for this managed
-                  resource should be written. Connection details frequently include
-                  the endpoint, username, and password required to connect to the
-                  managed resource. This field is planned to be replaced in a future
-                  release in favor of PublishConnectionDetailsTo. Currently, both
-                  could be set independently and connection details would be published
-                  to both without affecting each other.
+                description: |-
+                  WriteConnectionSecretToReference specifies the namespace and name of a
+                  Secret to which any connection details for this managed resource should
+                  be written. Connection details frequently include the endpoint, username,
+                  and password required to connect to the managed resource.
+                  This field is planned to be replaced in a future release in favor of
+                  PublishConnectionDetailsTo. Currently, both could be set independently
+                  and connection details would be published to both without affecting
+                  each other.
                 properties:
                   name:
                     description: Name of the secret.
@@ -265,13 +280,15 @@ spec:
                   description: A Condition that may apply to a resource.
                   properties:
                     lastTransitionTime:
-                      description: LastTransitionTime is the last time this condition
-                        transitioned from one status to another.
+                      description: |-
+                        LastTransitionTime is the last time this condition transitioned from one
+                        status to another.
                       format: date-time
                       type: string
                     message:
-                      description: A Message containing details about this condition's
-                        last transition from one status to another, if any.
+                      description: |-
+                        A Message containing details about this condition's last transition from
+                        one status to another, if any.
                       type: string
                     reason:
                       description: A Reason for this condition's last transition from
@@ -282,8 +299,9 @@ spec:
                         False, or Unknown?
                       type: string
                     type:
-                      description: Type of this condition. At most one of each condition
-                        type may apply to a resource at any point in time.
+                      description: |-
+                        Type of this condition. At most one of each condition type may apply to
+                        a resource at any point in time.
                       type: string
                   required:
                   - lastTransitionTime

--- a/crds/minio.crossplane.io_policies.yaml
+++ b/crds/minio.crossplane.io_policies.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: policies.minio.crossplane.io
 spec:
   group: minio.crossplane.io
@@ -35,14 +35,19 @@ spec:
       openAPIV3Schema:
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -50,13 +55,14 @@ spec:
             properties:
               deletionPolicy:
                 default: Delete
-                description: 'DeletionPolicy specifies what will happen to the underlying
-                  external when this managed resource is deleted - either "Delete"
-                  or "Orphan" the external resource. This field is planned to be deprecated
-                  in favor of the ManagementPolicies field in a future release. Currently,
-                  both could be set independently and non-default values would be
-                  honored if the feature flag is enabled. See the design doc for more
-                  information: https://github.com/crossplane/crossplane/blob/499895a25d1a1a0ba1604944ef98ac7a1a71f197/design/design-doc-observe-only-resources.md?plain=1#L223'
+                description: |-
+                  DeletionPolicy specifies what will happen to the underlying external
+                  when this managed resource is deleted - either "Delete" or "Orphan" the
+                  external resource.
+                  This field is planned to be deprecated in favor of the ManagementPolicies
+                  field in a future release. Currently, both could be set independently and
+                  non-default values would be honored if the feature flag is enabled.
+                  See the design doc for more information: https://github.com/crossplane/crossplane/blob/499895a25d1a1a0ba1604944ef98ac7a1a71f197/design/design-doc-observe-only-resources.md?plain=1#L223
                 enum:
                 - Orphan
                 - Delete
@@ -64,31 +70,35 @@ spec:
               forProvider:
                 properties:
                   allowBucket:
-                    description: AllowBucket will create a simple policy that allows
-                      all operations for the given bucket. Mutually exclusive to `RawPolicy`.
+                    description: |-
+                      AllowBucket will create a simple policy that allows all operations for the given bucket.
+                      Mutually exclusive to `RawPolicy`.
                     type: string
                   rawPolicy:
-                    description: RawPolicy describes a raw S3 policy ad verbatim.
-                      Please consult https://min.io/docs/minio/linux/administration/identity-access-management/policy-based-access-control.html
-                      for more details about the policy. Mutually exclusive to `AllowBucket`.
+                    description: |-
+                      RawPolicy describes a raw S3 policy ad verbatim.
+                      Please consult https://min.io/docs/minio/linux/administration/identity-access-management/policy-based-access-control.html for more details about the policy.
+                      Mutually exclusive to `AllowBucket`.
                     type: string
                 type: object
               managementPolicies:
                 default:
                 - '*'
-                description: 'THIS IS A BETA FIELD. It is on by default but can be
-                  opted out through a Crossplane feature flag. ManagementPolicies
-                  specify the array of actions Crossplane is allowed to take on the
-                  managed and external resources. This field is planned to replace
-                  the DeletionPolicy field in a future release. Currently, both could
-                  be set independently and non-default values would be honored if
-                  the feature flag is enabled. If both are custom, the DeletionPolicy
-                  field will be ignored. See the design doc for more information:
-                  https://github.com/crossplane/crossplane/blob/499895a25d1a1a0ba1604944ef98ac7a1a71f197/design/design-doc-observe-only-resources.md?plain=1#L223
-                  and this one: https://github.com/crossplane/crossplane/blob/444267e84783136daa93568b364a5f01228cacbe/design/one-pager-ignore-changes.md'
+                description: |-
+                  THIS IS A BETA FIELD. It is on by default but can be opted out
+                  through a Crossplane feature flag.
+                  ManagementPolicies specify the array of actions Crossplane is allowed to
+                  take on the managed and external resources.
+                  This field is planned to replace the DeletionPolicy field in a future
+                  release. Currently, both could be set independently and non-default
+                  values would be honored if the feature flag is enabled. If both are
+                  custom, the DeletionPolicy field will be ignored.
+                  See the design doc for more information: https://github.com/crossplane/crossplane/blob/499895a25d1a1a0ba1604944ef98ac7a1a71f197/design/design-doc-observe-only-resources.md?plain=1#L223
+                  and this one: https://github.com/crossplane/crossplane/blob/444267e84783136daa93568b364a5f01228cacbe/design/one-pager-ignore-changes.md
                 items:
-                  description: A ManagementAction represents an action that the Crossplane
-                    controllers can take on an external resource.
+                  description: |-
+                    A ManagementAction represents an action that the Crossplane controllers
+                    can take on an external resource.
                   enum:
                   - Observe
                   - Create
@@ -101,9 +111,10 @@ spec:
               providerConfigRef:
                 default:
                   name: default
-                description: ProviderConfigReference specifies how the provider that
-                  will be used to create, observe, update, and delete this managed
-                  resource should be configured.
+                description: |-
+                  ProviderConfigReference specifies how the provider that will be used to
+                  create, observe, update, and delete this managed resource should be
+                  configured.
                 properties:
                   name:
                     description: Name of the referenced object.
@@ -113,21 +124,21 @@ spec:
                     properties:
                       resolution:
                         default: Required
-                        description: Resolution specifies whether resolution of this
-                          reference is required. The default is 'Required', which
-                          means the reconcile will fail if the reference cannot be
-                          resolved. 'Optional' means this reference will be a no-op
-                          if it cannot be resolved.
+                        description: |-
+                          Resolution specifies whether resolution of this reference is required.
+                          The default is 'Required', which means the reconcile will fail if the
+                          reference cannot be resolved. 'Optional' means this reference will be
+                          a no-op if it cannot be resolved.
                         enum:
                         - Required
                         - Optional
                         type: string
                       resolve:
-                        description: Resolve specifies when this reference should
-                          be resolved. The default is 'IfNotPresent', which will attempt
-                          to resolve the reference only when the corresponding field
-                          is not present. Use 'Always' to resolve the reference on
-                          every reconcile.
+                        description: |-
+                          Resolve specifies when this reference should be resolved. The default
+                          is 'IfNotPresent', which will attempt to resolve the reference only when
+                          the corresponding field is not present. Use 'Always' to resolve the
+                          reference on every reconcile.
                         enum:
                         - Always
                         - IfNotPresent
@@ -137,17 +148,19 @@ spec:
                 - name
                 type: object
               publishConnectionDetailsTo:
-                description: PublishConnectionDetailsTo specifies the connection secret
-                  config which contains a name, metadata and a reference to secret
-                  store config to which any connection details for this managed resource
-                  should be written. Connection details frequently include the endpoint,
-                  username, and password required to connect to the managed resource.
+                description: |-
+                  PublishConnectionDetailsTo specifies the connection secret config which
+                  contains a name, metadata and a reference to secret store config to
+                  which any connection details for this managed resource should be written.
+                  Connection details frequently include the endpoint, username,
+                  and password required to connect to the managed resource.
                 properties:
                   configRef:
                     default:
                       name: default
-                    description: SecretStoreConfigRef specifies which secret store
-                      config should be used for this ConnectionSecret.
+                    description: |-
+                      SecretStoreConfigRef specifies which secret store config should be used
+                      for this ConnectionSecret.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -157,21 +170,21 @@ spec:
                         properties:
                           resolution:
                             default: Required
-                            description: Resolution specifies whether resolution of
-                              this reference is required. The default is 'Required',
-                              which means the reconcile will fail if the reference
-                              cannot be resolved. 'Optional' means this reference
-                              will be a no-op if it cannot be resolved.
+                            description: |-
+                              Resolution specifies whether resolution of this reference is required.
+                              The default is 'Required', which means the reconcile will fail if the
+                              reference cannot be resolved. 'Optional' means this reference will be
+                              a no-op if it cannot be resolved.
                             enum:
                             - Required
                             - Optional
                             type: string
                           resolve:
-                            description: Resolve specifies when this reference should
-                              be resolved. The default is 'IfNotPresent', which will
-                              attempt to resolve the reference only when the corresponding
-                              field is not present. Use 'Always' to resolve the reference
-                              on every reconcile.
+                            description: |-
+                              Resolve specifies when this reference should be resolved. The default
+                              is 'IfNotPresent', which will attempt to resolve the reference only when
+                              the corresponding field is not present. Use 'Always' to resolve the
+                              reference on every reconcile.
                             enum:
                             - Always
                             - IfNotPresent
@@ -186,21 +199,22 @@ spec:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Annotations are the annotations to be added to
-                          connection secret. - For Kubernetes secrets, this will be
-                          used as "metadata.annotations". - It is up to Secret Store
-                          implementation for others store types.
+                        description: |-
+                          Annotations are the annotations to be added to connection secret.
+                          - For Kubernetes secrets, this will be used as "metadata.annotations".
+                          - It is up to Secret Store implementation for others store types.
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Labels are the labels/tags to be added to connection
-                          secret. - For Kubernetes secrets, this will be used as "metadata.labels".
-                          - It is up to Secret Store implementation for others store
-                          types.
+                        description: |-
+                          Labels are the labels/tags to be added to connection secret.
+                          - For Kubernetes secrets, this will be used as "metadata.labels".
+                          - It is up to Secret Store implementation for others store types.
                         type: object
                       type:
-                        description: Type is the SecretType for the connection secret.
+                        description: |-
+                          Type is the SecretType for the connection secret.
                           - Only valid for Kubernetes Secret Stores.
                         type: string
                     type: object
@@ -211,14 +225,15 @@ spec:
                 - name
                 type: object
               writeConnectionSecretToRef:
-                description: WriteConnectionSecretToReference specifies the namespace
-                  and name of a Secret to which any connection details for this managed
-                  resource should be written. Connection details frequently include
-                  the endpoint, username, and password required to connect to the
-                  managed resource. This field is planned to be replaced in a future
-                  release in favor of PublishConnectionDetailsTo. Currently, both
-                  could be set independently and connection details would be published
-                  to both without affecting each other.
+                description: |-
+                  WriteConnectionSecretToReference specifies the namespace and name of a
+                  Secret to which any connection details for this managed resource should
+                  be written. Connection details frequently include the endpoint, username,
+                  and password required to connect to the managed resource.
+                  This field is planned to be replaced in a future release in favor of
+                  PublishConnectionDetailsTo. Currently, both could be set independently
+                  and connection details would be published to both without affecting
+                  each other.
                 properties:
                   name:
                     description: Name of the secret.
@@ -246,13 +261,15 @@ spec:
                   description: A Condition that may apply to a resource.
                   properties:
                     lastTransitionTime:
-                      description: LastTransitionTime is the last time this condition
-                        transitioned from one status to another.
+                      description: |-
+                        LastTransitionTime is the last time this condition transitioned from one
+                        status to another.
                       format: date-time
                       type: string
                     message:
-                      description: A Message containing details about this condition's
-                        last transition from one status to another, if any.
+                      description: |-
+                        A Message containing details about this condition's last transition from
+                        one status to another, if any.
                       type: string
                     reason:
                       description: A Reason for this condition's last transition from
@@ -263,8 +280,9 @@ spec:
                         False, or Unknown?
                       type: string
                     type:
-                      description: Type of this condition. At most one of each condition
-                        type may apply to a resource at any point in time.
+                      description: |-
+                        Type of this condition. At most one of each condition type may apply to
+                        a resource at any point in time.
                       type: string
                   required:
                   - lastTransitionTime

--- a/crds/minio.crossplane.io_users.yaml
+++ b/crds/minio.crossplane.io_users.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: users.minio.crossplane.io
 spec:
   group: minio.crossplane.io
@@ -38,14 +38,19 @@ spec:
       openAPIV3Schema:
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -53,13 +58,14 @@ spec:
             properties:
               deletionPolicy:
                 default: Delete
-                description: 'DeletionPolicy specifies what will happen to the underlying
-                  external when this managed resource is deleted - either "Delete"
-                  or "Orphan" the external resource. This field is planned to be deprecated
-                  in favor of the ManagementPolicies field in a future release. Currently,
-                  both could be set independently and non-default values would be
-                  honored if the feature flag is enabled. See the design doc for more
-                  information: https://github.com/crossplane/crossplane/blob/499895a25d1a1a0ba1604944ef98ac7a1a71f197/design/design-doc-observe-only-resources.md?plain=1#L223'
+                description: |-
+                  DeletionPolicy specifies what will happen to the underlying external
+                  when this managed resource is deleted - either "Delete" or "Orphan" the
+                  external resource.
+                  This field is planned to be deprecated in favor of the ManagementPolicies
+                  field in a future release. Currently, both could be set independently and
+                  non-default values would be honored if the feature flag is enabled.
+                  See the design doc for more information: https://github.com/crossplane/crossplane/blob/499895a25d1a1a0ba1604944ef98ac7a1a71f197/design/design-doc-observe-only-resources.md?plain=1#L223
                 enum:
                 - Orphan
                 - Delete
@@ -67,34 +73,37 @@ spec:
               forProvider:
                 properties:
                   policies:
-                    description: Policies contains a list of policies that should
-                      get assigned to this user. These policies need to be created
-                      seperately by using the policy CRD.
+                    description: |-
+                      Policies contains a list of policies that should get assigned to this user.
+                      These policies need to be created seperately by using the policy CRD.
                     items:
                       type: string
                     type: array
                   userName:
-                    description: UserName is the name of the user to create. Defaults
-                      to `metadata.name` if unset. Cannot be changed after user is
-                      created.
+                    description: |-
+                      UserName is the name of the user to create.
+                      Defaults to `metadata.name` if unset.
+                      Cannot be changed after user is created.
                     type: string
                 type: object
               managementPolicies:
                 default:
                 - '*'
-                description: 'THIS IS A BETA FIELD. It is on by default but can be
-                  opted out through a Crossplane feature flag. ManagementPolicies
-                  specify the array of actions Crossplane is allowed to take on the
-                  managed and external resources. This field is planned to replace
-                  the DeletionPolicy field in a future release. Currently, both could
-                  be set independently and non-default values would be honored if
-                  the feature flag is enabled. If both are custom, the DeletionPolicy
-                  field will be ignored. See the design doc for more information:
-                  https://github.com/crossplane/crossplane/blob/499895a25d1a1a0ba1604944ef98ac7a1a71f197/design/design-doc-observe-only-resources.md?plain=1#L223
-                  and this one: https://github.com/crossplane/crossplane/blob/444267e84783136daa93568b364a5f01228cacbe/design/one-pager-ignore-changes.md'
+                description: |-
+                  THIS IS A BETA FIELD. It is on by default but can be opted out
+                  through a Crossplane feature flag.
+                  ManagementPolicies specify the array of actions Crossplane is allowed to
+                  take on the managed and external resources.
+                  This field is planned to replace the DeletionPolicy field in a future
+                  release. Currently, both could be set independently and non-default
+                  values would be honored if the feature flag is enabled. If both are
+                  custom, the DeletionPolicy field will be ignored.
+                  See the design doc for more information: https://github.com/crossplane/crossplane/blob/499895a25d1a1a0ba1604944ef98ac7a1a71f197/design/design-doc-observe-only-resources.md?plain=1#L223
+                  and this one: https://github.com/crossplane/crossplane/blob/444267e84783136daa93568b364a5f01228cacbe/design/one-pager-ignore-changes.md
                 items:
-                  description: A ManagementAction represents an action that the Crossplane
-                    controllers can take on an external resource.
+                  description: |-
+                    A ManagementAction represents an action that the Crossplane controllers
+                    can take on an external resource.
                   enum:
                   - Observe
                   - Create
@@ -107,9 +116,10 @@ spec:
               providerConfigRef:
                 default:
                   name: default
-                description: ProviderConfigReference specifies how the provider that
-                  will be used to create, observe, update, and delete this managed
-                  resource should be configured.
+                description: |-
+                  ProviderConfigReference specifies how the provider that will be used to
+                  create, observe, update, and delete this managed resource should be
+                  configured.
                 properties:
                   name:
                     description: Name of the referenced object.
@@ -119,21 +129,21 @@ spec:
                     properties:
                       resolution:
                         default: Required
-                        description: Resolution specifies whether resolution of this
-                          reference is required. The default is 'Required', which
-                          means the reconcile will fail if the reference cannot be
-                          resolved. 'Optional' means this reference will be a no-op
-                          if it cannot be resolved.
+                        description: |-
+                          Resolution specifies whether resolution of this reference is required.
+                          The default is 'Required', which means the reconcile will fail if the
+                          reference cannot be resolved. 'Optional' means this reference will be
+                          a no-op if it cannot be resolved.
                         enum:
                         - Required
                         - Optional
                         type: string
                       resolve:
-                        description: Resolve specifies when this reference should
-                          be resolved. The default is 'IfNotPresent', which will attempt
-                          to resolve the reference only when the corresponding field
-                          is not present. Use 'Always' to resolve the reference on
-                          every reconcile.
+                        description: |-
+                          Resolve specifies when this reference should be resolved. The default
+                          is 'IfNotPresent', which will attempt to resolve the reference only when
+                          the corresponding field is not present. Use 'Always' to resolve the
+                          reference on every reconcile.
                         enum:
                         - Always
                         - IfNotPresent
@@ -143,17 +153,19 @@ spec:
                 - name
                 type: object
               publishConnectionDetailsTo:
-                description: PublishConnectionDetailsTo specifies the connection secret
-                  config which contains a name, metadata and a reference to secret
-                  store config to which any connection details for this managed resource
-                  should be written. Connection details frequently include the endpoint,
-                  username, and password required to connect to the managed resource.
+                description: |-
+                  PublishConnectionDetailsTo specifies the connection secret config which
+                  contains a name, metadata and a reference to secret store config to
+                  which any connection details for this managed resource should be written.
+                  Connection details frequently include the endpoint, username,
+                  and password required to connect to the managed resource.
                 properties:
                   configRef:
                     default:
                       name: default
-                    description: SecretStoreConfigRef specifies which secret store
-                      config should be used for this ConnectionSecret.
+                    description: |-
+                      SecretStoreConfigRef specifies which secret store config should be used
+                      for this ConnectionSecret.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -163,21 +175,21 @@ spec:
                         properties:
                           resolution:
                             default: Required
-                            description: Resolution specifies whether resolution of
-                              this reference is required. The default is 'Required',
-                              which means the reconcile will fail if the reference
-                              cannot be resolved. 'Optional' means this reference
-                              will be a no-op if it cannot be resolved.
+                            description: |-
+                              Resolution specifies whether resolution of this reference is required.
+                              The default is 'Required', which means the reconcile will fail if the
+                              reference cannot be resolved. 'Optional' means this reference will be
+                              a no-op if it cannot be resolved.
                             enum:
                             - Required
                             - Optional
                             type: string
                           resolve:
-                            description: Resolve specifies when this reference should
-                              be resolved. The default is 'IfNotPresent', which will
-                              attempt to resolve the reference only when the corresponding
-                              field is not present. Use 'Always' to resolve the reference
-                              on every reconcile.
+                            description: |-
+                              Resolve specifies when this reference should be resolved. The default
+                              is 'IfNotPresent', which will attempt to resolve the reference only when
+                              the corresponding field is not present. Use 'Always' to resolve the
+                              reference on every reconcile.
                             enum:
                             - Always
                             - IfNotPresent
@@ -192,21 +204,22 @@ spec:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Annotations are the annotations to be added to
-                          connection secret. - For Kubernetes secrets, this will be
-                          used as "metadata.annotations". - It is up to Secret Store
-                          implementation for others store types.
+                        description: |-
+                          Annotations are the annotations to be added to connection secret.
+                          - For Kubernetes secrets, this will be used as "metadata.annotations".
+                          - It is up to Secret Store implementation for others store types.
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Labels are the labels/tags to be added to connection
-                          secret. - For Kubernetes secrets, this will be used as "metadata.labels".
-                          - It is up to Secret Store implementation for others store
-                          types.
+                        description: |-
+                          Labels are the labels/tags to be added to connection secret.
+                          - For Kubernetes secrets, this will be used as "metadata.labels".
+                          - It is up to Secret Store implementation for others store types.
                         type: object
                       type:
-                        description: Type is the SecretType for the connection secret.
+                        description: |-
+                          Type is the SecretType for the connection secret.
                           - Only valid for Kubernetes Secret Stores.
                         type: string
                     type: object
@@ -217,14 +230,15 @@ spec:
                 - name
                 type: object
               writeConnectionSecretToRef:
-                description: WriteConnectionSecretToReference specifies the namespace
-                  and name of a Secret to which any connection details for this managed
-                  resource should be written. Connection details frequently include
-                  the endpoint, username, and password required to connect to the
-                  managed resource. This field is planned to be replaced in a future
-                  release in favor of PublishConnectionDetailsTo. Currently, both
-                  could be set independently and connection details would be published
-                  to both without affecting each other.
+                description: |-
+                  WriteConnectionSecretToReference specifies the namespace and name of a
+                  Secret to which any connection details for this managed resource should
+                  be written. Connection details frequently include the endpoint, username,
+                  and password required to connect to the managed resource.
+                  This field is planned to be replaced in a future release in favor of
+                  PublishConnectionDetailsTo. Currently, both could be set independently
+                  and connection details would be published to both without affecting
+                  each other.
                 properties:
                   name:
                     description: Name of the secret.
@@ -259,13 +273,15 @@ spec:
                   description: A Condition that may apply to a resource.
                   properties:
                     lastTransitionTime:
-                      description: LastTransitionTime is the last time this condition
-                        transitioned from one status to another.
+                      description: |-
+                        LastTransitionTime is the last time this condition transitioned from one
+                        status to another.
                       format: date-time
                       type: string
                     message:
-                      description: A Message containing details about this condition's
-                        last transition from one status to another, if any.
+                      description: |-
+                        A Message containing details about this condition's last transition from
+                        one status to another, if any.
                       type: string
                     reason:
                       description: A Reason for this condition's last transition from
@@ -276,8 +292,9 @@ spec:
                         False, or Unknown?
                       type: string
                     type:
-                      description: Type of this condition. At most one of each condition
-                        type may apply to a resource at any point in time.
+                      description: |-
+                        Type of this condition. At most one of each condition type may apply to
+                        a resource at any point in time.
                       type: string
                   required:
                   - lastTransitionTime

--- a/crds/stackgres.io_sgclusters.yaml
+++ b/crds/stackgres.io_sgclusters.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: sgclusters.stackgres.io
 spec:
   group: stackgres.io
@@ -20,14 +20,19 @@ spec:
         description: VSHNPostgreSQL is the API for creating Postgresql clusters.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -38,10 +43,14 @@ spec:
                 description: Cluster custom configurations.
                 properties:
                   backupPath:
-                    description: "**Deprecated**: use instead .spec.configurations.backups[].path
-                      \n The path were the backup is stored. If not set this field
-                      is filled up by the operator. \n When provided will indicate
-                      were the backups and WAL files will be stored."
+                    description: |-
+                      **Deprecated**: use instead .spec.configurations.backups[].path
+
+
+                      The path were the backup is stored. If not set this field is filled up by the operator.
+
+
+                      When provided will indicate were the backups and WAL files will be stored.
                     type: string
                   backups:
                     description: List of backups configurations for this SGCluster
@@ -59,28 +68,29 @@ spec:
                             better than LZ4.'
                           type: string
                         cronSchedule:
-                          description: "Continuous Archiving backups are composed
-                            of periodic *base backups* and all the WAL segments produced
-                            in between those base backups. This parameter specifies
-                            at what time and with what frequency to start performing
-                            a new base backup. \n Use cron syntax (`m h dom mon dow`)
-                            for this parameter, i.e., 5 values separated by spaces:
-                            *  `m`: minute, 0 to 59. *  `h`: hour, 0 to 23. *  `dom`:
-                            day of month, 1 to 31 (recommended not to set it higher
-                            than 28). *  `mon`: month, 1 to 12. *  `dow`: day of week,
-                            0 to 7 (0 and 7 both represent Sunday). \n Also ranges
-                            of values (`start-end`), the symbol `*` (meaning `first-last`)
-                            or even `*/N`, where `N` is a number, meaning \"\"every
-                            `N`, may be used. All times are UTC. It is recommended
-                            to avoid 00:00 as base backup time, to avoid overlapping
-                            with any other external operations happening at this time.
-                            \n If not set, full backups are performed each day at
-                            05:00 UTC."
+                          description: |-
+                            Continuous Archiving backups are composed of periodic *base backups* and all the WAL segments produced in between those base backups. This parameter specifies at what time and with what frequency to start performing a new base backup.
+
+
+                            Use cron syntax (`m h dom mon dow`) for this parameter, i.e., 5 values separated by spaces:
+                            *  `m`: minute, 0 to 59.
+                            *  `h`: hour, 0 to 23.
+                            *  `dom`: day of month, 1 to 31 (recommended not to set it higher than 28).
+                            *  `mon`: month, 1 to 12.
+                            *  `dow`: day of week, 0 to 7 (0 and 7 both represent Sunday).
+
+
+                            Also ranges of values (`start-end`), the symbol `*` (meaning `first-last`) or even `*/N`, where `N` is a number, meaning ""every `N`, may be used. All times are UTC. It is recommended to avoid 00:00 as base backup time, to avoid overlapping with any other external operations happening at this time.
+
+
+                            If not set, full backups are performed each day at 05:00 UTC.
                           type: string
                         path:
-                          description: "The path were the backup is stored. If not
-                            set this field is filled up by the operator. \n When provided
-                            will indicate were the backups and WAL files will be stored."
+                          description: |-
+                            The path were the backup is stored. If not set this field is filled up by the operator.
+
+
+                            When provided will indicate were the backups and WAL files will be stored.
                           type: string
                         performance:
                           description: Configuration that affects the backup network
@@ -115,13 +125,14 @@ spec:
                               type: integer
                           type: object
                         retention:
-                          description: "When an automatic retention policy is defined
-                            to delete old base backups, this parameter specifies the
-                            number of base backups to keep, in a sliding window. \n
-                            Consequently, the time range covered by backups is `periodicity*retention`,
-                            where `periodicity` is the separation between backups
-                            as specified by the `cronSchedule` property. \n Default
-                            is 5."
+                          description: |-
+                            When an automatic retention policy is defined to delete old base backups, this parameter specifies the number of base backups to keep, in a sliding window.
+
+
+                            Consequently, the time range covered by backups is `periodicity*retention`, where `periodicity` is the separation between backups as specified by the `cronSchedule` property.
+
+
+                            Default is 5.
                           type: integer
                         sgObjectStorage:
                           description: Name of the [SGObjectStorage](https://stackgres.io/doc/latest/reference/crd/sgobjectstorage)
@@ -133,20 +144,18 @@ spec:
                       type: object
                     type: array
                   sgBackupConfig:
-                    description: "**Deprecated**: use instead .spec.configurations.backups
-                      with sgObjectStorage. \n Name of the [SGBackupConfig](https://stackgres.io/doc/latest/reference/crd/sgbackupconfig)
-                      to use for the cluster. It defines the backups policy, storage
-                      and retention, among others, applied to the cluster. When not
-                      set, backup configuration will not be used."
+                    description: |-
+                      **Deprecated**: use instead .spec.configurations.backups with sgObjectStorage.
+
+
+                      Name of the [SGBackupConfig](https://stackgres.io/doc/latest/reference/crd/sgbackupconfig) to use for the cluster. It defines the backups policy, storage and retention, among others, applied to the cluster. When not set, backup configuration will not be used.
                     type: string
                   sgPoolingConfig:
-                    description: "Name of the [SGPoolingConfig](https://stackgres.io/doc/latest/reference/crd/sgpoolconfig)
-                      used for this cluster. Each pod contains a sidecar with a connection
-                      pooler (currently: [PgBouncer](https://www.pgbouncer.org/)).
-                      The connection pooler is implemented as a sidecar. \n If not
-                      set, a default configuration will be used. Disabling connection
-                      pooling altogether is possible if the disableConnectionPooling
-                      property of the pods object is set to true."
+                    description: |-
+                      Name of the [SGPoolingConfig](https://stackgres.io/doc/latest/reference/crd/sgpoolconfig) used for this cluster. Each pod contains a sidecar with a connection pooler (currently: [PgBouncer](https://www.pgbouncer.org/)). The connection pooler is implemented as a sidecar.
+
+
+                      If not set, a default configuration will be used. Disabling connection pooling altogether is possible if the disableConnectionPooling property of the pods object is set to true.
                     type: string
                   sgPostgresConfig:
                     description: Name of the [SGPostgresConfig](https://stackgres.io/doc/latest/reference/crd/sgpgconfig)
@@ -163,17 +172,15 @@ spec:
                   send to the pod's standard output.
                 properties:
                   retention:
-                    description: "Define a retention window with the syntax `<integer>
-                      (minutes|hours|days|months)` in which log entries are kept.
-                      Log entries will be removed when they get older more than the
-                      double of the specified retention window. \n When this field
-                      is changed the retention will be applied only to log entries
-                      that are newer than the end of the retention window previously
-                      specified. If no retention window was previously specified it
-                      is considered to be of 7 days. This means that if previous retention
-                      window is of `7 days` new retention configuration will apply
-                      after UTC timestamp calculated with: `SELECT date_trunc('days',
-                      now() at time zone 'UTC') - INTERVAL '7 days'`."
+                    description: |-
+                      Define a retention window with the syntax `<integer> (minutes|hours|days|months)` in which log entries are kept.
+                       Log entries will be removed when they get older more than the double of the specified retention window.
+
+
+                      When this field is changed the retention will be applied only to log entries that are newer than the end of
+                       the retention window previously specified. If no retention window was previously specified it is considered
+                       to be of 7 days. This means that if previous retention window is of `7 days` new retention configuration will
+                       apply after UTC timestamp calculated with: `SELECT date_trunc('days', now() at time zone 'UTC') - INTERVAL '7 days'`.
                     type: string
                   sgDistributedLogs:
                     description: Name of the [SGDistributedLogs](https://stackgres.io/doc/latest/04-postgres-cluster-management/06-distributed-logs/)
@@ -190,10 +197,11 @@ spec:
                       SGClusterSpecInitialDataRestore.
                     properties:
                       downloadDiskConcurrency:
-                        description: "The backup fetch process may fetch several streams
-                          in parallel. Parallel fetching is enabled when set to a
-                          value larger than one. \n If not specified it will be interpreted
-                          as latest."
+                        description: |-
+                          The backup fetch process may fetch several streams in parallel. Parallel fetching is enabled when set to a value larger than one.
+
+
+                          If not specified it will be interpreted as latest.
                         type: integer
                       fromBackup:
                         description: From which backup to restore and how the process
@@ -206,16 +214,14 @@ spec:
                               The selected backup must be in the same namespace.
                             type: string
                           pointInTimeRecovery:
-                            description: "It is possible to restore the database to
-                              its state at any time since your backup was taken using
-                              Point-in-Time Recovery (PITR) as long as another backup
-                              newer than the PITR requested restoration date does
-                              not exists. \n Point In Time Recovery (PITR). PITR allow
-                              to restore the database state to an arbitrary point
-                              of time in the past, as long as you specify a backup
-                              older than the PITR requested restoration date and does
-                              not exists a backup newer than the same restoration
-                              date. \n See also: https://www.postgresql.org/docs/current/continuous-archiving.html"
+                            description: |-
+                              It is possible to restore the database to its state at any time since your backup was taken using Point-in-Time Recovery (PITR) as long as another backup newer than the PITR requested restoration date does not exists.
+
+
+                              Point In Time Recovery (PITR). PITR allow to restore the database state to an arbitrary point of time in the past, as long as you specify a backup older than the PITR requested restoration date and does not exists a backup newer than the same restoration date.
+
+
+                              See also: https://www.postgresql.org/docs/current/continuous-archiving.html
                             properties:
                               restoreToTimestamp:
                                 description: An ISO 8601 date, that holds UTC date
@@ -224,24 +230,19 @@ spec:
                                 type: string
                             type: object
                           target:
-                            description: "Specify the [recovery_target](https://postgresqlco.nf/doc/en/param/recovery_target/)
-                              that specifies that recovery should end as soon as a
-                              consistent state is reached, i.e., as early as possible.
-                              When restoring from an online backup, this means the
-                              point where taking the backup ended. \n Technically,
-                              this is a string parameter, but 'immediate' is currently
-                              the only allowed value."
+                            description: |-
+                              Specify the [recovery_target](https://postgresqlco.nf/doc/en/param/recovery_target/) that specifies that recovery should end as soon as a consistent
+                               state is reached, i.e., as early as possible. When restoring from an online backup, this means the point where taking the backup ended.
+
+
+                              Technically, this is a string parameter, but 'immediate' is currently the only allowed value.
                             type: string
                           targetTimeline:
-                            description: Specify the [recovery_target_timeline](https://postgresqlco.nf/doc/en/param/recovery_target_timeline/)
-                              to recover into a particular timeline. The default is
-                              to recover along the same timeline that was current
-                              when the base backup was taken. Setting this to latest
-                              recovers to the latest timeline found in the archive,
-                              which is useful in a standby server. Other than that
-                              you only need to set this parameter in complex re-recovery
-                              situations, where you need to return to a state that
-                              itself was reached after a point-in-time recovery.
+                            description: |-
+                              Specify the [recovery_target_timeline](https://postgresqlco.nf/doc/en/param/recovery_target_timeline/) to recover into a particular timeline.
+                               The default is to recover along the same timeline that was current when the base backup was taken. Setting this to latest recovers to the latest
+                               timeline found in the archive, which is useful in a standby server. Other than that you only need to set this parameter in complex re-recovery
+                               situations, where you need to return to a state that itself was reached after a point-in-time recovery.
                             type: string
                           uid:
                             description: When set to the UID of an existing [SGBackup](https://stackgres.io/doc/latest/reference/crd/sgbackup),
@@ -252,10 +253,11 @@ spec:
                         type: object
                     type: object
                   scripts:
-                    description: "**Deprecated** use instead .spec.managedSql with
-                      SGScript. \n A list of SQL scripts executed in sequence, exactly
-                      once, when the database is bootstrap and/or after restore is
-                      completed."
+                    description: |-
+                      **Deprecated** use instead .spec.managedSql with SGScript.
+
+
+                      A list of SQL scripts executed in sequence, exactly once, when the database is bootstrap and/or after restore is completed.
                     items:
                       description: SGClusterSpecInitialDataScriptsItem defines model
                         for SGClusterSpecInitialDataScriptsItem.
@@ -273,12 +275,11 @@ spec:
                             exclusive with `scriptFrom` field.
                           type: string
                         scriptFrom:
-                          description: "Reference to either a Kubernetes [Secret](https://kubernetes.io/docs/concepts/configuration/secret/)
-                            or a [ConfigMap](https://kubernetes.io/docs/concepts/configuration/configmap/)
-                            that contains the SQL script to execute. This field is
-                            mutually exclusive with `script` field. \n Fields `secretKeyRef`
-                            and `configMapKeyRef` are mutually exclusive, and one
-                            of them is required."
+                          description: |-
+                            Reference to either a Kubernetes [Secret](https://kubernetes.io/docs/concepts/configuration/secret/) or a [ConfigMap](https://kubernetes.io/docs/concepts/configuration/configmap/) that contains the SQL script to execute. This field is mutually exclusive with `script` field.
+
+
+                            Fields `secretKeyRef` and `configMapKeyRef` are mutually exclusive, and one of them is required.
                           properties:
                             configMapKeyRef:
                               description: A [ConfigMap](https://kubernetes.io/docs/concepts/configuration/configmap/)
@@ -313,9 +314,9 @@ spec:
                     type: array
                 type: object
               instances:
-                description: Number of StackGres instances for the cluster. Each instance
-                  contains one Postgres server. Out of all of the Postgres servers,
-                  one is elected as the primary, the rest remain as read-only replicas.
+                description: |-
+                  Number of StackGres instances for the cluster. Each instance contains one Postgres server.
+                   Out of all of the Postgres servers, one is elected as the primary, the rest remain as read-only replicas.
                 type: integer
               managedSql:
                 description: This section allows to reference SQL scripts that will
@@ -398,92 +399,69 @@ spec:
                 description: SGClusterSpecNonProductionOptions defines model for SGClusterSpecNonProductionOptions.
                 properties:
                   disableClusterPodAntiAffinity:
-                    description: "It is a best practice, on non-containerized environments,
-                      when running production workloads, to run each database server
-                      on a different server (virtual or physical), i.e., not to co-locate
-                      more than one database server per host. \n The same best practice
-                      applies to databases on containers. By default, StackGres will
-                      not allow to run more than one StackGres pod on a given Kubernetes
-                      node. Set this property to true to allow more than one StackGres
-                      pod per node."
+                    description: |-
+                      It is a best practice, on non-containerized environments, when running production workloads, to run each database server on a different server (virtual or physical), i.e., not to co-locate more than one database server per host.
+
+
+                      The same best practice applies to databases on containers. By default, StackGres will not allow to run more than one StackGres pod on a given Kubernetes node. Set this property to true to allow more than one StackGres pod per node.
                     type: boolean
                   disableClusterResourceRequirements:
-                    description: "It is a best practice, on containerized environments,
-                      when running production workloads, to enforce container's resources
-                      requirements. \n By default, StackGres will configure resource
-                      requirements for all the containers. Set this property to true
-                      to prevent StackGres from setting container's resources requirements
-                      (except for patroni container, see `disablePatroniResourceRequirements`)."
+                    description: |-
+                      It is a best practice, on containerized environments, when running production workloads, to enforce container's resources requirements.
+
+
+                      By default, StackGres will configure resource requirements for all the containers. Set this property to true to prevent StackGres from setting container's resources requirements (except for patroni container, see `disablePatroniResourceRequirements`).
                     type: boolean
                   disablePatroniResourceRequirements:
-                    description: "It is a best practice, on containerized environments,
-                      when running production workloads, to enforce container's resources
-                      requirements. \n The same best practice applies to databases
-                      on containers. By default, StackGres will configure resource
-                      requirements for patroni container. Set this property to true
-                      to prevent StackGres from setting patroni container's resources
-                      requirement."
+                    description: |-
+                      It is a best practice, on containerized environments, when running production workloads, to enforce container's resources requirements.
+
+
+                      The same best practice applies to databases on containers. By default, StackGres will configure resource requirements for patroni container. Set this property to true to prevent StackGres from setting patroni container's resources requirement.
                     type: boolean
                   enableSetClusterCpuRequests:
-                    description: "On containerized environments, when running production
-                      workloads, enforcing container's cpu requirements request to
-                      be equals to the limit allow to achieve the highest level of
-                      performance. Doing so, reduces the chances of leaving the workload
-                      with less cpu than it requires. It also allow to set [static
-                      CPU management policy](https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/#static-policy)
-                      that allows to guarantee a pod the usage exclusive CPUs on the
-                      node. \n By default, StackGres will configure cpu requirements
-                      to have the same limit and request for all the containers. Set
-                      this property to true to prevent StackGres from setting container's
-                      cpu requirements request equals to the limit (except for patroni
-                      container, see `enablePatroniCpuRequests`) when `.spec.requests.containers.<container
-                      name>.cpu` `.spec.requests.initContainers.<container name>.cpu`
-                      is configured in the referenced `SGInstanceProfile`."
+                    description: |-
+                      On containerized environments, when running production workloads, enforcing container's cpu requirements request to be equals to the limit allow to achieve the highest level of performance. Doing so, reduces the chances of leaving
+                       the workload with less cpu than it requires. It also allow to set [static CPU management policy](https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/#static-policy) that allows to guarantee a pod the usage exclusive CPUs on the node.
+
+
+                      By default, StackGres will configure cpu requirements to have the same limit and request for all the containers. Set this property to true to prevent StackGres from setting container's cpu requirements request equals to the limit (except for patroni container, see `enablePatroniCpuRequests`)
+                       when `.spec.requests.containers.<container name>.cpu` `.spec.requests.initContainers.<container name>.cpu` is configured in the referenced `SGInstanceProfile`.
                     type: boolean
                   enableSetClusterMemoryRequests:
-                    description: "On containerized environments, when running production
-                      workloads, enforcing container's memory requirements request
-                      to be equals to the limit allow to achieve the highest level
-                      of performance. Doing so, reduces the chances of leaving the
-                      workload with less memory than it requires. \n By default, StackGres
-                      will configure memory requirements to have the same limit and
-                      request for all the containers. Set this property to true to
-                      prevent StackGres from setting container's memory requirements
-                      request equals to the limit (except for patroni container, see
-                      `enablePatroniCpuRequests`) when `.spec.requests.containers.<container
-                      name>.memory` `.spec.requests.initContainers.<container name>.memory`
-                      is configured in the referenced `SGInstanceProfile`."
+                    description: |-
+                      On containerized environments, when running production workloads, enforcing container's memory requirements request to be equals to the limit allow to achieve the highest level of performance. Doing so, reduces the chances of leaving
+                       the workload with less memory than it requires.
+
+
+                      By default, StackGres will configure memory requirements to have the same limit and request for all the containers. Set this property to true to prevent StackGres from setting container's memory requirements request equals to the limit (except for patroni container, see `enablePatroniCpuRequests`)
+                       when `.spec.requests.containers.<container name>.memory` `.spec.requests.initContainers.<container name>.memory` is configured in the referenced `SGInstanceProfile`.
                     type: boolean
                   enableSetPatroniCpuRequests:
-                    description: "On containerized environments, when running production
-                      workloads, enforcing container's cpu requirements request to
-                      be equals to the limit allow to achieve the highest level of
-                      performance. Doing so, reduces the chances of leaving the workload
-                      with less cpu than it requires. It also allow to set [static
-                      CPU management policy](https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/#static-policy)
-                      that allows to guarantee a pod the usage exclusive CPUs on the
-                      node. \n By default, StackGres will configure cpu requirements
-                      to have the same limit and request for the patroni container.
-                      Set this property to true to prevent StackGres from setting
-                      patroni container's cpu requirements request equals to the limit
-                      when `.spec.requests.cpu` is configured in the referenced `SGInstanceProfile`."
+                    description: |-
+                      On containerized environments, when running production workloads, enforcing container's cpu requirements request to be equals to the limit allow to achieve the highest level of performance. Doing so, reduces the chances of leaving
+                       the workload with less cpu than it requires. It also allow to set [static CPU management policy](https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/#static-policy) that allows to guarantee a pod the usage exclusive CPUs on the node.
+
+
+                      By default, StackGres will configure cpu requirements to have the same limit and request for the patroni container. Set this property to true to prevent StackGres from setting patroni container's cpu requirements request equals to the limit
+                       when `.spec.requests.cpu` is configured in the referenced `SGInstanceProfile`.
                     type: boolean
                   enableSetPatroniMemoryRequests:
-                    description: "On containerized environments, when running production
-                      workloads, enforcing container's memory requirements request
-                      to be equals to the limit allow to achieve the highest level
-                      of performance. Doing so, reduces the chances of leaving the
-                      workload with less memory than it requires. \n By default, StackGres
-                      will configure memory requirements to have the same limit and
-                      request for the patroni container. Set this property to true
-                      to prevent StackGres from setting patroni container's memory
-                      requirements request equals to the limit when `.spec.requests.memory`
-                      is configured in the referenced `SGInstanceProfile`."
+                    description: |-
+                      On containerized environments, when running production workloads, enforcing container's memory requirements request to be equals to the limit allow to achieve the highest level of performance. Doing so, reduces the chances of leaving
+                       the workload with less memory than it requires.
+
+
+                      By default, StackGres will configure memory requirements to have the same limit and request for the patroni container. Set this property to true to prevent StackGres from setting patroni container's memory requirements request equals to the limit
+                       when `.spec.requests.memory` is configured in the referenced `SGInstanceProfile`.
                     type: boolean
                   enabledFeatureGates:
-                    description: "A list of StackGres feature gates to enable (not
-                      suitable for a production environment). \n Available feature
-                      gates are: * `babelfish-flavor`: Allow to use `babelfish` flavor."
+                    description: |-
+                      A list of StackGres feature gates to enable (not suitable for a production environment).
+
+
+                      Available feature gates are:
+                      * `babelfish-flavor`: Allow to use `babelfish` flavor.
                     items:
                       type: string
                     type: array
@@ -492,12 +470,16 @@ spec:
                 description: Cluster pod's configuration.
                 properties:
                   customContainers:
-                    description: "A list of custom application containers that run
-                      within the cluster's Pods. \n The name used in this section
-                      will be prefixed with the string `custom-` so that when referencing
-                      them in the .spec.containers section of SGInstanceProfile the
-                      name used have to be prepended with the same prefix. \n See:
-                      https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#container-v1-core"
+                    description: |-
+                      A list of custom application containers that run within the cluster's Pods.
+
+
+                      The name used in this section will be prefixed with the string `custom-` so that when
+                       referencing them in the .spec.containers section of SGInstanceProfile the name used
+                       have to be prepended with the same prefix.
+
+
+                      See: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#container-v1-core
                     items:
                       description: SGClusterSpecPodsCustomContainersItem defines model
                         for SGClusterSpecPodsCustomContainersItem.
@@ -601,61 +583,47 @@ spec:
                                           volumes, optional for env vars'
                                         type: string
                                       divisor:
-                                        description: "Quantity is a fixed-point representation
-                                          of a number. It provides convenient marshaling/unmarshaling
-                                          in JSON and YAML, in addition to String()
-                                          and AsInt64() accessors. \n The serialization
-                                          format is: \n <quantity>        ::= <signedNumber><suffix>
-                                          (Note that <suffix> may be empty, from the
-                                          \"\" case in <decimalSI>.) <digit>           ::=
-                                          0 | 1 | ... | 9 <digits>          ::= <digit>
-                                          | <digit><digits> <number>          ::=
-                                          <digits> | <digits>.<digits> | <digits>.
-                                          | .<digits> <sign>            ::= \"+\"
-                                          | \"-\" <signedNumber>    ::= <number> |
-                                          <sign><number> <suffix>          ::= <binarySI>
-                                          | <decimalExponent> | <decimalSI> <binarySI>
-                                          \       ::= Ki | Mi | Gi | Ti | Pi | Ei
-                                          (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)
-                                          <decimalSI>       ::= m | \"\" | k | M |
-                                          G | T | P | E (Note that 1024 = 1Ki but
-                                          1000 = 1k; I didn't choose the capitalization.)
-                                          <decimalExponent> ::= \"e\" <signedNumber>
-                                          | \"E\" <signedNumber> \n No matter which
-                                          of the three exponent forms is used, no
-                                          quantity may represent a number greater
-                                          than 2^63-1 in magnitude, nor may it have
-                                          more than 3 decimal places. Numbers larger
-                                          or more precise will be capped or rounded
-                                          up. (E.g.: 0.1m will rounded up to 1m.)
-                                          This may be extended in the future if we
-                                          require larger or smaller quantities. \n
-                                          When a Quantity is parsed from a string,
-                                          it will remember the type of suffix it had,
-                                          and will use the same type again when it
-                                          is serialized. \n Before serializing, Quantity
-                                          will be put in \"canonical form\". This
-                                          means that Exponent/suffix will be adjusted
-                                          up or down (with a corresponding increase
-                                          or decrease in Mantissa) such that: a. No
-                                          precision is lost b. No fractional digits
-                                          will be emitted c. The exponent (or suffix)
-                                          is as large as possible. The sign will be
-                                          omitted unless the number is negative. \n
-                                          Examples: 1.5 will be serialized as \"1500m\"
-                                          1.5Gi will be serialized as \"1536Mi\" \n
-                                          Note that the quantity will NEVER be internally
-                                          represented by a floating point number.
-                                          That is the whole point of this exercise.
-                                          \n Non-canonical values will still parse
-                                          as long as they are well formed, but will
-                                          be re-emitted in their canonical form. (So
-                                          always use canonical form, or don't diff.)
-                                          \n This format is intended to make it difficult
-                                          to use these numbers without writing some
-                                          sort of special handling code in the hopes
-                                          that that will cause implementors to also
-                                          use a fixed point implementation."
+                                        description: |-
+                                          Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.
+
+
+                                          The serialization format is:
+
+
+                                          <quantity>        ::= <signedNumber><suffix>
+                                            (Note that <suffix> may be empty, from the "" case in <decimalSI>.)
+                                          <digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= "+" | "-" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei
+                                            (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)
+                                          <decimalSI>       ::= m | "" | k | M | G | T | P | E
+                                            (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)
+                                          <decimalExponent> ::= "e" <signedNumber> | "E" <signedNumber>
+
+
+                                          No matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.
+
+
+                                          When a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.
+
+
+                                          Before serializing, Quantity will be put in "canonical form". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:
+                                            a. No precision is lost
+                                            b. No fractional digits will be emitted
+                                            c. The exponent (or suffix) is as large as possible.
+                                          The sign will be omitted unless the number is negative.
+
+
+                                          Examples:
+                                            1.5 will be serialized as "1500m"
+                                            1.5Gi will be serialized as "1536Mi"
+
+
+                                          Note that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.
+
+
+                                          Non-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)
+
+
+                                          This format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.
                                         type: string
                                       resource:
                                         description: 'Required: resource to select'
@@ -700,10 +668,11 @@ spec:
                               defines model for SGClusterSpecPodsCustomContainersItemEnvFromItem.
                             properties:
                               configMapRef:
-                                description: "ConfigMapEnvSource selects a ConfigMap
-                                  to populate the environment variables with. \n The
-                                  contents of the target ConfigMap's Data field will
-                                  represent the key-value pairs as environment variables."
+                                description: |-
+                                  ConfigMapEnvSource selects a ConfigMap to populate the environment variables with.
+
+
+                                  The contents of the target ConfigMap's Data field will represent the key-value pairs as environment variables.
                                 properties:
                                   name:
                                     description: 'Name of the referent. More info:
@@ -719,10 +688,11 @@ spec:
                                   each key in the ConfigMap. Must be a C_IDENTIFIER.
                                 type: string
                               secretRef:
-                                description: "SecretEnvSource selects a Secret to
-                                  populate the environment variables with. \n The
-                                  contents of the target Secret's Data field will
-                                  represent the key-value pairs as environment variables."
+                                description: |-
+                                  SecretEnvSource selects a Secret to populate the environment variables with.
+
+
+                                  The contents of the target Secret's Data field will represent the key-value pairs as environment variables.
                                 properties:
                                   name:
                                     description: 'Name of the referent. More info:
@@ -1066,12 +1036,15 @@ spec:
                               type: integer
                           type: object
                         name:
-                          description: "Name of the container specified as a DNS_LABEL.
-                            Each container in a pod must have a unique name (DNS_LABEL).
-                            Cannot be updated. \n The name will be prefixed with the
-                            string `custom-` so that when referencing it in the .spec.containers
-                            section of SGInstanceProfile the name used have to be
-                            prepended with the same prefix."
+                          description: |-
+                            Name of the container specified as a DNS_LABEL. Each
+                             container in a pod must have a unique name (DNS_LABEL). Cannot
+                             be updated.
+
+
+                            The name will be prefixed with the string `custom-` so that when referencing it
+                             in the .spec.containers section of SGInstanceProfile the name used have to be
+                             prepended with the same prefix.
                           type: string
                         ports:
                           description: List of ports to expose from the container.
@@ -1380,12 +1353,11 @@ spec:
                                     Must only be set if type is "Localhost".
                                   type: string
                                 type:
-                                  description: "type indicates which kind of seccomp
-                                    profile will be applied. Valid options are: \n
-                                    Localhost - a profile defined in a file on the
-                                    node should be used. RuntimeDefault - the container
-                                    runtime default profile should be used. Unconfined
-                                    - no profile should be applied."
+                                  description: |-
+                                    type indicates which kind of seccomp profile will be applied. Valid options are:
+
+
+                                    Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
                                   type: string
                               required:
                               - type
@@ -1679,13 +1651,18 @@ spec:
                       type: object
                     type: array
                   customInitContainers:
-                    description: "A list of custom application init containers that
-                      run within the cluster's Pods. The custom init containers will
-                      run following the defined sequence as the end of cluster's Pods
-                      init containers. \n The name used in this section will be prefixed
-                      with the string `custom-` so that when referencing them in the
-                      .spec.containers section of SGInstanceProfile the name used
-                      have to be prepended with the same prefix. \n See: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#container-v1-core"
+                    description: |-
+                      A list of custom application init containers that run within the cluster's Pods. The
+                       custom init containers will run following the defined sequence as the end of
+                       cluster's Pods init containers.
+
+
+                      The name used in this section will be prefixed with the string `custom-` so that when
+                       referencing them in the .spec.containers section of SGInstanceProfile the name used
+                       have to be prepended with the same prefix.
+
+
+                      See: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#container-v1-core
                     items:
                       description: SGClusterSpecPodsCustomInitContainersItem defines
                         model for SGClusterSpecPodsCustomInitContainersItem.
@@ -1789,61 +1766,47 @@ spec:
                                           volumes, optional for env vars'
                                         type: string
                                       divisor:
-                                        description: "Quantity is a fixed-point representation
-                                          of a number. It provides convenient marshaling/unmarshaling
-                                          in JSON and YAML, in addition to String()
-                                          and AsInt64() accessors. \n The serialization
-                                          format is: \n <quantity>        ::= <signedNumber><suffix>
-                                          (Note that <suffix> may be empty, from the
-                                          \"\" case in <decimalSI>.) <digit>           ::=
-                                          0 | 1 | ... | 9 <digits>          ::= <digit>
-                                          | <digit><digits> <number>          ::=
-                                          <digits> | <digits>.<digits> | <digits>.
-                                          | .<digits> <sign>            ::= \"+\"
-                                          | \"-\" <signedNumber>    ::= <number> |
-                                          <sign><number> <suffix>          ::= <binarySI>
-                                          | <decimalExponent> | <decimalSI> <binarySI>
-                                          \       ::= Ki | Mi | Gi | Ti | Pi | Ei
-                                          (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)
-                                          <decimalSI>       ::= m | \"\" | k | M |
-                                          G | T | P | E (Note that 1024 = 1Ki but
-                                          1000 = 1k; I didn't choose the capitalization.)
-                                          <decimalExponent> ::= \"e\" <signedNumber>
-                                          | \"E\" <signedNumber> \n No matter which
-                                          of the three exponent forms is used, no
-                                          quantity may represent a number greater
-                                          than 2^63-1 in magnitude, nor may it have
-                                          more than 3 decimal places. Numbers larger
-                                          or more precise will be capped or rounded
-                                          up. (E.g.: 0.1m will rounded up to 1m.)
-                                          This may be extended in the future if we
-                                          require larger or smaller quantities. \n
-                                          When a Quantity is parsed from a string,
-                                          it will remember the type of suffix it had,
-                                          and will use the same type again when it
-                                          is serialized. \n Before serializing, Quantity
-                                          will be put in \"canonical form\". This
-                                          means that Exponent/suffix will be adjusted
-                                          up or down (with a corresponding increase
-                                          or decrease in Mantissa) such that: a. No
-                                          precision is lost b. No fractional digits
-                                          will be emitted c. The exponent (or suffix)
-                                          is as large as possible. The sign will be
-                                          omitted unless the number is negative. \n
-                                          Examples: 1.5 will be serialized as \"1500m\"
-                                          1.5Gi will be serialized as \"1536Mi\" \n
-                                          Note that the quantity will NEVER be internally
-                                          represented by a floating point number.
-                                          That is the whole point of this exercise.
-                                          \n Non-canonical values will still parse
-                                          as long as they are well formed, but will
-                                          be re-emitted in their canonical form. (So
-                                          always use canonical form, or don't diff.)
-                                          \n This format is intended to make it difficult
-                                          to use these numbers without writing some
-                                          sort of special handling code in the hopes
-                                          that that will cause implementors to also
-                                          use a fixed point implementation."
+                                        description: |-
+                                          Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.
+
+
+                                          The serialization format is:
+
+
+                                          <quantity>        ::= <signedNumber><suffix>
+                                            (Note that <suffix> may be empty, from the "" case in <decimalSI>.)
+                                          <digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= "+" | "-" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei
+                                            (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)
+                                          <decimalSI>       ::= m | "" | k | M | G | T | P | E
+                                            (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)
+                                          <decimalExponent> ::= "e" <signedNumber> | "E" <signedNumber>
+
+
+                                          No matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.
+
+
+                                          When a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.
+
+
+                                          Before serializing, Quantity will be put in "canonical form". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:
+                                            a. No precision is lost
+                                            b. No fractional digits will be emitted
+                                            c. The exponent (or suffix) is as large as possible.
+                                          The sign will be omitted unless the number is negative.
+
+
+                                          Examples:
+                                            1.5 will be serialized as "1500m"
+                                            1.5Gi will be serialized as "1536Mi"
+
+
+                                          Note that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.
+
+
+                                          Non-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)
+
+
+                                          This format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.
                                         type: string
                                       resource:
                                         description: 'Required: resource to select'
@@ -1888,10 +1851,11 @@ spec:
                               defines model for SGClusterSpecPodsCustomInitContainersItemEnvFromItem.
                             properties:
                               configMapRef:
-                                description: "ConfigMapEnvSource selects a ConfigMap
-                                  to populate the environment variables with. \n The
-                                  contents of the target ConfigMap's Data field will
-                                  represent the key-value pairs as environment variables."
+                                description: |-
+                                  ConfigMapEnvSource selects a ConfigMap to populate the environment variables with.
+
+
+                                  The contents of the target ConfigMap's Data field will represent the key-value pairs as environment variables.
                                 properties:
                                   name:
                                     description: 'Name of the referent. More info:
@@ -1907,10 +1871,11 @@ spec:
                                   each key in the ConfigMap. Must be a C_IDENTIFIER.
                                 type: string
                               secretRef:
-                                description: "SecretEnvSource selects a Secret to
-                                  populate the environment variables with. \n The
-                                  contents of the target Secret's Data field will
-                                  represent the key-value pairs as environment variables."
+                                description: |-
+                                  SecretEnvSource selects a Secret to populate the environment variables with.
+
+
+                                  The contents of the target Secret's Data field will represent the key-value pairs as environment variables.
                                 properties:
                                   name:
                                     description: 'Name of the referent. More info:
@@ -2254,12 +2219,15 @@ spec:
                               type: integer
                           type: object
                         name:
-                          description: "Name of the container specified as a DNS_LABEL.
-                            Each container in a pod must have a unique name (DNS_LABEL).
-                            Cannot be updated. \n The name will be prefixed with the
-                            string `custom-` so that when referencing it in the .spec.containers
-                            section of SGInstanceProfile the name used have to be
-                            prepended with the same prefix."
+                          description: |-
+                            Name of the container specified as a DNS_LABEL. Each
+                             container in a pod must have a unique name (DNS_LABEL). Cannot
+                             be updated.
+
+
+                            The name will be prefixed with the string `custom-` so that when referencing it
+                             in the .spec.containers section of SGInstanceProfile the name used have to be
+                             prepended with the same prefix.
                           type: string
                         ports:
                           description: List of ports to expose from the container.
@@ -2568,12 +2536,11 @@ spec:
                                     Must only be set if type is "Localhost".
                                   type: string
                                 type:
-                                  description: "type indicates which kind of seccomp
-                                    profile will be applied. Valid options are: \n
-                                    Localhost - a profile defined in a file on the
-                                    node should be used. RuntimeDefault - the container
-                                    runtime default profile should be used. Unconfined
-                                    - no profile should be applied."
+                                  description: |-
+                                    type indicates which kind of seccomp profile will be applied. Valid options are:
+
+
+                                    Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
                                   type: string
                               required:
                               - type
@@ -2867,26 +2834,31 @@ spec:
                       type: object
                     type: array
                   customVolumes:
-                    description: "A list of custom volumes that may be used along
-                      with any container defined in customInitContainers or customContainers
-                      sections. \n The name used in this section will be prefixed
-                      with the string `custom-` so that when referencing them in the
-                      customInitContainers or customContainers sections the name used
-                      have to be prepended with the same prefix. \n Only the following
-                      volume types are allowed: configMap, downwardAPI, emptyDir,
-                      gitRepo, glusterfs, hostPath, nfs, projected and secret \n See:
-                      https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#volume-v1-core"
+                    description: |-
+                      A list of custom volumes that may be used along with any container defined in
+                       customInitContainers or customContainers sections.
+
+
+                      The name used in this section will be prefixed with the string `custom-` so that when
+                       referencing them in the customInitContainers or customContainers sections the name used
+                       have to be prepended with the same prefix.
+
+
+                      Only the following volume types are allowed: configMap, downwardAPI, emptyDir,
+                       gitRepo, glusterfs, hostPath, nfs, projected and secret
+
+
+                      See: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#volume-v1-core
                     items:
                       description: SGClusterSpecPodsCustomVolumesItem defines model
                         for SGClusterSpecPodsCustomVolumesItem.
                       properties:
                         configMap:
-                          description: "Adapts a ConfigMap into a volume. \n The contents
-                            of the target ConfigMap's Data field will be presented
-                            in a volume as files using the keys in the Data field
-                            as the file names, unless the items element is populated
-                            with specific mappings of keys to paths. ConfigMap volumes
-                            support ownership management and SELinux relabeling."
+                          description: |-
+                            Adapts a ConfigMap into a volume.
+
+
+                            The contents of the target ConfigMap's Data field will be presented in a volume as files using the keys in the Data field as the file names, unless the items element is populated with specific mappings of keys to paths. ConfigMap volumes support ownership management and SELinux relabeling.
                           properties:
                             defaultMode:
                               description: 'Optional: mode bits used to set permissions
@@ -3021,61 +2993,47 @@ spec:
                                           volumes, optional for env vars'
                                         type: string
                                       divisor:
-                                        description: "Quantity is a fixed-point representation
-                                          of a number. It provides convenient marshaling/unmarshaling
-                                          in JSON and YAML, in addition to String()
-                                          and AsInt64() accessors. \n The serialization
-                                          format is: \n <quantity>        ::= <signedNumber><suffix>
-                                          (Note that <suffix> may be empty, from the
-                                          \"\" case in <decimalSI>.) <digit>           ::=
-                                          0 | 1 | ... | 9 <digits>          ::= <digit>
-                                          | <digit><digits> <number>          ::=
-                                          <digits> | <digits>.<digits> | <digits>.
-                                          | .<digits> <sign>            ::= \"+\"
-                                          | \"-\" <signedNumber>    ::= <number> |
-                                          <sign><number> <suffix>          ::= <binarySI>
-                                          | <decimalExponent> | <decimalSI> <binarySI>
-                                          \       ::= Ki | Mi | Gi | Ti | Pi | Ei
-                                          (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)
-                                          <decimalSI>       ::= m | \"\" | k | M |
-                                          G | T | P | E (Note that 1024 = 1Ki but
-                                          1000 = 1k; I didn't choose the capitalization.)
-                                          <decimalExponent> ::= \"e\" <signedNumber>
-                                          | \"E\" <signedNumber> \n No matter which
-                                          of the three exponent forms is used, no
-                                          quantity may represent a number greater
-                                          than 2^63-1 in magnitude, nor may it have
-                                          more than 3 decimal places. Numbers larger
-                                          or more precise will be capped or rounded
-                                          up. (E.g.: 0.1m will rounded up to 1m.)
-                                          This may be extended in the future if we
-                                          require larger or smaller quantities. \n
-                                          When a Quantity is parsed from a string,
-                                          it will remember the type of suffix it had,
-                                          and will use the same type again when it
-                                          is serialized. \n Before serializing, Quantity
-                                          will be put in \"canonical form\". This
-                                          means that Exponent/suffix will be adjusted
-                                          up or down (with a corresponding increase
-                                          or decrease in Mantissa) such that: a. No
-                                          precision is lost b. No fractional digits
-                                          will be emitted c. The exponent (or suffix)
-                                          is as large as possible. The sign will be
-                                          omitted unless the number is negative. \n
-                                          Examples: 1.5 will be serialized as \"1500m\"
-                                          1.5Gi will be serialized as \"1536Mi\" \n
-                                          Note that the quantity will NEVER be internally
-                                          represented by a floating point number.
-                                          That is the whole point of this exercise.
-                                          \n Non-canonical values will still parse
-                                          as long as they are well formed, but will
-                                          be re-emitted in their canonical form. (So
-                                          always use canonical form, or don't diff.)
-                                          \n This format is intended to make it difficult
-                                          to use these numbers without writing some
-                                          sort of special handling code in the hopes
-                                          that that will cause implementors to also
-                                          use a fixed point implementation."
+                                        description: |-
+                                          Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.
+
+
+                                          The serialization format is:
+
+
+                                          <quantity>        ::= <signedNumber><suffix>
+                                            (Note that <suffix> may be empty, from the "" case in <decimalSI>.)
+                                          <digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= "+" | "-" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei
+                                            (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)
+                                          <decimalSI>       ::= m | "" | k | M | G | T | P | E
+                                            (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)
+                                          <decimalExponent> ::= "e" <signedNumber> | "E" <signedNumber>
+
+
+                                          No matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.
+
+
+                                          When a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.
+
+
+                                          Before serializing, Quantity will be put in "canonical form". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:
+                                            a. No precision is lost
+                                            b. No fractional digits will be emitted
+                                            c. The exponent (or suffix) is as large as possible.
+                                          The sign will be omitted unless the number is negative.
+
+
+                                          Examples:
+                                            1.5 will be serialized as "1500m"
+                                            1.5Gi will be serialized as "1536Mi"
+
+
+                                          Note that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.
+
+
+                                          Non-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)
+
+
+                                          This format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.
                                         type: string
                                       resource:
                                         description: 'Required: resource to select'
@@ -3100,62 +3058,55 @@ spec:
                                 (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                               type: string
                             sizeLimit:
-                              description: "Quantity is a fixed-point representation
-                                of a number. It provides convenient marshaling/unmarshaling
-                                in JSON and YAML, in addition to String() and AsInt64()
-                                accessors. \n The serialization format is: \n <quantity>
-                                \       ::= <signedNumber><suffix> (Note that <suffix>
-                                may be empty, from the \"\" case in <decimalSI>.)
-                                <digit>           ::= 0 | 1 | ... | 9 <digits>          ::=
-                                <digit> | <digit><digits> <number>          ::= <digits>
-                                | <digits>.<digits> | <digits>. | .<digits> <sign>
-                                \           ::= \"+\" | \"-\" <signedNumber>    ::=
-                                <number> | <sign><number> <suffix>          ::= <binarySI>
-                                | <decimalExponent> | <decimalSI> <binarySI>        ::=
-                                Ki | Mi | Gi | Ti | Pi | Ei (International System
-                                of units; See: http://physics.nist.gov/cuu/Units/binary.html)
-                                <decimalSI>       ::= m | \"\" | k | M | G | T | P
-                                | E (Note that 1024 = 1Ki but 1000 = 1k; I didn't
-                                choose the capitalization.) <decimalExponent> ::=
-                                \"e\" <signedNumber> | \"E\" <signedNumber> \n No
-                                matter which of the three exponent forms is used,
-                                no quantity may represent a number greater than 2^63-1
-                                in magnitude, nor may it have more than 3 decimal
-                                places. Numbers larger or more precise will be capped
-                                or rounded up. (E.g.: 0.1m will rounded up to 1m.)
-                                This may be extended in the future if we require larger
-                                or smaller quantities. \n When a Quantity is parsed
-                                from a string, it will remember the type of suffix
-                                it had, and will use the same type again when it is
-                                serialized. \n Before serializing, Quantity will be
-                                put in \"canonical form\". This means that Exponent/suffix
-                                will be adjusted up or down (with a corresponding
-                                increase or decrease in Mantissa) such that: a. No
-                                precision is lost b. No fractional digits will be
-                                emitted c. The exponent (or suffix) is as large as
-                                possible. The sign will be omitted unless the number
-                                is negative. \n Examples: 1.5 will be serialized as
-                                \"1500m\" 1.5Gi will be serialized as \"1536Mi\" \n
-                                Note that the quantity will NEVER be internally represented
-                                by a floating point number. That is the whole point
-                                of this exercise. \n Non-canonical values will still
-                                parse as long as they are well formed, but will be
-                                re-emitted in their canonical form. (So always use
-                                canonical form, or don't diff.) \n This format is
-                                intended to make it difficult to use these numbers
-                                without writing some sort of special handling code
-                                in the hopes that that will cause implementors to
-                                also use a fixed point implementation."
+                              description: |-
+                                Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.
+
+
+                                The serialization format is:
+
+
+                                <quantity>        ::= <signedNumber><suffix>
+                                  (Note that <suffix> may be empty, from the "" case in <decimalSI>.)
+                                <digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= "+" | "-" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei
+                                  (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)
+                                <decimalSI>       ::= m | "" | k | M | G | T | P | E
+                                  (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)
+                                <decimalExponent> ::= "e" <signedNumber> | "E" <signedNumber>
+
+
+                                No matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.
+
+
+                                When a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.
+
+
+                                Before serializing, Quantity will be put in "canonical form". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:
+                                  a. No precision is lost
+                                  b. No fractional digits will be emitted
+                                  c. The exponent (or suffix) is as large as possible.
+                                The sign will be omitted unless the number is negative.
+
+
+                                Examples:
+                                  1.5 will be serialized as "1500m"
+                                  1.5Gi will be serialized as "1536Mi"
+
+
+                                Note that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.
+
+
+                                Non-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)
+
+
+                                This format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.
                               type: string
                           type: object
                         gitRepo:
-                          description: "Represents a volume that is populated with
-                            the contents of a git repository. Git repo volumes do
-                            not support ownership management. Git repo volumes support
-                            SELinux relabeling. \n DEPRECATED: GitRepo is deprecated.
-                            To provision a container with a git repo, mount an EmptyDir
-                            into an InitContainer that clones the repo using git,
-                            then mount the EmptyDir into the Pod's container."
+                          description: |-
+                            Represents a volume that is populated with the contents of a git repository. Git repo volumes do not support ownership management. Git repo volumes support SELinux relabeling.
+
+
+                            DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container.
                           properties:
                             directory:
                               description: Target directory name. Must not contain
@@ -3213,12 +3164,14 @@ spec:
                           - path
                           type: object
                         name:
-                          description: "Volumes name. Must be a DNS_LABEL and unique
-                            within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            \n The name will be prefixed with the string `custom-`
-                            so that when referencing them in the customInitContainers
-                            or customContainers sections the name used have to be
-                            prepended with the same prefix."
+                          description: |-
+                            Volumes name. Must be a DNS_LABEL and unique within the pod.
+                             More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+
+                            The name will be prefixed with the string `custom-` so that when referencing them in the
+                             customInitContainers or customContainers sections the name used have to be prepended with
+                             the same prefix.
                           type: string
                         nfs:
                           description: Represents an NFS mount that lasts the lifetime
@@ -3264,14 +3217,11 @@ spec:
                                   defines model for SGClusterSpecPodsCustomVolumesItemProjectedSourcesItem.
                                 properties:
                                   configMap:
-                                    description: "Adapts a ConfigMap into a projected
-                                      volume. \n The contents of the target ConfigMap's
-                                      Data field will be presented in a projected
-                                      volume as files using the keys in the Data field
-                                      as the file names, unless the items element
-                                      is populated with specific mappings of keys
-                                      to paths. Note that this is identical to a configmap
-                                      volume source without the default mode."
+                                    description: |-
+                                      Adapts a ConfigMap into a projected volume.
+
+
+                                      The contents of the target ConfigMap's Data field will be presented in a projected volume as files using the keys in the Data field as the file names, unless the items element is populated with specific mappings of keys to paths. Note that this is identical to a configmap volume source without the default mode.
                                     properties:
                                       items:
                                         description: If unspecified, each key-value
@@ -3392,76 +3342,47 @@ spec:
                                                     vars'
                                                   type: string
                                                 divisor:
-                                                  description: "Quantity is a fixed-point
-                                                    representation of a number. It
-                                                    provides convenient marshaling/unmarshaling
-                                                    in JSON and YAML, in addition
-                                                    to String() and AsInt64() accessors.
-                                                    \n The serialization format is:
-                                                    \n <quantity>        ::= <signedNumber><suffix>
-                                                    (Note that <suffix> may be empty,
-                                                    from the \"\" case in <decimalSI>.)
-                                                    <digit>           ::= 0 | 1 |
-                                                    ... | 9 <digits>          ::=
-                                                    <digit> | <digit><digits> <number>
-                                                    \         ::= <digits> | <digits>.<digits>
-                                                    | <digits>. | .<digits> <sign>
-                                                    \           ::= \"+\" | \"-\"
-                                                    <signedNumber>    ::= <number>
-                                                    | <sign><number> <suffix>          ::=
-                                                    <binarySI> | <decimalExponent>
-                                                    | <decimalSI> <binarySI>        ::=
-                                                    Ki | Mi | Gi | Ti | Pi | Ei (International
-                                                    System of units; See: http://physics.nist.gov/cuu/Units/binary.html)
-                                                    <decimalSI>       ::= m | \"\"
-                                                    | k | M | G | T | P | E (Note
-                                                    that 1024 = 1Ki but 1000 = 1k;
-                                                    I didn't choose the capitalization.)
-                                                    <decimalExponent> ::= \"e\" <signedNumber>
-                                                    | \"E\" <signedNumber> \n No matter
-                                                    which of the three exponent forms
-                                                    is used, no quantity may represent
-                                                    a number greater than 2^63-1 in
-                                                    magnitude, nor may it have more
-                                                    than 3 decimal places. Numbers
-                                                    larger or more precise will be
-                                                    capped or rounded up. (E.g.: 0.1m
-                                                    will rounded up to 1m.) This may
-                                                    be extended in the future if we
-                                                    require larger or smaller quantities.
-                                                    \n When a Quantity is parsed from
-                                                    a string, it will remember the
-                                                    type of suffix it had, and will
-                                                    use the same type again when it
-                                                    is serialized. \n Before serializing,
-                                                    Quantity will be put in \"canonical
-                                                    form\". This means that Exponent/suffix
-                                                    will be adjusted up or down (with
-                                                    a corresponding increase or decrease
-                                                    in Mantissa) such that: a. No
-                                                    precision is lost b. No fractional
-                                                    digits will be emitted c. The
-                                                    exponent (or suffix) is as large
-                                                    as possible. The sign will be
-                                                    omitted unless the number is negative.
-                                                    \n Examples: 1.5 will be serialized
-                                                    as \"1500m\" 1.5Gi will be serialized
-                                                    as \"1536Mi\" \n Note that the
-                                                    quantity will NEVER be internally
-                                                    represented by a floating point
-                                                    number. That is the whole point
-                                                    of this exercise. \n Non-canonical
-                                                    values will still parse as long
-                                                    as they are well formed, but will
-                                                    be re-emitted in their canonical
-                                                    form. (So always use canonical
-                                                    form, or don't diff.) \n This
-                                                    format is intended to make it
-                                                    difficult to use these numbers
-                                                    without writing some sort of special
-                                                    handling code in the hopes that
-                                                    that will cause implementors to
-                                                    also use a fixed point implementation."
+                                                  description: |-
+                                                    Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.
+
+
+                                                    The serialization format is:
+
+
+                                                    <quantity>        ::= <signedNumber><suffix>
+                                                      (Note that <suffix> may be empty, from the "" case in <decimalSI>.)
+                                                    <digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= "+" | "-" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei
+                                                      (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)
+                                                    <decimalSI>       ::= m | "" | k | M | G | T | P | E
+                                                      (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)
+                                                    <decimalExponent> ::= "e" <signedNumber> | "E" <signedNumber>
+
+
+                                                    No matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.
+
+
+                                                    When a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.
+
+
+                                                    Before serializing, Quantity will be put in "canonical form". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:
+                                                      a. No precision is lost
+                                                      b. No fractional digits will be emitted
+                                                      c. The exponent (or suffix) is as large as possible.
+                                                    The sign will be omitted unless the number is negative.
+
+
+                                                    Examples:
+                                                      1.5 will be serialized as "1500m"
+                                                      1.5Gi will be serialized as "1536Mi"
+
+
+                                                    Note that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.
+
+
+                                                    Non-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)
+
+
+                                                    This format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.
                                                   type: string
                                                 resource:
                                                   description: 'Required: resource
@@ -3476,13 +3397,11 @@ spec:
                                         type: array
                                     type: object
                                   secret:
-                                    description: "Adapts a secret into a projected
-                                      volume. \n The contents of the target Secret's
-                                      Data field will be presented in a projected
-                                      volume as files using the keys in the Data field
-                                      as the file names. Note that this is identical
-                                      to a secret volume source without the default
-                                      mode."
+                                    description: |-
+                                      Adapts a secret into a projected volume.
+
+
+                                      The contents of the target Secret's Data field will be presented in a projected volume as files using the keys in the Data field as the file names. Note that this is identical to a secret volume source without the default mode.
                                     properties:
                                       items:
                                         description: If unspecified, each key-value
@@ -3580,11 +3499,11 @@ spec:
                               type: array
                           type: object
                         secret:
-                          description: "Adapts a Secret into a volume. \n The contents
-                            of the target Secret's Data field will be presented in
-                            a volume as files using the keys in the Data field as
-                            the file names. Secret volumes support ownership management
-                            and SELinux relabeling."
+                          description: |-
+                            Adapts a Secret into a volume.
+
+
+                            The contents of the target Secret's Data field will be presented in a volume as files using the keys in the Data field as the file names. Secret volumes support ownership management and SELinux relabeling.
                           properties:
                             defaultMode:
                               description: 'Optional: mode bits used to set permissions
@@ -3667,15 +3586,13 @@ spec:
                       like `psql`. Only disable if you know what you are doing.
                     type: boolean
                   managementPolicy:
-                    description: managementPolicy controls how pods are created during
-                      initial scale up, when replacing pods on nodes, or when scaling
-                      down. The default policy is `OrderedReady`, where pods are created
-                      in increasing order (pod-0, then pod-1, etc) and the controller
-                      will wait until each pod is ready before continuing. When scaling
-                      down, the pods are removed in the opposite order. The alternative
-                      policy is `Parallel` which will create pods in parallel to match
-                      the desired scale without waiting, and on scale down will delete
-                      all pods at once.
+                    description: |-
+                      managementPolicy controls how pods are created during initial scale up, when replacing pods
+                       on nodes, or when scaling down. The default policy is `OrderedReady`, where pods are created
+                       in increasing order (pod-0, then pod-1, etc) and the controller will wait until each pod is
+                       ready before continuing. When scaling down, the pods are removed in the opposite order.
+                       The alternative policy is `Parallel` which will create pods in parallel to match the desired
+                       scale without waiting, and on scale down will delete all pods at once.
                     type: string
                   persistentVolume:
                     description: Pod's persistent volume configuration.
@@ -3711,8 +3628,11 @@ spec:
                         description: Backup Pod custom scheduling and affinity configuration.
                         properties:
                           nodeAffinity:
-                            description: "Node affinity is a group of node affinity
-                              scheduling rules. \n See: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#nodeaffinity-v1-core"
+                            description: |-
+                              Node affinity is a group of node affinity scheduling rules.
+
+
+                              See: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#nodeaffinity-v1-core
                             properties:
                               preferredDuringSchedulingIgnoredDuringExecution:
                                 description: The scheduler will prefer to schedule
@@ -3921,8 +3841,11 @@ spec:
                               that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
                             type: object
                           podAffinity:
-                            description: "Pod affinity is a group of inter pod affinity
-                              scheduling rules. \n See: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#podaffinity-v1-core"
+                            description: |-
+                              Pod affinity is a group of inter pod affinity scheduling rules.
+
+
+                              See: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#podaffinity-v1-core
                             properties:
                               preferredDuringSchedulingIgnoredDuringExecution:
                                 description: The scheduler will prefer to schedule
@@ -4250,8 +4173,11 @@ spec:
                                 type: array
                             type: object
                           podAntiAffinity:
-                            description: "Pod anti affinity is a group of inter pod
-                              anti affinity scheduling rules. \n See: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#podantiaffinity-v1-core"
+                            description: |-
+                              Pod anti affinity is a group of inter pod anti affinity scheduling rules.
+
+
+                              See: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#podantiaffinity-v1-core
                             properties:
                               preferredDuringSchedulingIgnoredDuringExecution:
                                 description: The scheduler will prefer to schedule
@@ -4579,8 +4505,11 @@ spec:
                                 type: array
                             type: object
                           tolerations:
-                            description: "If specified, the pod's tolerations. \n
-                              See: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#toleration-v1-core"
+                            description: |-
+                              If specified, the pod's tolerations.
+
+
+                              See: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#toleration-v1-core
                             items:
                               description: SGClusterSpecPodsSchedulingBackupTolerationsItem
                                 defines model for SGClusterSpecPodsSchedulingBackupTolerationsItem.
@@ -4624,8 +4553,11 @@ spec:
                             type: array
                         type: object
                       nodeAffinity:
-                        description: "Node affinity is a group of node affinity scheduling
-                          rules. \n See: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#nodeaffinity-v1-core"
+                        description: |-
+                          Node affinity is a group of node affinity scheduling rules.
+
+
+                          See: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#nodeaffinity-v1-core
                         properties:
                           preferredDuringSchedulingIgnoredDuringExecution:
                             description: The scheduler will prefer to schedule pods
@@ -4832,8 +4764,11 @@ spec:
                           More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
                         type: object
                       podAffinity:
-                        description: "Pod affinity is a group of inter pod affinity
-                          scheduling rules. \n See: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#podaffinity-v1-core"
+                        description: |-
+                          Pod affinity is a group of inter pod affinity scheduling rules.
+
+
+                          See: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#podaffinity-v1-core
                         properties:
                           preferredDuringSchedulingIgnoredDuringExecution:
                             description: The scheduler will prefer to schedule pods
@@ -5145,8 +5080,11 @@ spec:
                             type: array
                         type: object
                       podAntiAffinity:
-                        description: "Pod anti affinity is a group of inter pod anti
-                          affinity scheduling rules. \n See: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#podantiaffinity-v1-core"
+                        description: |-
+                          Pod anti affinity is a group of inter pod anti affinity scheduling rules.
+
+
+                          See: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#podantiaffinity-v1-core
                         properties:
                           preferredDuringSchedulingIgnoredDuringExecution:
                             description: The scheduler will prefer to schedule pods
@@ -5458,8 +5396,11 @@ spec:
                             type: array
                         type: object
                       tolerations:
-                        description: "If specified, the pod's tolerations. \n See:
-                          https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#toleration-v1-core"
+                        description: |-
+                          If specified, the pod's tolerations.
+
+
+                          See: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#toleration-v1-core
                         items:
                           description: SGClusterSpecPodsSchedulingTolerationsItem
                             defines model for SGClusterSpecPodsSchedulingTolerationsItem.
@@ -5593,55 +5534,29 @@ spec:
                               format: int32
                               type: integer
                             minDomains:
-                              description: "MinDomains indicates a minimum number
-                                of eligible domains. When the number of eligible domains
-                                with matching topology keys is less than minDomains,
-                                Pod Topology Spread treats \"global minimum\" as 0,
-                                and then the calculation of Skew is performed. And
-                                when the number of eligible domains with matching
-                                topology keys equals or greater than minDomains, this
-                                value has no effect on scheduling. As a result, when
-                                the number of eligible domains is less than minDomains,
-                                scheduler won't schedule more than maxSkew Pods to
-                                those domains. If value is nil, the constraint behaves
-                                as if MinDomains is equal to 1. Valid values are integers
-                                greater than 0. When value is not nil, WhenUnsatisfiable
-                                must be DoNotSchedule. \n For example, in a 3-zone
-                                cluster, MaxSkew is set to 2, MinDomains is set to
-                                5 and pods with the same labelSelector spread as 2/2/2:
-                                | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  |
-                                The number of domains is less than 5(MinDomains),
-                                so \"global minimum\" is treated as 0. In this situation,
-                                new pod with the same labelSelector cannot be scheduled,
-                                because computed skew will be 3(3 - 0) if new Pod
-                                is scheduled to any of the three zones, it will violate
-                                MaxSkew. \n This is a beta field and requires the
-                                MinDomainsInPodTopologySpread feature gate to be enabled
-                                (enabled by default)."
+                              description: |-
+                                MinDomains indicates a minimum number of eligible domains. When the number of eligible domains with matching topology keys is less than minDomains, Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed. And when the number of eligible domains with matching topology keys equals or greater than minDomains, this value has no effect on scheduling. As a result, when the number of eligible domains is less than minDomains, scheduler won't schedule more than maxSkew Pods to those domains. If value is nil, the constraint behaves as if MinDomains is equal to 1. Valid values are integers greater than 0. When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
+
+
+                                For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same labelSelector spread as 2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  | The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0. In this situation, new pod with the same labelSelector cannot be scheduled, because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones, it will violate MaxSkew.
+
+
+                                This is a beta field and requires the MinDomainsInPodTopologySpread feature gate to be enabled (enabled by default).
                               format: int32
                               type: integer
                             nodeAffinityPolicy:
-                              description: "NodeAffinityPolicy indicates how we will
-                                treat Pod's nodeAffinity/nodeSelector when calculating
-                                pod topology spread skew. Options are: - Honor: only
-                                nodes matching nodeAffinity/nodeSelector are included
-                                in the calculations. - Ignore: nodeAffinity/nodeSelector
-                                are ignored. All nodes are included in the calculations.
-                                \n If this value is nil, the behavior is equivalent
-                                to the Honor policy. This is a alpha-level feature
-                                enabled by the NodeInclusionPolicyInPodTopologySpread
-                                feature flag."
+                              description: |-
+                                NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector when calculating pod topology spread skew. Options are: - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations. - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
+
+
+                                If this value is nil, the behavior is equivalent to the Honor policy. This is a alpha-level feature enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
                               type: string
                             nodeTaintsPolicy:
-                              description: "NodeTaintsPolicy indicates how we will
-                                treat node taints when calculating pod topology spread
-                                skew. Options are: - Honor: nodes without taints,
-                                along with tainted nodes for which the incoming pod
-                                has a toleration, are included. - Ignore: node taints
-                                are ignored. All nodes are included. \n If this value
-                                is nil, the behavior is equivalent to the Ignore policy.
-                                This is a alpha-level feature enabled by the NodeInclusionPolicyInPodTopologySpread
-                                feature flag."
+                              description: |-
+                                NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew. Options are: - Honor: nodes without taints, along with tainted nodes for which the incoming pod has a toleration, are included. - Ignore: node taints are ignored. All nodes are included.
+
+
+                                If this value is nil, the behavior is equivalent to the Ignore policy. This is a alpha-level feature enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
                               type: string
                             topologyKey:
                               description: TopologyKey is the key of node labels.
@@ -5658,24 +5573,11 @@ spec:
                                 of that topology. It's a required field.
                               type: string
                             whenUnsatisfiable:
-                              description: 'WhenUnsatisfiable indicates how to deal
-                                with a pod if it doesn''t satisfy the spread constraint.
-                                - DoNotSchedule (default) tells the scheduler not
-                                to schedule it. - ScheduleAnyway tells the scheduler
-                                to schedule the pod in any location, but giving higher
-                                precedence to topologies that would help reduce the
-                                skew. A constraint is considered "Unsatisfiable" for
-                                an incoming pod if and only if every possible node
-                                assignment for that pod would violate "MaxSkew" on
-                                some topology. For example, in a 3-zone cluster, MaxSkew
-                                is set to 1, and pods with the same labelSelector
-                                spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P
-                                |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule,
-                                incoming pod can only be scheduled to zone2(zone3)
-                                to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3)
-                                satisfies MaxSkew(1). In other words, the cluster
-                                can still be imbalanced, but scheduler won''t make
-                                it *more* imbalanced. It''s a required field.'
+                              description: |-
+                                WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                                  but giving higher precedence to topologies that would help reduce the
+                                  skew.
+                                A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assignment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won't make it *more* imbalanced. It's a required field.
                               type: string
                           required:
                           - maxSkew
@@ -5691,20 +5593,17 @@ spec:
                 description: This section allows to configure Postgres features
                 properties:
                   extensions:
-                    description: "StackGres support deploy of extensions at runtime
-                      by simply adding an entry to this array. A deployed extension
-                      still requires the creation in a database using the [`CREATE
-                      EXTENSION`](https://www.postgresql.org/docs/current/sql-createextension.html)
-                      statement. After an extension is deployed correctly it will
-                      be present until removed and the cluster restarted. \n A cluster
-                      restart is required for: * Extensions that requires to add an
-                      entry to [`shared_preload_libraries`](https://postgresqlco.nf/en/doc/param/shared_preload_libraries/)
-                      configuration parameter. * Upgrading extensions that overwrite
-                      any file that is not the extension''s control file or extension''s
-                      script file. * Removing extensions. Until the cluster is not
-                      restarted a removed extension will still be available. * Install
-                      of extensions that require extra mount. After installed the
-                      cluster will require to be restarted."
+                    description: |-
+                      StackGres support deploy of extensions at runtime by simply adding an entry to this array. A deployed extension still
+                      requires the creation in a database using the [`CREATE EXTENSION`](https://www.postgresql.org/docs/current/sql-createextension.html)
+                      statement. After an extension is deployed correctly it will be present until removed and the cluster restarted.
+
+
+                      A cluster restart is required for:
+                      * Extensions that requires to add an entry to [`shared_preload_libraries`](https://postgresqlco.nf/en/doc/param/shared_preload_libraries/) configuration parameter.
+                      * Upgrading extensions that overwrite any file that is not the extension''s control file or extension''s script file.
+                      * Removing extensions. Until the cluster is not restarted a removed extension will still be available.
+                      * Install of extensions that require extra mount. After installed the cluster will require to be restarted.
                     items:
                       description: SGClusterSpecPostgresExtensionsItem defines model
                         for SGClusterSpecPostgresExtensionsItem.
@@ -5733,10 +5632,12 @@ spec:
                       type: object
                     type: array
                   flavor:
-                    description: "Postgres flavor used on the cluster. It is either
-                      of: *  `babelfish` will use the [Babelfish for Postgres](https://babelfish-for-postgresql.github.io/babelfish-for-postgresql/).
-                      \n If not specified then the vanilla Postgres will be used for
-                      the cluster."
+                    description: |-
+                      Postgres flavor used on the cluster. It is either of:
+                      *  `babelfish` will use the [Babelfish for Postgres](https://babelfish-for-postgresql.github.io/babelfish-for-postgresql/).
+
+
+                      If not specified then the vanilla Postgres will be used for the cluster.
                     type: string
                   ssl:
                     description: This section allows to use SSL when connecting to
@@ -5759,9 +5660,11 @@ spec:
                         - name
                         type: object
                       enabled:
-                        description: "Allow to enable SSL for connections to Postgres.
-                          By default is `false`. \n If `true` fields `certificateSecretKeySelector`
-                          and `privateKeySecretKeySelector` will be required."
+                        description: |-
+                          Allow to enable SSL for connections to Postgres. By default is `false`.
+
+
+                          If `true` fields `certificateSecretKeySelector` and `privateKeySecretKeySelector` will be required.
                         type: boolean
                       privateKeySecretKeySelector:
                         description: Secret key selector for the private key used
@@ -5781,11 +5684,11 @@ spec:
                         type: object
                     type: object
                   version:
-                    description: 'Postgres version used on the cluster. It is either
-                      of: *  The string ''latest'', which automatically sets the latest
-                      major.minor Postgres version. *  A major version, like ''14''
-                      or ''13'', which sets that major version and the latest minor
-                      version. *  A specific major.minor version, like ''14.4''.'
+                    description: |-
+                      Postgres version used on the cluster. It is either of:
+                      *  The string 'latest', which automatically sets the latest major.minor Postgres version.
+                      *  A major version, like '14' or '13', which sets that major version and the latest minor version.
+                      *  A specific major.minor version, like '14.4'.
                     type: string
                 required:
                 - version
@@ -5800,15 +5703,21 @@ spec:
                       to the read-write Postgres server of the cluster.
                     properties:
                       customPorts:
-                        description: "The list of custom ports that will be exposed
-                          by the Postgres primary service. \n The names of custom
-                          ports will be prefixed with the string `custom-` so they
-                          do not conflict with ports defined for the primary service.
-                          \n The names of target ports will be prefixed with the string
-                          `custom-` so that the ports that can be referenced in this
-                          section will be only those defined under .spec.pods.customContainers[].ports
-                          sections were names are also prepended with the same prefix.
-                          \n See: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#serviceport-v1-core"
+                        description: |-
+                          The list of custom ports that will be exposed by the Postgres primary service.
+
+
+                          The names of custom ports will be prefixed with the string `custom-` so they do not
+                           conflict with ports defined for the primary service.
+
+
+                          The names of target ports will be prefixed with the string `custom-` so that the ports
+                           that can be referenced in this section will be only those defined under
+                           .spec.pods.customContainers[].ports sections were names are also prepended with the same
+                           prefix.
+
+
+                          See: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#serviceport-v1-core
                         items:
                           description: SGClusterSpecPostgresServicesPrimaryCustomPortsItem
                             defines model for SGClusterSpecPostgresServicesPrimaryCustomPortsItem.
@@ -5851,16 +5760,16 @@ spec:
                                 "TCP", "UDP", and "SCTP". Default is TCP.
                               type: string
                             targetPort:
-                              description: "IntOrString is a type that can hold an
-                                int32 or a string.  When used in JSON or YAML marshalling
-                                and unmarshalling, it produces or consumes the inner
-                                type.  This allows you to have, for example, a JSON
-                                field that can accept a name or number. \n The name
-                                will be prefixed with the string `custom-` so that
-                                the target port that can be referenced will be only
-                                those defined under .spec.pods.customContainers[].ports
-                                sections were names are also prepended with the same
-                                prefix."
+                              description: |-
+                                IntOrString is a type that can hold an int32 or a string.  When
+                                 used in JSON or YAML marshalling and unmarshalling, it produces
+                                 or consumes the inner type.  This allows you to have, for example,
+                                 a JSON field that can accept a name or number.
+
+
+                                The name will be prefixed with the string `custom-` so that the target port that can be
+                                 referenced will be only those defined under .spec.pods.customContainers[].ports sections
+                                 were names are also prepended with the same prefix.
                               type: string
                           required:
                           - port
@@ -5891,14 +5800,18 @@ spec:
                       are load-balanced via this service.
                     properties:
                       customPorts:
-                        description: "The list of custom ports that will be exposed
-                          by the Postgres replicas service. \n The names of custom
-                          ports will be prefixed with the string `custom-` so they
-                          do not conflict with ports defined for the replicas service.
-                          \n The names of target ports will be prefixed with the string
-                          `custom-` so that the ports that can be referenced in this
-                          section will be only those defined under .spec.pods.customContainers[].ports
-                          sections were names are also prepended with the same prefix."
+                        description: |-
+                          The list of custom ports that will be exposed by the Postgres replicas service.
+
+
+                          The names of custom ports will be prefixed with the string `custom-` so they do not
+                           conflict with ports defined for the replicas service.
+
+
+                          The names of target ports will be prefixed with the string `custom-` so that the ports
+                           that can be referenced in this section will be only those defined under
+                           .spec.pods.customContainers[].ports sections were names are also prepended with the same
+                           prefix.
                         items:
                           description: SGClusterSpecPostgresServicesReplicasCustomPortsItem
                             defines model for SGClusterSpecPostgresServicesReplicasCustomPortsItem.
@@ -5941,16 +5854,16 @@ spec:
                                 "TCP", "UDP", and "SCTP". Default is TCP.
                               type: string
                             targetPort:
-                              description: "IntOrString is a type that can hold an
-                                int32 or a string.  When used in JSON or YAML marshalling
-                                and unmarshalling, it produces or consumes the inner
-                                type.  This allows you to have, for example, a JSON
-                                field that can accept a name or number. \n The name
-                                will be prefixed with the string `custom-` so that
-                                the target port that can be referenced will be only
-                                those defined under .spec.pods.customContainers[].ports
-                                sections were names are also prepended with the same
-                                prefix."
+                              description: |-
+                                IntOrString is a type that can hold an int32 or a string.  When
+                                 used in JSON or YAML marshalling and unmarshalling, it produces
+                                 or consumes the inner type.  This allows you to have, for example,
+                                 a JSON field that can accept a name or number.
+
+
+                                The name will be prefixed with the string `custom-` so that the target port that can be
+                                 referenced will be only those defined under .spec.pods.customContainers[].ports sections
+                                 were names are also prepended with the same prefix.
                               type: string
                           required:
                           - port
@@ -5980,12 +5893,14 @@ spec:
                   instance found in order to collect metrics.
                 type: boolean
               replicateFrom:
-                description: "Make the cluster a read-only standby replica allowing
-                  to replicate from another PostgreSQL instance and acting as a rely.
-                  \n Changing this section is allowed to fix issues or to change the
-                  replication source. \n Removing this section convert the cluster
-                  in a normal cluster where the standby leader is converted into the
-                  a primary instance."
+                description: |-
+                  Make the cluster a read-only standby replica allowing to replicate from another PostgreSQL instance and acting as a rely.
+
+
+                  Changing this section is allowed to fix issues or to change the replication source.
+
+
+                  Removing this section convert the cluster in a normal cluster where the standby leader is converted into the a primary instance.
                 properties:
                   instance:
                     description: Configure replication from a PostgreSQL instance.
@@ -6009,9 +5924,12 @@ spec:
                         type: string
                     type: object
                   storage:
-                    description: "Configure replication from an SGObjectStorage using
-                      WAL shipping. \n The file structure of the object storage must
-                      follow the [WAL-G](https://github.com/wal-g/wal-g) file structure."
+                    description: |-
+                      Configure replication from an SGObjectStorage using WAL shipping.
+
+
+                      The file structure of the object storage must follow the
+                       [WAL-G](https://github.com/wal-g/wal-g) file structure.
                     properties:
                       path:
                         description: The path in the SGObjectStorage to replicate
@@ -6173,41 +6091,47 @@ spec:
                     type: object
                 type: object
               replication:
-                description: "This section allows to configure Postgres replication
-                  mode and HA roles groups. \n The main replication group is implicit
-                  and contains the total number of instances less the sum of all instances
-                  in other replication groups. \n The total number of instances is
-                  always specified by `.spec.instances`."
+                description: |-
+                  This section allows to configure Postgres replication mode and HA roles groups.
+
+
+                  The main replication group is implicit and contains the total number of instances less the sum of all
+                   instances in other replication groups.
+
+
+                  The total number of instances is always specified by `.spec.instances`.
                 properties:
                   groups:
-                    description: StackGres support replication groups where a replication
-                      group of a specified number of instances could have different
-                      replication role. The main replication group is implicit and
-                      contains the total number of instances less the sum of all instances
-                      in other replication groups.
+                    description: |-
+                      StackGres support replication groups where a replication group of a specified number of instances could have different
+                       replication role. The main replication group is implicit and contains the total number of instances less the sum of all
+                       instances in other replication groups.
                     items:
                       description: SGClusterSpecReplicationGroupsItem defines model
                         for SGClusterSpecReplicationGroupsItem.
                       properties:
                         instances:
-                          description: "Number of StackGres instances for this replication
-                            group. \n The total number of instance of a cluster is
-                            always `.spec.instances`. The sum of the instances in
-                            the replication group must be less than the total number
-                            of instances."
+                          description: |-
+                            Number of StackGres instances for this replication group.
+
+
+                            The total number of instance of a cluster is always `.spec.instances`. The sum of the instances in the replication group must be
+                             less than the total number of instances.
                           type: integer
                         name:
                           description: The name of the replication group. If not set
                             will default to the `group-<index>`.
                           type: string
                         role:
-                          description: 'This role is applied to the instances of this
-                            replication group. Possible values are: * `ha-read` *
-                            `ha` * `readonly` * `none` The primary instance will be
-                            elected among all the replication groups that are either
-                            `ha` or `ha-read`. Only if the role is set to `readonly`
-                            or `ha-read` instances of such replication group will
-                            be exposed via the replicas service.'
+                          description: |-
+                            This role is applied to the instances of this replication group.
+                            Possible values are:
+                            * `ha-read`
+                            * `ha`
+                            * `readonly`
+                            * `none`
+                            The primary instance will be elected among all the replication groups that are either `ha` or `ha-read`.
+                            Only if the role is set to `readonly` or `ha-read` instances of such replication group will be exposed via the replicas service.
                           type: string
                       required:
                       - instances
@@ -6215,70 +6139,76 @@ spec:
                       type: object
                     type: array
                   mode:
-                    description: "The replication mode applied to the whole cluster.
-                      Possible values are: * `async` (default) * `sync` * `strict-sync`
-                      \n ### `async` Mode \n When in asynchronous mode the cluster
-                      is allowed to lose some committed transactions. When the primary
-                      server fails or becomes unavailable for any other reason a sufficiently
-                      healthy standby will automatically be promoted to primary. Any
-                      transactions that have not been replicated to that standby remain
-                      in a \"forked timeline\" on the primary, and are effectively
-                      unrecoverable (the data is still there, but recovering it requires
-                      a manual recovery effort by data recovery specialists). \n ###
-                      `sync` Mode \n When in synchronous mode a standby will not be
-                      promoted unless it is certain that the standby contains all
-                      transactions that may have returned a successful commit status
-                      to client (clients can change the behavior per transaction using
-                      PostgreSQL’s `synchronous_commit` setting. Transactions with
-                      `synchronous_commit` values of `off` and `local` may be lost
-                      on fail over, but will not be blocked by replication delays).
-                      This means that the system may be unavailable for writes even
-                      though some servers are available. System administrators can
-                      still use manual failover commands to promote a standby even
-                      if it results in transaction loss. \n Synchronous mode does
-                      not guarantee multi node durability of commits under all circumstances.
-                      When no suitable standby is available, primary server will still
-                      accept writes, but does not guarantee their replication. When
-                      the primary fails in this mode no standby will be promoted.
-                      When the host that used to be the primary comes back it will
-                      get promoted automatically, unless system administrator performed
-                      a manual failover. This behavior makes synchronous mode usable
-                      with 2 node clusters. \n When synchronous mode is used and a
-                      standby crashes, commits will block until the primary is switched
-                      to standalone mode. Manually shutting down or restarting a standby
-                      will not cause a commit service interruption. Standby will signal
-                      the primary to release itself from synchronous standby duties
-                      before PostgreSQL shutdown is initiated. \n ### `strict-sync`
-                      Mode \n When it is absolutely necessary to guarantee that each
-                      write is stored durably on at least two nodes, use the strict
-                      synchronous mode. This mode prevents synchronous replication
-                      to be switched off on the primary when no synchronous standby
-                      candidates are available. As a downside, the primary will not
-                      be available for writes (unless the Postgres transaction explicitly
-                      turns off `synchronous_mode` parameter), blocking all client
-                      write requests until at least one synchronous replica comes
-                      up. \n **Note**: Because of the way synchronous replication
-                      is implemented in PostgreSQL it is still possible to lose transactions
-                      even when using strict synchronous mode. If the PostgreSQL backend
-                      is cancelled while waiting to acknowledge replication (as a
-                      result of packet cancellation due to client timeout or backend
-                      failure) transaction changes become visible for other backends.
-                      Such changes are not yet replicated and may be lost in case
-                      of standby promotion."
+                    description: |-
+                      The replication mode applied to the whole cluster.
+                      Possible values are:
+                      * `async` (default)
+                      * `sync`
+                      * `strict-sync`
+
+
+                      ### `async` Mode
+
+
+                      When in asynchronous mode the cluster is allowed to lose some committed transactions.
+                       When the primary server fails or becomes unavailable for any other reason a sufficiently healthy standby
+                       will automatically be promoted to primary. Any transactions that have not been replicated to that standby
+                       remain in a "forked timeline" on the primary, and are effectively unrecoverable (the data is still there,
+                       but recovering it requires a manual recovery effort by data recovery specialists).
+
+
+                      ### `sync` Mode
+
+
+                      When in synchronous mode a standby will not be promoted unless it is certain that the standby contains all
+                       transactions that may have returned a successful commit status to client (clients can change the behavior
+                       per transaction using PostgreSQL’s `synchronous_commit` setting. Transactions with `synchronous_commit`
+                       values of `off` and `local` may be lost on fail over, but will not be blocked by replication delays). This
+                       means that the system may be unavailable for writes even though some servers are available. System
+                       administrators can still use manual failover commands to promote a standby even if it results in transaction
+                       loss.
+
+
+                      Synchronous mode does not guarantee multi node durability of commits under all circumstances. When no suitable
+                       standby is available, primary server will still accept writes, but does not guarantee their replication. When
+                       the primary fails in this mode no standby will be promoted. When the host that used to be the primary comes
+                       back it will get promoted automatically, unless system administrator performed a manual failover. This behavior
+                       makes synchronous mode usable with 2 node clusters.
+
+
+                      When synchronous mode is used and a standby crashes, commits will block until the primary is switched to standalone
+                       mode. Manually shutting down or restarting a standby will not cause a commit service interruption. Standby will
+                       signal the primary to release itself from synchronous standby duties before PostgreSQL shutdown is initiated.
+
+
+                      ### `strict-sync` Mode
+
+
+                      When it is absolutely necessary to guarantee that each write is stored durably on at least two nodes, use the strict
+                       synchronous mode. This mode prevents synchronous replication to be switched off on the primary when no synchronous
+                       standby candidates are available. As a downside, the primary will not be available for writes (unless the Postgres
+                       transaction explicitly turns off `synchronous_mode` parameter), blocking all client write requests until at least one
+                       synchronous replica comes up.
+
+
+                      **Note**: Because of the way synchronous replication is implemented in PostgreSQL it is still possible to lose
+                       transactions even when using strict synchronous mode. If the PostgreSQL backend is cancelled while waiting to acknowledge
+                       replication (as a result of packet cancellation due to client timeout or backend failure) transaction changes become
+                       visible for other backends. Such changes are not yet replicated and may be lost in case of standby promotion.
                     type: string
                   role:
-                    description: 'This role is applied to the instances of the implicit
-                      replication group that is composed by `.spec.instances` number
-                      of instances. Possible values are: * `ha-read` (default) * `ha`
-                      The primary instance will be elected among all the replication
-                      groups that are either `ha` or `ha-read`. Only if the role is
-                      set to `ha-read` instances of main replication group will be
-                      exposed via the replicas service.'
+                    description: |-
+                      This role is applied to the instances of the implicit replication group that is composed by `.spec.instances` number of instances.
+                      Possible values are:
+                      * `ha-read` (default)
+                      * `ha`
+                      The primary instance will be elected among all the replication groups that are either `ha` or `ha-read`.
+                      Only if the role is set to `ha-read` instances of main replication group will be exposed via the replicas service.
                     type: string
                   syncInstances:
-                    description: Number of synchronous standby instances. Must be
-                      less than the total number of instances. It is set to 1 by default.
-                      Only setteable if mode is `sync` or `strict-sync`.
+                    description: |-
+                      Number of synchronous standby instances. Must be less than the total number of instances. It is set to 1 by default.
+                       Only setteable if mode is `sync` or `strict-sync`.
                     type: integer
                 type: object
               sgInstanceProfile:

--- a/crds/stackgres.io_sgdbops.yaml
+++ b/crds/stackgres.io_sgdbops.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: sgdbops.stackgres.io
 spec:
   group: stackgres.io
@@ -20,14 +20,19 @@ spec:
         description: VSHNPostgreSQL is the API for creating Postgresql clusters.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -38,9 +43,12 @@ spec:
                 description: Configuration of the benchmark
                 properties:
                   connectionType:
-                    description: "Specify the service where the benchmark will connect
-                      to: \n * `primary-service`: Connect to the primary service *
-                      `replicas-service`: Connect to the replicas service"
+                    description: |-
+                      Specify the service where the benchmark will connect to:
+
+
+                      * `primary-service`: Connect to the primary service
+                      * `replicas-service`: Connect to the replicas service
                     type: string
                   pgbench:
                     description: Configuration of [pgbench](https://www.postgresql.org/docs/current/pgbench.html)
@@ -74,10 +82,11 @@ spec:
                     - duration
                     type: object
                   type:
-                    description: "The type of benchmark that will be performed on
-                      the SGCluster. Available benchmarks are: \n * `pgbench`: run
-                      [pgbench](https://www.postgresql.org/docs/current/pgbench.html)
-                      on the specified SGCluster and report the results in the status."
+                    description: |-
+                      The type of benchmark that will be performed on the SGCluster. Available benchmarks are:
+
+
+                      * `pgbench`: run [pgbench](https://www.postgresql.org/docs/current/pgbench.html) on the specified SGCluster and report the results in the status.
                     type: string
                 required:
                 - type
@@ -87,12 +96,15 @@ spec:
                   command)
                 properties:
                   backupPath:
-                    description: "The path were the backup is stored. If not set this
-                      field is filled up by the operator. \n When provided will indicate
-                      were the backups and WAL files will be stored. \n The path should
-                      be different from the current `.spec.configurations.backupPath`
-                      value for the target `SGCluster` in order to avoid mixing WAL
-                      files of two distinct major versions of postgres."
+                    description: |-
+                      The path were the backup is stored. If not set this field is filled up by the operator.
+
+
+                      When provided will indicate were the backups and WAL files will be stored.
+
+
+                      The path should be different from the current `.spec.configurations.backupPath` value for the target `SGCluster`
+                       in order to avoid mixing WAL files of two distinct major versions of postgres.
                     type: string
                   check:
                     description: 'If true does some checks to see if the cluster can
@@ -100,17 +112,15 @@ spec:
                       to: `false`.'
                     type: boolean
                   clone:
-                    description: "If true use efficient file cloning (also known as
-                      \"reflinks\" on some systems) instead of copying files to the
-                      new cluster. This can result in near-instantaneous copying of
-                      the data files, giving the speed advantages of `link` while
-                      leaving the old cluster untouched. This option is mutually exclusive
-                      with `link`. Defaults to: `false`. \n File cloning is only supported
-                      on some operating systems and file systems. If it is selected
-                      but not supported, the pg_upgrade run will error. At present,
-                      it is supported on Linux (kernel 4.5 or later) with Btrfs and
-                      XFS (on file systems created with reflink support), and on macOS
-                      with APFS."
+                    description: |-
+                      If true use efficient file cloning (also known as "reflinks" on some systems) instead of copying files to the new cluster.
+                      This can result in near-instantaneous copying of the data files, giving the speed advantages of `link` while leaving the old
+                       cluster untouched. This option is mutually exclusive with `link`. Defaults to: `false`.
+
+
+                      File cloning is only supported on some operating systems and file systems. If it is selected but not supported, the pg_upgrade
+                       run will error. At present, it is supported on Linux (kernel 4.5 or later) with Btrfs and XFS (on file systems created with
+                       reflink support), and on macOS with APFS.
                     type: boolean
                   link:
                     description: 'If true use hard links instead of copying files
@@ -127,24 +137,25 @@ spec:
                     type: string
                 type: object
               maxRetries:
-                description: "The maximum number of retries the operation is allowed
-                  to do after a failure. \n A value of `0` (zero) means no retries
-                  are made. Can not be greater than `10`. Defaults to: `0`."
+                description: |-
+                  The maximum number of retries the operation is allowed to do after a failure.
+
+
+                  A value of `0` (zero) means no retries are made. Can not be greater than `10`. Defaults to: `0`.
                 type: integer
               minorVersionUpgrade:
                 description: Configuration of minor version upgrade
                 properties:
                   method:
-                    description: "The method used to perform the minor version upgrade
-                      operation. Available methods are: \n * `InPlace`: the in-place
-                      method does not require more resources than those that are available.
-                      In case only an instance of the StackGres cluster is present
-                      this mean the service disruption will last longer so we encourage
-                      use the reduced impact restart and especially for a production
-                      environment. * `ReducedImpact`: this procedure is the same as
-                      the in-place method but require additional resources in order
-                      to spawn a new updated replica that will be removed when the
-                      procedure completes."
+                    description: |-
+                      The method used to perform the minor version upgrade operation. Available methods are:
+
+
+                      * `InPlace`: the in-place method does not require more resources than those that are available.
+                        In case only an instance of the StackGres cluster is present this mean the service disruption will
+                        last longer so we encourage use the reduced impact restart and especially for a production environment.
+                      * `ReducedImpact`: this procedure is the same as the in-place method but require additional
+                        resources in order to spawn a new updated replica that will be removed when the procedure completes.
                     type: string
                   postgresVersion:
                     description: The target postgres version that must have the same
@@ -152,17 +163,18 @@ spec:
                     type: string
                 type: object
               op:
-                description: "The kind of operation that will be performed on the
-                  SGCluster. Available operations are: \n * `benchmark`: run a benchmark
-                  on the specified SGCluster and report the results in the status.
-                  * `vacuum`: perform a [vacuum](https://www.postgresql.org/docs/current/sql-vacuum.html)
-                  operation on the specified SGCluster. * `repack`: run [`pg_repack`](https://github.com/reorg/pg_repack)
-                  command on the specified SGCluster. * `majorVersionUpgrade`: perform
-                  a major version upgrade of PostgreSQL using [`pg_upgrade`](https://www.postgresql.org/docs/current/pgupgrade.html)
-                  command. * `restart`: perform a restart of the cluster. * `minorVersionUpgrade`:
-                  perform a minor version upgrade of PostgreSQL. * `securityUpgrade`:
-                  perform a security upgrade of the cluster. * `upgrade`: perform
-                  a operator API upgrade of the cluster"
+                description: |-
+                  The kind of operation that will be performed on the SGCluster. Available operations are:
+
+
+                  * `benchmark`: run a benchmark on the specified SGCluster and report the results in the status.
+                  * `vacuum`: perform a [vacuum](https://www.postgresql.org/docs/current/sql-vacuum.html) operation on the specified SGCluster.
+                  * `repack`: run [`pg_repack`](https://github.com/reorg/pg_repack) command on the specified SGCluster.
+                  * `majorVersionUpgrade`: perform a major version upgrade of PostgreSQL using [`pg_upgrade`](https://www.postgresql.org/docs/current/pgupgrade.html) command.
+                  * `restart`: perform a restart of the cluster.
+                  * `minorVersionUpgrade`: perform a minor version upgrade of PostgreSQL.
+                  * `securityUpgrade`: perform a security upgrade of the cluster.
+                  * `upgrade`: perform a operator API upgrade of the cluster
                 type: string
               repack:
                 description: Configuration of [`pg_repack`](https://github.com/reorg/pg_repack)
@@ -226,35 +238,38 @@ spec:
                 description: Configuration of restart
                 properties:
                   method:
-                    description: "The method used to perform the restart operation.
-                      Available methods are: \n * `InPlace`: the in-place method does
-                      not require more resources than those that are available. In
-                      case only an instance of the StackGres cluster is present this
-                      mean the service disruption will last longer so we encourage
-                      use the reduced impact restart and especially for a production
-                      environment. * `ReducedImpact`: this procedure is the same as
-                      the in-place method but require additional resources in order
-                      to spawn a new updated replica that will be removed when the
-                      procedure completes."
+                    description: |-
+                      The method used to perform the restart operation. Available methods are:
+
+
+                      * `InPlace`: the in-place method does not require more resources than those that are available.
+                        In case only an instance of the StackGres cluster is present this mean the service disruption will
+                        last longer so we encourage use the reduced impact restart and especially for a production environment.
+                      * `ReducedImpact`: this procedure is the same as the in-place method but require additional
+                        resources in order to spawn a new updated replica that will be removed when the procedure completes.
                     type: string
                   onlyPendingRestart:
-                    description: 'By default all Pods are restarted. Setting this
-                      option to `true` allow to restart only those Pods which are
-                      in pending restart state as detected by the operation. Defaults
-                      to: `false`.'
+                    description: |-
+                      By default all Pods are restarted. Setting this option to `true` allow to restart only those Pods which
+                       are in pending restart state as detected by the operation. Defaults to: `false`.
                     type: boolean
                 type: object
               runAt:
-                description: "An ISO 8601 date, that holds UTC scheduled date of the
-                  operation execution. \n If not specified or if the date it's in
-                  the past, it will be interpreted ASAP."
+                description: |-
+                  An ISO 8601 date, that holds UTC scheduled date of the operation execution.
+
+
+                  If not specified or if the date it's in the past, it will be interpreted ASAP.
                 type: string
               scheduling:
                 description: Pod custom node scheduling and affinity configuration
                 properties:
                   nodeAffinity:
-                    description: "Node affinity is a group of node affinity scheduling
-                      rules. \n See: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#nodeaffinity-v1-core"
+                    description: |-
+                      Node affinity is a group of node affinity scheduling rules.
+
+
+                      See: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#nodeaffinity-v1-core
                     properties:
                       preferredDuringSchedulingIgnoredDuringExecution:
                         description: The scheduler will prefer to schedule pods to
@@ -457,8 +472,11 @@ spec:
                       https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
                     type: object
                   podAffinity:
-                    description: "Pod affinity is a group of inter pod affinity scheduling
-                      rules. \n See: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#podaffinity-v1-core"
+                    description: |-
+                      Pod affinity is a group of inter pod affinity scheduling rules.
+
+
+                      See: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#podaffinity-v1-core
                     properties:
                       preferredDuringSchedulingIgnoredDuringExecution:
                         description: The scheduler will prefer to schedule pods to
@@ -758,8 +776,11 @@ spec:
                         type: array
                     type: object
                   podAntiAffinity:
-                    description: "Pod anti affinity is a group of inter pod anti affinity
-                      scheduling rules. \n See: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#podantiaffinity-v1-core"
+                    description: |-
+                      Pod anti affinity is a group of inter pod anti affinity scheduling rules.
+
+
+                      See: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#podantiaffinity-v1-core
                     properties:
                       preferredDuringSchedulingIgnoredDuringExecution:
                         description: The scheduler will prefer to schedule pods to
@@ -1059,7 +1080,11 @@ spec:
                         type: array
                     type: object
                   tolerations:
-                    description: "If specified, the pod's tolerations. \n See: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#toleration-v1-core"
+                    description: |-
+                      If specified, the pod's tolerations.
+
+
+                      See: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#toleration-v1-core
                     items:
                       description: SGDbOpsSpecSchedulingTolerationsItem defines model
                         for SGDbOpsSpecSchedulingTolerationsItem.
@@ -1103,16 +1128,15 @@ spec:
                 description: Configuration of security upgrade
                 properties:
                   method:
-                    description: "The method used to perform the security upgrade
-                      operation. Available methods are: \n * `InPlace`: the in-place
-                      method does not require more resources than those that are available.
-                      In case only an instance of the StackGres cluster is present
-                      this mean the service disruption will last longer so we encourage
-                      use the reduced impact restart and especially for a production
-                      environment. * `ReducedImpact`: this procedure is the same as
-                      the in-place method but require additional resources in order
-                      to spawn a new updated replica that will be removed when the
-                      procedure completes."
+                    description: |-
+                      The method used to perform the security upgrade operation. Available methods are:
+
+
+                      * `InPlace`: the in-place method does not require more resources than those that are available.
+                        In case only an instance of the StackGres cluster is present this mean the service disruption will
+                        last longer so we encourage use the reduced impact restart and especially for a production environment.
+                      * `ReducedImpact`: this procedure is the same as the in-place method but require additional
+                        resources in order to spawn a new updated replica that will be removed when the procedure completes.
                     type: string
                 type: object
               sgCluster:
@@ -1120,12 +1144,14 @@ spec:
                   performed.
                 type: string
               timeout:
-                description: "An ISO 8601 duration in the format `PnDTnHnMn.nS`, that
-                  specifies a timeout after which the operation execution will be
-                  canceled. \n If the operation can not be performed due to timeout
-                  expiration, the condition `Failed` will have a status of `True`
-                  and the reason will be `OperationTimedOut`. \n If not specified
-                  the operation will never fail for timeout expiration."
+                description: |-
+                  An ISO 8601 duration in the format `PnDTnHnMn.nS`, that specifies a timeout after which the operation execution will be canceled.
+
+
+                  If the operation can not be performed due to timeout expiration, the condition `Failed` will have a status of `True` and the reason will be `OperationTimedOut`.
+
+
+                  If not specified the operation will never fail for timeout expiration.
                 type: string
               vacuum:
                 description: Configuration of [vacuum](https://www.postgresql.org/docs/current/sql-vacuum.html)
@@ -1149,36 +1175,26 @@ spec:
                             Defaults to: `true`.'
                           type: boolean
                         disablePageSkipping:
-                          description: 'Normally, VACUUM will skip pages based on
-                            the visibility map. Pages where all tuples are known to
-                            be frozen can always be skipped, and those where all tuples
-                            are known to be visible to all transactions may be skipped
-                            except when performing an aggressive vacuum. Furthermore,
-                            except when performing an aggressive vacuum, some pages
-                            may be skipped in order to avoid waiting for other sessions
-                            to finish using them. This option disables all page-skipping
-                            behavior, and is intended to be used only when the contents
-                            of the visibility map are suspect, which should happen
-                            only if there is a hardware or software issue causing
-                            database corruption. Defaults to: `false`.'
+                          description: |-
+                            Normally, VACUUM will skip pages based on the visibility map. Pages where all tuples are known to be frozen can always be
+                             skipped, and those where all tuples are known to be visible to all transactions may be skipped except when performing an
+                             aggressive vacuum. Furthermore, except when performing an aggressive vacuum, some pages may be skipped in order to avoid
+                             waiting for other sessions to finish using them. This option disables all page-skipping behavior, and is intended to be
+                             used only when the contents of the visibility map are suspect, which should happen only if there is a hardware or
+                             software issue causing database corruption. Defaults to: `false`.
                           type: boolean
                         freeze:
-                          description: 'If true selects aggressive "freezing" of tuples.
-                            Specifying FREEZE is equivalent to performing VACUUM with
-                            the vacuum_freeze_min_age and vacuum_freeze_table_age
-                            parameters set to zero. Aggressive freezing is always
-                            performed when the table is rewritten, so this option
-                            is redundant when FULL is specified. Defaults to: `false`.'
+                          description: |-
+                            If true selects aggressive "freezing" of tuples. Specifying FREEZE is equivalent to performing VACUUM with the
+                             vacuum_freeze_min_age and vacuum_freeze_table_age parameters set to zero. Aggressive freezing is always performed
+                             when the table is rewritten, so this option is redundant when FULL is specified. Defaults to: `false`.
                           type: boolean
                         full:
-                          description: 'If true selects "full" vacuum, which can reclaim
-                            more space, but takes much longer and exclusively locks
-                            the table. This method also requires extra disk space,
-                            since it writes a new copy of the table and doesn''t release
-                            the old copy until the operation is complete. Usually
-                            this should only be used when a significant amount of
-                            space needs to be reclaimed from within the table. Defaults
-                            to: `false`.'
+                          description: |-
+                            If true selects "full" vacuum, which can reclaim more space, but takes much longer and exclusively locks the table.
+                            This method also requires extra disk space, since it writes a new copy of the table and doesn't release the old copy
+                             until the operation is complete. Usually this should only be used when a significant amount of space needs to be
+                             reclaimed from within the table. Defaults to: `false`.
                           type: boolean
                         name:
                           description: the name of the database
@@ -1188,34 +1204,26 @@ spec:
                       type: object
                     type: array
                   disablePageSkipping:
-                    description: 'Normally, VACUUM will skip pages based on the visibility
-                      map. Pages where all tuples are known to be frozen can always
-                      be skipped, and those where all tuples are known to be visible
-                      to all transactions may be skipped except when performing an
-                      aggressive vacuum. Furthermore, except when performing an aggressive
-                      vacuum, some pages may be skipped in order to avoid waiting
-                      for other sessions to finish using them. This option disables
-                      all page-skipping behavior, and is intended to be used only
-                      when the contents of the visibility map are suspect, which should
-                      happen only if there is a hardware or software issue causing
-                      database corruption. Defaults to: `false`.'
+                    description: |-
+                      Normally, VACUUM will skip pages based on the visibility map. Pages where all tuples are known to be frozen can always be
+                       skipped, and those where all tuples are known to be visible to all transactions may be skipped except when performing an
+                       aggressive vacuum. Furthermore, except when performing an aggressive vacuum, some pages may be skipped in order to avoid
+                       waiting for other sessions to finish using them. This option disables all page-skipping behavior, and is intended to be
+                       used only when the contents of the visibility map are suspect, which should happen only if there is a hardware or
+                       software issue causing database corruption. Defaults to: `false`.
                     type: boolean
                   freeze:
-                    description: 'If true selects aggressive "freezing" of tuples.
-                      Specifying FREEZE is equivalent to performing VACUUM with the
-                      vacuum_freeze_min_age and vacuum_freeze_table_age parameters
-                      set to zero. Aggressive freezing is always performed when the
-                      table is rewritten, so this option is redundant when FULL is
-                      specified. Defaults to: `false`.'
+                    description: |-
+                      If true selects aggressive "freezing" of tuples. Specifying FREEZE is equivalent to performing VACUUM with the
+                       vacuum_freeze_min_age and vacuum_freeze_table_age parameters set to zero. Aggressive freezing is always performed
+                       when the table is rewritten, so this option is redundant when FULL is specified. Defaults to: `false`.
                     type: boolean
                   full:
-                    description: 'If true selects "full" vacuum, which can reclaim
-                      more space, but takes much longer and exclusively locks the
-                      table. This method also requires extra disk space, since it
-                      writes a new copy of the table and doesn''t release the old
-                      copy until the operation is complete. Usually this should only
-                      be used when a significant amount of space needs to be reclaimed
-                      from within the table. Defaults to: `false`.'
+                    description: |-
+                      If true selects "full" vacuum, which can reclaim more space, but takes much longer and exclusively locks the table.
+                      This method also requires extra disk space, since it writes a new copy of the table and doesn't release the old copy
+                       until the operation is complete. Usually this should only be used when a significant amount of space needs to be
+                       reclaimed from within the table. Defaults to: `false`.
                     type: boolean
                 type: object
             required:
@@ -1306,10 +1314,13 @@ spec:
                     type: object
                 type: object
               conditions:
-                description: "Possible conditions are: \n * Running: to indicate when
-                  the operation is actually running * Completed: to indicate when
-                  the operation has completed successfully * Failed: to indicate when
-                  the operation has failed"
+                description: |-
+                  Possible conditions are:
+
+
+                  * Running: to indicate when the operation is actually running
+                  * Completed: to indicate when the operation has completed successfully
+                  * Failed: to indicate when the operation has failed
                 items:
                   description: SGDbOpsStatusConditionsItem defines model for SGDbOpsStatusConditionsItem.
                   properties:

--- a/crds/stackgres.io_sgpoolingconfigs.yaml
+++ b/crds/stackgres.io_sgpoolingconfigs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: sgpoolingconfigs.stackgres.io
 spec:
   group: stackgres.io
@@ -20,14 +20,19 @@ spec:
         description: SGPoolingConfig is the API for creating pgbouncer configs clusters.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -38,34 +43,34 @@ spec:
                 description: Connection pooling configuration based on PgBouncer.
                 properties:
                   pgbouncer.ini:
-                    description: "The `pgbouncer.ini` parameters the configuration
-                      contains, represented as an object where the keys are valid
-                      names for the `pgbouncer.ini` configuration file parameters.
-                      \n Check [pgbouncer configuration](https://www.pgbouncer.org/config.html#generic-settings)
-                      for more information about supported parameters."
+                    description: |-
+                      The `pgbouncer.ini` parameters the configuration contains, represented as an object where the keys are valid names for the `pgbouncer.ini` configuration file parameters.
+
+
+                      Check [pgbouncer configuration](https://www.pgbouncer.org/config.html#generic-settings) for more information about supported parameters.
                     properties:
                       databases:
-                        description: "The `pgbouncer.ini` (Section [databases]) parameters
-                          the configuration contains, represented as an object where
-                          the keys are valid names for the `pgbouncer.ini` configuration
-                          file parameters. \n Check [pgbouncer configuration](https://www.pgbouncer.org/config.html#section-databases)
-                          for more information about supported parameters."
+                        description: |-
+                          The `pgbouncer.ini` (Section [databases]) parameters the configuration contains, represented as an object where the keys are valid names for the `pgbouncer.ini` configuration file parameters.
+
+
+                          Check [pgbouncer configuration](https://www.pgbouncer.org/config.html#section-databases) for more information about supported parameters.
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
                       pgbouncer:
-                        description: "The `pgbouncer.ini` (Section [pgbouncer]) parameters
-                          the configuration contains, represented as an object where
-                          the keys are valid names for the `pgbouncer.ini` configuration
-                          file parameters. \n Check [pgbouncer configuration](https://www.pgbouncer.org/config.html#generic-settings)
-                          for more information about supported parameters"
+                        description: |-
+                          The `pgbouncer.ini` (Section [pgbouncer]) parameters the configuration contains, represented as an object where the keys are valid names for the `pgbouncer.ini` configuration file parameters.
+
+
+                          Check [pgbouncer configuration](https://www.pgbouncer.org/config.html#generic-settings) for more information about supported parameters
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
                       users:
-                        description: "The `pgbouncer.ini` (Section [users]) parameters
-                          the configuration contains, represented as an object where
-                          the keys are valid names for the `pgbouncer.ini` configuration
-                          file parameters. \n Check [pgbouncer configuration](https://www.pgbouncer.org/config.html#section-users)
-                          for more information about supported parameters."
+                        description: |-
+                          The `pgbouncer.ini` (Section [users]) parameters the configuration contains, represented as an object where the keys are valid names for the `pgbouncer.ini` configuration file parameters.
+
+
+                          Check [pgbouncer configuration](https://www.pgbouncer.org/config.html#section-users) for more information about supported parameters.
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
                     type: object
@@ -82,27 +87,27 @@ spec:
                       which are used if not set.
                     properties:
                       databases:
-                        description: "The `pgbouncer.ini` (Section [databases]) parameters
-                          the configuration contains, represented as an object where
-                          the keys are valid names for the `pgbouncer.ini` configuration
-                          file parameters. \n Check [pgbouncer configuration](https://www.pgbouncer.org/config.html#section-databases)
-                          for more information about supported parameters."
+                        description: |-
+                          The `pgbouncer.ini` (Section [databases]) parameters the configuration contains, represented as an object where the keys are valid names for the `pgbouncer.ini` configuration file parameters.
+
+
+                          Check [pgbouncer configuration](https://www.pgbouncer.org/config.html#section-databases) for more information about supported parameters.
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
                       pgbouncer:
-                        description: "The `pgbouncer.ini` (Section [pgbouncer]) parameters
-                          the configuration contains, represented as an object where
-                          the keys are valid names for the `pgbouncer.ini` configuration
-                          file parameters. \n Check [pgbouncer configuration](https://www.pgbouncer.org/config.html#generic-settings)
-                          for more information about supported parameters"
+                        description: |-
+                          The `pgbouncer.ini` (Section [pgbouncer]) parameters the configuration contains, represented as an object where the keys are valid names for the `pgbouncer.ini` configuration file parameters.
+
+
+                          Check [pgbouncer configuration](https://www.pgbouncer.org/config.html#generic-settings) for more information about supported parameters
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
                       users:
-                        description: "The `pgbouncer.ini` (Section [users]) parameters
-                          the configuration contains, represented as an object where
-                          the keys are valid names for the `pgbouncer.ini` configuration
-                          file parameters. \n Check [pgbouncer configuration](https://www.pgbouncer.org/config.html#section-users)
-                          for more information about supported parameters."
+                        description: |-
+                          The `pgbouncer.ini` (Section [users]) parameters the configuration contains, represented as an object where the keys are valid names for the `pgbouncer.ini` configuration file parameters.
+
+
+                          Check [pgbouncer configuration](https://www.pgbouncer.org/config.html#section-users) for more information about supported parameters.
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
                     type: object

--- a/crds/stackgres.io_sgpostgresconfigs.yaml
+++ b/crds/stackgres.io_sgpostgresconfigs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: sgpostgresconfigs.stackgres.io
 spec:
   group: stackgres.io
@@ -19,14 +19,19 @@ spec:
       openAPIV3Schema:
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -34,14 +39,14 @@ spec:
             description: Spec defines the desired state of a SGPostgresConfig.
             properties:
               postgresVersion:
-                description: "The **major** Postgres version the configuration is
-                  for. Postgres major versions contain one number starting with version
-                  10 (`10`, `11`, `12`, etc), and two numbers separated by a dot for
-                  previous versions (`9.6`, `9.5`, etc). \n Note that Postgres maintains
-                  full compatibility across minor versions, and hence a configuration
-                  for a given major version will work for any minor version of that
-                  same major version. \n Check [StackGres component versions](https://stackgres.io/doc/latest/intro/versions)
-                  to see the Postgres versions supported by this version of StackGres."
+                description: |-
+                  The **major** Postgres version the configuration is for. Postgres major versions contain one number starting with version 10 (`10`, `11`, `12`, etc), and two numbers separated by a dot for previous versions (`9.6`, `9.5`, etc).
+
+
+                  Note that Postgres maintains full compatibility across minor versions, and hence a configuration for a given major version will work for any minor version of that same major version.
+
+
+                  Check [StackGres component versions](https://stackgres.io/doc/latest/intro/versions) to see the Postgres versions supported by this version of StackGres.
                 type: string
               postgresql.conf:
                 additionalProperties:

--- a/crds/vshn.appcat.vshn.io_vshnkeycloaks.yaml
+++ b/crds/vshn.appcat.vshn.io_vshnkeycloaks.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: vshnkeycloaks.vshn.appcat.vshn.io
 spec:
   group: vshn.appcat.vshn.io
@@ -20,10 +20,19 @@ spec:
           description: VSHNKeycloak is the API for creating keycloak instances.
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -62,7 +71,9 @@ spec:
                       description: Maintenance contains settings to control the maintenance of an instance.
                       properties:
                         dayOfWeek:
-                          description: DayOfWeek specifies at which weekday the maintenance is held place. Allowed values are [monday, tuesday, wednesday, thursday, friday, saturday, sunday]
+                          description: |-
+                            DayOfWeek specifies at which weekday the maintenance is held place.
+                            Allowed values are [monday, tuesday, wednesday, thursday, friday, saturday, sunday]
                           enum:
                             - monday
                             - tuesday
@@ -73,7 +84,9 @@ spec:
                             - sunday
                           type: string
                         timeOfDay:
-                          description: 'TimeOfDay for installing updates in UTC. Format: "hh:mm:ss".'
+                          description: |-
+                            TimeOfDay for installing updates in UTC.
+                            Format: "hh:mm:ss".
                           pattern: ^([0-1]?[0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9])$
                           type: string
                       type: object
@@ -84,7 +97,9 @@ spec:
                           description: BackupName is the name of the specific backup you want to restore.
                           type: string
                         claimName:
-                          description: ClaimName specifies the name of the instance you want to restore from. The claim has to be in the same namespace as this new instance.
+                          description: |-
+                            ClaimName specifies the name of the instance you want to restore from.
+                            The claim has to be in the same namespace as this new instance.
                           type: string
                       type: object
                     scheduling:
@@ -100,7 +115,10 @@ spec:
                       description: Service contains keycloak DBaaS specific properties
                       properties:
                         customizationImage:
-                          description: CustomizationImage can be used to provide an image with custom themes and providers. The themes need to be be placed in the `/themes` directory of the custom image. the providers need to be placed in the `/providers` directory of the custom image.
+                          description: |-
+                            CustomizationImage can be used to provide an image with custom themes and providers.
+                            The themes need to be be placed in the `/themes` directory of the custom image.
+                            the providers need to be placed in the `/providers` directory of the custom image.
                           properties:
                             image:
                               description: Path to a valid image
@@ -118,21 +136,30 @@ spec:
                               x-kubernetes-map-type: atomic
                           type: object
                         fqdn:
-                          description: FQDN contains the FQDN which will be used for the ingress. If it's not set, no ingress will be deployed. This also enables strict hostname checking for this FQDN.
+                          description: |-
+                            FQDN contains the FQDN which will be used for the ingress.
+                            If it's not set, no ingress will be deployed.
+                            This also enables strict hostname checking for this FQDN.
                           type: string
                         postgreSQLParameters:
-                          description: PostgreSQLParameters can be used to set any supported setting in the underlying PostgreSQL instance.
+                          description: |-
+                            PostgreSQLParameters can be used to set any supported setting in the
+                            underlying PostgreSQL instance.
                           properties:
                             backup:
                               description: Backup contains settings to control the backups of an instance.
                               properties:
                                 deletionProtection:
                                   default: true
-                                  description: DeletionProtection will protect the instance from being deleted for the given retention time. This is enabled by default.
+                                  description: |-
+                                    DeletionProtection will protect the instance from being deleted for the given retention time.
+                                    This is enabled by default.
                                   type: boolean
                                 deletionRetention:
                                   default: 7
-                                  description: DeletionRetention specifies in days how long the instance should be kept after deletion. The default is keeping it one week.
+                                  description: |-
+                                    DeletionRetention specifies in days how long the instance should be kept after deletion.
+                                    The default is keeping it one week.
                                   type: integer
                                 retention:
                                   default: 6
@@ -152,7 +179,10 @@ spec:
                               type: object
                             instances:
                               default: 1
-                              description: Instances configures the number of PostgreSQL instances for the cluster. Each instance contains one Postgres server. Out of all Postgres servers, one is elected as the primary, the rest remain as read-only replicas.
+                              description: |-
+                                Instances configures the number of PostgreSQL instances for the cluster.
+                                Each instance contains one Postgres server.
+                                Out of all Postgres servers, one is elected as the primary, the rest remain as read-only replicas.
                               maximum: 3
                               minimum: 1
                               type: integer
@@ -160,7 +190,9 @@ spec:
                               description: Maintenance contains settings to control the maintenance of an instance.
                               properties:
                                 dayOfWeek:
-                                  description: DayOfWeek specifies at which weekday the maintenance is held place. Allowed values are [monday, tuesday, wednesday, thursday, friday, saturday, sunday]
+                                  description: |-
+                                    DayOfWeek specifies at which weekday the maintenance is held place.
+                                    Allowed values are [monday, tuesday, wednesday, thursday, friday, saturday, sunday]
                                   enum:
                                     - monday
                                     - tuesday
@@ -171,7 +203,9 @@ spec:
                                     - sunday
                                   type: string
                                 timeOfDay:
-                                  description: 'TimeOfDay for installing updates in UTC. Format: "hh:mm:ss".'
+                                  description: |-
+                                    TimeOfDay for installing updates in UTC.
+                                    Format: "hh:mm:ss".
                                   pattern: ^([0-1]?[0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9])$
                                   type: string
                               type: object
@@ -179,31 +213,49 @@ spec:
                               description: Monitoring contains settings to control monitoring.
                               properties:
                                 alertmanagerConfigRef:
-                                  description: AlertmanagerConfigRef contains the name of the AlertmanagerConfig that should be copied over to the namespace of the instance.
+                                  description: |-
+                                    AlertmanagerConfigRef contains the name of the AlertmanagerConfig that should be copied over to the
+                                    namespace of the instance.
                                   type: string
                                 alertmanagerConfigSecretRef:
-                                  description: AlertmanagerConfigSecretRef contains the name of the secret that is used in the referenced AlertmanagerConfig
+                                  description: |-
+                                    AlertmanagerConfigSecretRef contains the name of the secret that is used
+                                    in the referenced AlertmanagerConfig
                                   type: string
                                 alertmanagerConfigTemplate:
-                                  description: AlertmanagerConfigSpecTemplate takes an AlertmanagerConfigSpec object. This takes precedence over the AlertmanagerConfigRef.
+                                  description: |-
+                                    AlertmanagerConfigSpecTemplate takes an AlertmanagerConfigSpec object.
+                                    This takes precedence over the AlertmanagerConfigRef.
                                   properties:
                                     inhibitRules:
-                                      description: List of inhibition rules. The rules will only apply to alerts matching the resource's namespace.
+                                      description: |-
+                                        List of inhibition rules. The rules will only apply to alerts matching
+                                        the resource's namespace.
                                       items:
-                                        description: InhibitRule defines an inhibition rule that allows to mute alerts when other alerts are already firing. See https://prometheus.io/docs/alerting/latest/configuration/#inhibit_rule
+                                        description: |-
+                                          InhibitRule defines an inhibition rule that allows to mute alerts when other
+                                          alerts are already firing.
+                                          See https://prometheus.io/docs/alerting/latest/configuration/#inhibit_rule
                                         properties:
                                           equal:
-                                            description: Labels that must have an equal value in the source and target alert for the inhibition to take effect.
+                                            description: |-
+                                              Labels that must have an equal value in the source and target alert for
+                                              the inhibition to take effect.
                                             items:
                                               type: string
                                             type: array
                                           sourceMatch:
-                                            description: Matchers for which one or more alerts have to exist for the inhibition to take effect. The operator enforces that the alert matches the resource's namespace.
+                                            description: |-
+                                              Matchers for which one or more alerts have to exist for the inhibition
+                                              to take effect. The operator enforces that the alert matches the
+                                              resource's namespace.
                                             items:
                                               description: Matcher defines how to match on alert's labels.
                                               properties:
                                                 matchType:
-                                                  description: Match operation available with AlertManager >= v0.22.0 and takes precedence over Regex (deprecated) if non-empty.
+                                                  description: |-
+                                                    Match operation available with AlertManager >= v0.22.0 and
+                                                    takes precedence over Regex (deprecated) if non-empty.
                                                   enum:
                                                     - '!='
                                                     - "="
@@ -215,7 +267,9 @@ spec:
                                                   minLength: 1
                                                   type: string
                                                 regex:
-                                                  description: Whether to match on equality (false) or regular-expression (true). Deprecated as of AlertManager >= v0.22.0 where a user should use MatchType instead.
+                                                  description: |-
+                                                    Whether to match on equality (false) or regular-expression (true).
+                                                    Deprecated as of AlertManager >= v0.22.0 where a user should use MatchType instead.
                                                   type: boolean
                                                 value:
                                                   description: Label value to match.
@@ -225,12 +279,16 @@ spec:
                                               type: object
                                             type: array
                                           targetMatch:
-                                            description: Matchers that have to be fulfilled in the alerts to be muted. The operator enforces that the alert matches the resource's namespace.
+                                            description: |-
+                                              Matchers that have to be fulfilled in the alerts to be muted. The
+                                              operator enforces that the alert matches the resource's namespace.
                                             items:
                                               description: Matcher defines how to match on alert's labels.
                                               properties:
                                                 matchType:
-                                                  description: Match operation available with AlertManager >= v0.22.0 and takes precedence over Regex (deprecated) if non-empty.
+                                                  description: |-
+                                                    Match operation available with AlertManager >= v0.22.0 and
+                                                    takes precedence over Regex (deprecated) if non-empty.
                                                   enum:
                                                     - '!='
                                                     - "="
@@ -242,7 +300,9 @@ spec:
                                                   minLength: 1
                                                   type: string
                                                 regex:
-                                                  description: Whether to match on equality (false) or regular-expression (true). Deprecated as of AlertManager >= v0.22.0 where a user should use MatchType instead.
+                                                  description: |-
+                                                    Whether to match on equality (false) or regular-expression (true).
+                                                    Deprecated as of AlertManager >= v0.22.0 where a user should use MatchType instead.
                                                   type: boolean
                                                 value:
                                                   description: Label value to match.
@@ -286,7 +346,9 @@ spec:
                                                 months:
                                                   description: Months is a list of MonthRange
                                                   items:
-                                                    description: MonthRange is an inclusive range of months of the year beginning in January Months can be specified by name (e.g 'January') by numerical month (e.g '1') or as an inclusive range (e.g 'January:March', '1:3', '1:March')
+                                                    description: |-
+                                                      MonthRange is an inclusive range of months of the year beginning in January
+                                                      Months can be specified by name (e.g 'January') by numerical month (e.g '1') or as an inclusive range (e.g 'January:March', '1:3', '1:March')
                                                     pattern: ^((?i)january|february|march|april|may|june|july|august|september|october|november|december|[1-12])(?:((:((?i)january|february|march|april|may|june|july|august|september|october|november|december|[1-12]))$)|$)
                                                     type: string
                                                   type: array
@@ -308,7 +370,9 @@ spec:
                                                 weekdays:
                                                   description: Weekdays is a list of WeekdayRange
                                                   items:
-                                                    description: WeekdayRange is an inclusive range of days of the week beginning on Sunday Days can be specified by name (e.g 'Sunday') or as an inclusive range (e.g 'Monday:Friday')
+                                                    description: |-
+                                                      WeekdayRange is an inclusive range of days of the week beginning on Sunday
+                                                      Days can be specified by name (e.g 'Sunday') or as an inclusive range (e.g 'Monday:Friday')
                                                     pattern: ^((?i)sun|mon|tues|wednes|thurs|fri|satur)day(?:((:(sun|mon|tues|wednes|thurs|fri|satur)day)$)|$)
                                                     type: string
                                                   type: array
@@ -337,13 +401,19 @@ spec:
                                                   description: The identity to use for authentication.
                                                   type: string
                                                 authPassword:
-                                                  description: The secret's key that contains the password to use for authentication. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.
+                                                  description: |-
+                                                    The secret's key that contains the password to use for authentication.
+                                                    The secret needs to be in the same namespace as the AlertmanagerConfig
+                                                    object and accessible by the Prometheus Operator.
                                                   properties:
                                                     key:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -353,13 +423,19 @@ spec:
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 authSecret:
-                                                  description: The secret's key that contains the CRAM-MD5 secret. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.
+                                                  description: |-
+                                                    The secret's key that contains the CRAM-MD5 secret.
+                                                    The secret needs to be in the same namespace as the AlertmanagerConfig
+                                                    object and accessible by the Prometheus Operator.
                                                   properties:
                                                     key:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -375,7 +451,9 @@ spec:
                                                   description: The sender address.
                                                   type: string
                                                 headers:
-                                                  description: Further headers email header key/value pairs. Overrides any headers previously set by the notification implementation.
+                                                  description: |-
+                                                    Further headers email header key/value pairs. Overrides any headers
+                                                    previously set by the notification implementation.
                                                   items:
                                                     description: KeyValue defines a (key, value) tuple.
                                                     properties:
@@ -398,7 +476,9 @@ spec:
                                                   description: The HTML body of the email notification.
                                                   type: string
                                                 requireTLS:
-                                                  description: The SMTP TLS requirement. Note that Go does not support unencrypted connections to remote SMTP endpoints.
+                                                  description: |-
+                                                    The SMTP TLS requirement.
+                                                    Note that Go does not support unencrypted connections to remote SMTP endpoints.
                                                   type: boolean
                                                 sendResolved:
                                                   description: Whether or not to notify about resolved alerts.
@@ -422,7 +502,10 @@ spec:
                                                               description: The key to select.
                                                               type: string
                                                             name:
-                                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                              description: |-
+                                                                Name of the referent.
+                                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                                               type: string
                                                             optional:
                                                               description: Specify whether the ConfigMap or its key must be defined
@@ -438,7 +521,10 @@ spec:
                                                               description: The key of the secret to select from.  Must be a valid secret key.
                                                               type: string
                                                             name:
-                                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                              description: |-
+                                                                Name of the referent.
+                                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                                               type: string
                                                             optional:
                                                               description: Specify whether the Secret or its key must be defined
@@ -458,7 +544,10 @@ spec:
                                                               description: The key to select.
                                                               type: string
                                                             name:
-                                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                              description: |-
+                                                                Name of the referent.
+                                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                                               type: string
                                                             optional:
                                                               description: Specify whether the ConfigMap or its key must be defined
@@ -474,7 +563,10 @@ spec:
                                                               description: The key of the secret to select from.  Must be a valid secret key.
                                                               type: string
                                                             name:
-                                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                              description: |-
+                                                                Name of the referent.
+                                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                                               type: string
                                                             optional:
                                                               description: Specify whether the Secret or its key must be defined
@@ -494,7 +586,10 @@ spec:
                                                           description: The key of the secret to select from.  Must be a valid secret key.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the Secret or its key must be defined
@@ -519,19 +614,27 @@ spec:
                                           opsgenieConfigs:
                                             description: List of OpsGenie configurations.
                                             items:
-                                              description: OpsGenieConfig configures notifications via OpsGenie. See https://prometheus.io/docs/alerting/latest/configuration/#opsgenie_config
+                                              description: |-
+                                                OpsGenieConfig configures notifications via OpsGenie.
+                                                See https://prometheus.io/docs/alerting/latest/configuration/#opsgenie_config
                                               properties:
                                                 actions:
                                                   description: Comma separated list of actions that will be available for the alert.
                                                   type: string
                                                 apiKey:
-                                                  description: The secret's key that contains the OpsGenie API key. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.
+                                                  description: |-
+                                                    The secret's key that contains the OpsGenie API key.
+                                                    The secret needs to be in the same namespace as the AlertmanagerConfig
+                                                    object and accessible by the Prometheus Operator.
                                                   properties:
                                                     key:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -570,7 +673,9 @@ spec:
                                                   description: HTTP client configuration.
                                                   properties:
                                                     authorization:
-                                                      description: Authorization header configuration for the client. This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
+                                                      description: |-
+                                                        Authorization header configuration for the client.
+                                                        This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
                                                       properties:
                                                         credentials:
                                                           description: The secret's key that contains the credentials of the request
@@ -579,7 +684,10 @@ spec:
                                                               description: The key of the secret to select from.  Must be a valid secret key.
                                                               type: string
                                                             name:
-                                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                              description: |-
+                                                                Name of the referent.
+                                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                                               type: string
                                                             optional:
                                                               description: Specify whether the Secret or its key must be defined
@@ -589,20 +697,29 @@ spec:
                                                           type: object
                                                           x-kubernetes-map-type: atomic
                                                         type:
-                                                          description: Set the authentication type. Defaults to Bearer, Basic will cause an error
+                                                          description: |-
+                                                            Set the authentication type. Defaults to Bearer, Basic will cause an
+                                                            error
                                                           type: string
                                                       type: object
                                                     basicAuth:
-                                                      description: BasicAuth for the client. This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
+                                                      description: |-
+                                                        BasicAuth for the client.
+                                                        This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
                                                       properties:
                                                         password:
-                                                          description: The secret in the service monitor namespace that contains the password for authentication.
+                                                          description: |-
+                                                            The secret in the service monitor namespace that contains the password
+                                                            for authentication.
                                                           properties:
                                                             key:
                                                               description: The key of the secret to select from.  Must be a valid secret key.
                                                               type: string
                                                             name:
-                                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                              description: |-
+                                                                Name of the referent.
+                                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                                               type: string
                                                             optional:
                                                               description: Specify whether the Secret or its key must be defined
@@ -612,13 +729,18 @@ spec:
                                                           type: object
                                                           x-kubernetes-map-type: atomic
                                                         username:
-                                                          description: The secret in the service monitor namespace that contains the username for authentication.
+                                                          description: |-
+                                                            The secret in the service monitor namespace that contains the username
+                                                            for authentication.
                                                           properties:
                                                             key:
                                                               description: The key of the secret to select from.  Must be a valid secret key.
                                                               type: string
                                                             name:
-                                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                              description: |-
+                                                                Name of the referent.
+                                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                                               type: string
                                                             optional:
                                                               description: Specify whether the Secret or its key must be defined
@@ -629,13 +751,20 @@ spec:
                                                           x-kubernetes-map-type: atomic
                                                       type: object
                                                     bearerTokenSecret:
-                                                      description: The secret's key that contains the bearer token to be used by the client for authentication. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.
+                                                      description: |-
+                                                        The secret's key that contains the bearer token to be used by the client
+                                                        for authentication.
+                                                        The secret needs to be in the same namespace as the AlertmanagerConfig
+                                                        object and accessible by the Prometheus Operator.
                                                       properties:
                                                         key:
                                                           description: The key of the secret to select from.  Must be a valid secret key.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the Secret or its key must be defined
@@ -660,7 +789,10 @@ spec:
                                                                   description: The key to select.
                                                                   type: string
                                                                 name:
-                                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                                  description: |-
+                                                                    Name of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                                   type: string
                                                                 optional:
                                                                   description: Specify whether the ConfigMap or its key must be defined
@@ -676,7 +808,10 @@ spec:
                                                                   description: The key of the secret to select from.  Must be a valid secret key.
                                                                   type: string
                                                                 name:
-                                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                                  description: |-
+                                                                    Name of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                                   type: string
                                                                 optional:
                                                                   description: Specify whether the Secret or its key must be defined
@@ -693,7 +828,10 @@ spec:
                                                               description: The key of the secret to select from.  Must be a valid secret key.
                                                               type: string
                                                             name:
-                                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                              description: |-
+                                                                Name of the referent.
+                                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                                               type: string
                                                             optional:
                                                               description: Specify whether the Secret or its key must be defined
@@ -737,7 +875,10 @@ spec:
                                                                   description: The key to select.
                                                                   type: string
                                                                 name:
-                                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                                  description: |-
+                                                                    Name of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                                   type: string
                                                                 optional:
                                                                   description: Specify whether the ConfigMap or its key must be defined
@@ -753,7 +894,10 @@ spec:
                                                                   description: The key of the secret to select from.  Must be a valid secret key.
                                                                   type: string
                                                                 name:
-                                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                                  description: |-
+                                                                    Name of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                                   type: string
                                                                 optional:
                                                                   description: Specify whether the Secret or its key must be defined
@@ -773,7 +917,10 @@ spec:
                                                                   description: The key to select.
                                                                   type: string
                                                                 name:
-                                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                                  description: |-
+                                                                    Name of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                                   type: string
                                                                 optional:
                                                                   description: Specify whether the ConfigMap or its key must be defined
@@ -789,7 +936,10 @@ spec:
                                                                   description: The key of the secret to select from.  Must be a valid secret key.
                                                                   type: string
                                                                 name:
-                                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                                  description: |-
+                                                                    Name of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                                   type: string
                                                                 optional:
                                                                   description: Specify whether the Secret or its key must be defined
@@ -809,7 +959,10 @@ spec:
                                                               description: The key of the secret to select from.  Must be a valid secret key.
                                                               type: string
                                                             name:
-                                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                              description: |-
+                                                                Name of the referent.
+                                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                                               type: string
                                                             optional:
                                                               description: Specify whether the Secret or its key must be defined
@@ -835,7 +988,9 @@ spec:
                                                 responders:
                                                   description: List of responders responsible for notifications.
                                                   items:
-                                                    description: OpsGenieConfigResponder defines a responder to an incident. One of `id`, `name` or `username` has to be defined.
+                                                    description: |-
+                                                      OpsGenieConfigResponder defines a responder to an incident.
+                                                      One of `id`, `name` or `username` has to be defined.
                                                     properties:
                                                       id:
                                                         description: ID of the responder.
@@ -870,14 +1025,18 @@ spec:
                                                   description: Comma separated list of tags attached to the notifications.
                                                   type: string
                                                 updateAlerts:
-                                                  description: Whether to update message and description of the alert in OpsGenie if it already exists By default, the alert is never updated in OpsGenie, the new message only appears in activity log.
+                                                  description: |-
+                                                    Whether to update message and description of the alert in OpsGenie if it already exists
+                                                    By default, the alert is never updated in OpsGenie, the new message only appears in activity log.
                                                   type: boolean
                                               type: object
                                             type: array
                                           pagerdutyConfigs:
                                             description: List of PagerDuty configurations.
                                             items:
-                                              description: PagerDutyConfig configures notifications via PagerDuty. See https://prometheus.io/docs/alerting/latest/configuration/#pagerduty_config
+                                              description: |-
+                                                PagerDutyConfig configures notifications via PagerDuty.
+                                                See https://prometheus.io/docs/alerting/latest/configuration/#pagerduty_config
                                               properties:
                                                 class:
                                                   description: The class/type of the event.
@@ -918,7 +1077,9 @@ spec:
                                                   description: HTTP client configuration.
                                                   properties:
                                                     authorization:
-                                                      description: Authorization header configuration for the client. This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
+                                                      description: |-
+                                                        Authorization header configuration for the client.
+                                                        This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
                                                       properties:
                                                         credentials:
                                                           description: The secret's key that contains the credentials of the request
@@ -927,7 +1088,10 @@ spec:
                                                               description: The key of the secret to select from.  Must be a valid secret key.
                                                               type: string
                                                             name:
-                                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                              description: |-
+                                                                Name of the referent.
+                                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                                               type: string
                                                             optional:
                                                               description: Specify whether the Secret or its key must be defined
@@ -937,20 +1101,29 @@ spec:
                                                           type: object
                                                           x-kubernetes-map-type: atomic
                                                         type:
-                                                          description: Set the authentication type. Defaults to Bearer, Basic will cause an error
+                                                          description: |-
+                                                            Set the authentication type. Defaults to Bearer, Basic will cause an
+                                                            error
                                                           type: string
                                                       type: object
                                                     basicAuth:
-                                                      description: BasicAuth for the client. This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
+                                                      description: |-
+                                                        BasicAuth for the client.
+                                                        This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
                                                       properties:
                                                         password:
-                                                          description: The secret in the service monitor namespace that contains the password for authentication.
+                                                          description: |-
+                                                            The secret in the service monitor namespace that contains the password
+                                                            for authentication.
                                                           properties:
                                                             key:
                                                               description: The key of the secret to select from.  Must be a valid secret key.
                                                               type: string
                                                             name:
-                                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                              description: |-
+                                                                Name of the referent.
+                                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                                               type: string
                                                             optional:
                                                               description: Specify whether the Secret or its key must be defined
@@ -960,13 +1133,18 @@ spec:
                                                           type: object
                                                           x-kubernetes-map-type: atomic
                                                         username:
-                                                          description: The secret in the service monitor namespace that contains the username for authentication.
+                                                          description: |-
+                                                            The secret in the service monitor namespace that contains the username
+                                                            for authentication.
                                                           properties:
                                                             key:
                                                               description: The key of the secret to select from.  Must be a valid secret key.
                                                               type: string
                                                             name:
-                                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                              description: |-
+                                                                Name of the referent.
+                                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                                               type: string
                                                             optional:
                                                               description: Specify whether the Secret or its key must be defined
@@ -977,13 +1155,20 @@ spec:
                                                           x-kubernetes-map-type: atomic
                                                       type: object
                                                     bearerTokenSecret:
-                                                      description: The secret's key that contains the bearer token to be used by the client for authentication. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.
+                                                      description: |-
+                                                        The secret's key that contains the bearer token to be used by the client
+                                                        for authentication.
+                                                        The secret needs to be in the same namespace as the AlertmanagerConfig
+                                                        object and accessible by the Prometheus Operator.
                                                       properties:
                                                         key:
                                                           description: The key of the secret to select from.  Must be a valid secret key.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the Secret or its key must be defined
@@ -1008,7 +1193,10 @@ spec:
                                                                   description: The key to select.
                                                                   type: string
                                                                 name:
-                                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                                  description: |-
+                                                                    Name of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                                   type: string
                                                                 optional:
                                                                   description: Specify whether the ConfigMap or its key must be defined
@@ -1024,7 +1212,10 @@ spec:
                                                                   description: The key of the secret to select from.  Must be a valid secret key.
                                                                   type: string
                                                                 name:
-                                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                                  description: |-
+                                                                    Name of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                                   type: string
                                                                 optional:
                                                                   description: Specify whether the Secret or its key must be defined
@@ -1041,7 +1232,10 @@ spec:
                                                               description: The key of the secret to select from.  Must be a valid secret key.
                                                               type: string
                                                             name:
-                                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                              description: |-
+                                                                Name of the referent.
+                                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                                               type: string
                                                             optional:
                                                               description: Specify whether the Secret or its key must be defined
@@ -1085,7 +1279,10 @@ spec:
                                                                   description: The key to select.
                                                                   type: string
                                                                 name:
-                                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                                  description: |-
+                                                                    Name of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                                   type: string
                                                                 optional:
                                                                   description: Specify whether the ConfigMap or its key must be defined
@@ -1101,7 +1298,10 @@ spec:
                                                                   description: The key of the secret to select from.  Must be a valid secret key.
                                                                   type: string
                                                                 name:
-                                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                                  description: |-
+                                                                    Name of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                                   type: string
                                                                 optional:
                                                                   description: Specify whether the Secret or its key must be defined
@@ -1121,7 +1321,10 @@ spec:
                                                                   description: The key to select.
                                                                   type: string
                                                                 name:
-                                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                                  description: |-
+                                                                    Name of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                                   type: string
                                                                 optional:
                                                                   description: Specify whether the ConfigMap or its key must be defined
@@ -1137,7 +1340,10 @@ spec:
                                                                   description: The key of the secret to select from.  Must be a valid secret key.
                                                                   type: string
                                                                 name:
-                                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                                  description: |-
+                                                                    Name of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                                   type: string
                                                                 optional:
                                                                   description: Specify whether the Secret or its key must be defined
@@ -1157,7 +1363,10 @@ spec:
                                                               description: The key of the secret to select from.  Must be a valid secret key.
                                                               type: string
                                                             name:
-                                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                              description: |-
+                                                                Name of the referent.
+                                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                                               type: string
                                                             optional:
                                                               description: Specify whether the Secret or its key must be defined
@@ -1201,13 +1410,20 @@ spec:
                                                     type: object
                                                   type: array
                                                 routingKey:
-                                                  description: The secret's key that contains the PagerDuty integration key (when using Events API v2). Either this field or `serviceKey` needs to be defined. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.
+                                                  description: |-
+                                                    The secret's key that contains the PagerDuty integration key (when using
+                                                    Events API v2). Either this field or `serviceKey` needs to be defined.
+                                                    The secret needs to be in the same namespace as the AlertmanagerConfig
+                                                    object and accessible by the Prometheus Operator.
                                                   properties:
                                                     key:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -1220,13 +1436,21 @@ spec:
                                                   description: Whether or not to notify about resolved alerts.
                                                   type: boolean
                                                 serviceKey:
-                                                  description: The secret's key that contains the PagerDuty service key (when using integration type "Prometheus"). Either this field or `routingKey` needs to be defined. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.
+                                                  description: |-
+                                                    The secret's key that contains the PagerDuty service key (when using
+                                                    integration type "Prometheus"). Either this field or `routingKey` needs to
+                                                    be defined.
+                                                    The secret needs to be in the same namespace as the AlertmanagerConfig
+                                                    object and accessible by the Prometheus Operator.
                                                   properties:
                                                     key:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -1246,10 +1470,14 @@ spec:
                                           pushoverConfigs:
                                             description: List of Pushover configurations.
                                             items:
-                                              description: PushoverConfig configures notifications via Pushover. See https://prometheus.io/docs/alerting/latest/configuration/#pushover_config
+                                              description: |-
+                                                PushoverConfig configures notifications via Pushover.
+                                                See https://prometheus.io/docs/alerting/latest/configuration/#pushover_config
                                               properties:
                                                 expire:
-                                                  description: How long your notification will continue to be retried for, unless the user acknowledges the notification.
+                                                  description: |-
+                                                    How long your notification will continue to be retried for, unless the user
+                                                    acknowledges the notification.
                                                   pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
                                                   type: string
                                                 html:
@@ -1259,7 +1487,9 @@ spec:
                                                   description: HTTP client configuration.
                                                   properties:
                                                     authorization:
-                                                      description: Authorization header configuration for the client. This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
+                                                      description: |-
+                                                        Authorization header configuration for the client.
+                                                        This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
                                                       properties:
                                                         credentials:
                                                           description: The secret's key that contains the credentials of the request
@@ -1268,7 +1498,10 @@ spec:
                                                               description: The key of the secret to select from.  Must be a valid secret key.
                                                               type: string
                                                             name:
-                                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                              description: |-
+                                                                Name of the referent.
+                                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                                               type: string
                                                             optional:
                                                               description: Specify whether the Secret or its key must be defined
@@ -1278,20 +1511,29 @@ spec:
                                                           type: object
                                                           x-kubernetes-map-type: atomic
                                                         type:
-                                                          description: Set the authentication type. Defaults to Bearer, Basic will cause an error
+                                                          description: |-
+                                                            Set the authentication type. Defaults to Bearer, Basic will cause an
+                                                            error
                                                           type: string
                                                       type: object
                                                     basicAuth:
-                                                      description: BasicAuth for the client. This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
+                                                      description: |-
+                                                        BasicAuth for the client.
+                                                        This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
                                                       properties:
                                                         password:
-                                                          description: The secret in the service monitor namespace that contains the password for authentication.
+                                                          description: |-
+                                                            The secret in the service monitor namespace that contains the password
+                                                            for authentication.
                                                           properties:
                                                             key:
                                                               description: The key of the secret to select from.  Must be a valid secret key.
                                                               type: string
                                                             name:
-                                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                              description: |-
+                                                                Name of the referent.
+                                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                                               type: string
                                                             optional:
                                                               description: Specify whether the Secret or its key must be defined
@@ -1301,13 +1543,18 @@ spec:
                                                           type: object
                                                           x-kubernetes-map-type: atomic
                                                         username:
-                                                          description: The secret in the service monitor namespace that contains the username for authentication.
+                                                          description: |-
+                                                            The secret in the service monitor namespace that contains the username
+                                                            for authentication.
                                                           properties:
                                                             key:
                                                               description: The key of the secret to select from.  Must be a valid secret key.
                                                               type: string
                                                             name:
-                                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                              description: |-
+                                                                Name of the referent.
+                                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                                               type: string
                                                             optional:
                                                               description: Specify whether the Secret or its key must be defined
@@ -1318,13 +1565,20 @@ spec:
                                                           x-kubernetes-map-type: atomic
                                                       type: object
                                                     bearerTokenSecret:
-                                                      description: The secret's key that contains the bearer token to be used by the client for authentication. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.
+                                                      description: |-
+                                                        The secret's key that contains the bearer token to be used by the client
+                                                        for authentication.
+                                                        The secret needs to be in the same namespace as the AlertmanagerConfig
+                                                        object and accessible by the Prometheus Operator.
                                                       properties:
                                                         key:
                                                           description: The key of the secret to select from.  Must be a valid secret key.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the Secret or its key must be defined
@@ -1349,7 +1603,10 @@ spec:
                                                                   description: The key to select.
                                                                   type: string
                                                                 name:
-                                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                                  description: |-
+                                                                    Name of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                                   type: string
                                                                 optional:
                                                                   description: Specify whether the ConfigMap or its key must be defined
@@ -1365,7 +1622,10 @@ spec:
                                                                   description: The key of the secret to select from.  Must be a valid secret key.
                                                                   type: string
                                                                 name:
-                                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                                  description: |-
+                                                                    Name of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                                   type: string
                                                                 optional:
                                                                   description: Specify whether the Secret or its key must be defined
@@ -1382,7 +1642,10 @@ spec:
                                                               description: The key of the secret to select from.  Must be a valid secret key.
                                                               type: string
                                                             name:
-                                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                              description: |-
+                                                                Name of the referent.
+                                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                                               type: string
                                                             optional:
                                                               description: Specify whether the Secret or its key must be defined
@@ -1426,7 +1689,10 @@ spec:
                                                                   description: The key to select.
                                                                   type: string
                                                                 name:
-                                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                                  description: |-
+                                                                    Name of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                                   type: string
                                                                 optional:
                                                                   description: Specify whether the ConfigMap or its key must be defined
@@ -1442,7 +1708,10 @@ spec:
                                                                   description: The key of the secret to select from.  Must be a valid secret key.
                                                                   type: string
                                                                 name:
-                                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                                  description: |-
+                                                                    Name of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                                   type: string
                                                                 optional:
                                                                   description: Specify whether the Secret or its key must be defined
@@ -1462,7 +1731,10 @@ spec:
                                                                   description: The key to select.
                                                                   type: string
                                                                 name:
-                                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                                  description: |-
+                                                                    Name of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                                   type: string
                                                                 optional:
                                                                   description: Specify whether the ConfigMap or its key must be defined
@@ -1478,7 +1750,10 @@ spec:
                                                                   description: The key of the secret to select from.  Must be a valid secret key.
                                                                   type: string
                                                                 name:
-                                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                                  description: |-
+                                                                    Name of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                                   type: string
                                                                 optional:
                                                                   description: Specify whether the Secret or its key must be defined
@@ -1498,7 +1773,10 @@ spec:
                                                               description: The key of the secret to select from.  Must be a valid secret key.
                                                               type: string
                                                             name:
-                                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                              description: |-
+                                                                Name of the referent.
+                                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                                               type: string
                                                             optional:
                                                               description: Specify whether the Secret or its key must be defined
@@ -1519,7 +1797,9 @@ spec:
                                                   description: Priority, see https://pushover.net/api#priority
                                                   type: string
                                                 retry:
-                                                  description: How often the Pushover servers will send the same notification to the user. Must be at least 30 seconds.
+                                                  description: |-
+                                                    How often the Pushover servers will send the same notification to the user.
+                                                    Must be at least 30 seconds.
                                                   pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
                                                   type: string
                                                 sendResolved:
@@ -1532,13 +1812,19 @@ spec:
                                                   description: Notification title.
                                                   type: string
                                                 token:
-                                                  description: The secret's key that contains the registered application's API token, see https://pushover.net/apps. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.
+                                                  description: |-
+                                                    The secret's key that contains the registered application's API token, see https://pushover.net/apps.
+                                                    The secret needs to be in the same namespace as the AlertmanagerConfig
+                                                    object and accessible by the Prometheus Operator.
                                                   properties:
                                                     key:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -1554,13 +1840,19 @@ spec:
                                                   description: A title for supplementary URL, otherwise just the URL is shown
                                                   type: string
                                                 userKey:
-                                                  description: The secret's key that contains the recipient user's user key. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.
+                                                  description: |-
+                                                    The secret's key that contains the recipient user's user key.
+                                                    The secret needs to be in the same namespace as the AlertmanagerConfig
+                                                    object and accessible by the Prometheus Operator.
                                                   properties:
                                                     key:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -1574,15 +1866,26 @@ spec:
                                           slackConfigs:
                                             description: List of Slack configurations.
                                             items:
-                                              description: SlackConfig configures notifications via Slack. See https://prometheus.io/docs/alerting/latest/configuration/#slack_config
+                                              description: |-
+                                                SlackConfig configures notifications via Slack.
+                                                See https://prometheus.io/docs/alerting/latest/configuration/#slack_config
                                               properties:
                                                 actions:
                                                   description: A list of Slack actions that are sent with each notification.
                                                   items:
-                                                    description: SlackAction configures a single Slack action that is sent with each notification. See https://api.slack.com/docs/message-attachments#action_fields and https://api.slack.com/docs/message-buttons for more information.
+                                                    description: |-
+                                                      SlackAction configures a single Slack action that is sent with each
+                                                      notification.
+                                                      See https://api.slack.com/docs/message-attachments#action_fields and
+                                                      https://api.slack.com/docs/message-buttons for more information.
                                                     properties:
                                                       confirm:
-                                                        description: SlackConfirmationField protect users from destructive actions or particularly distinguished decisions by asking them to confirm their button click one more time. See https://api.slack.com/docs/interactive-message-field-guide#confirmation_fields for more information.
+                                                        description: |-
+                                                          SlackConfirmationField protect users from destructive actions or
+                                                          particularly distinguished decisions by asking them to confirm their button
+                                                          click one more time.
+                                                          See https://api.slack.com/docs/interactive-message-field-guide#confirmation_fields
+                                                          for more information.
                                                         properties:
                                                           dismissText:
                                                             type: string
@@ -1616,13 +1919,19 @@ spec:
                                                     type: object
                                                   type: array
                                                 apiURL:
-                                                  description: The secret's key that contains the Slack webhook URL. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.
+                                                  description: |-
+                                                    The secret's key that contains the Slack webhook URL.
+                                                    The secret needs to be in the same namespace as the AlertmanagerConfig
+                                                    object and accessible by the Prometheus Operator.
                                                   properties:
                                                     key:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -1643,7 +1952,11 @@ spec:
                                                 fields:
                                                   description: A list of Slack fields that are sent with each notification.
                                                   items:
-                                                    description: SlackField configures a single Slack field that is sent with each notification. Each field must contain a title, value, and optionally, a boolean value to indicate if the field is short enough to be displayed next to other fields designated as short. See https://api.slack.com/docs/message-attachments#fields for more information.
+                                                    description: |-
+                                                      SlackField configures a single Slack field that is sent with each notification.
+                                                      Each field must contain a title, value, and optionally, a boolean value to indicate if the field
+                                                      is short enough to be displayed next to other fields designated as short.
+                                                      See https://api.slack.com/docs/message-attachments#fields for more information.
                                                     properties:
                                                       short:
                                                         type: boolean
@@ -1664,7 +1977,9 @@ spec:
                                                   description: HTTP client configuration.
                                                   properties:
                                                     authorization:
-                                                      description: Authorization header configuration for the client. This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
+                                                      description: |-
+                                                        Authorization header configuration for the client.
+                                                        This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
                                                       properties:
                                                         credentials:
                                                           description: The secret's key that contains the credentials of the request
@@ -1673,7 +1988,10 @@ spec:
                                                               description: The key of the secret to select from.  Must be a valid secret key.
                                                               type: string
                                                             name:
-                                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                              description: |-
+                                                                Name of the referent.
+                                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                                               type: string
                                                             optional:
                                                               description: Specify whether the Secret or its key must be defined
@@ -1683,20 +2001,29 @@ spec:
                                                           type: object
                                                           x-kubernetes-map-type: atomic
                                                         type:
-                                                          description: Set the authentication type. Defaults to Bearer, Basic will cause an error
+                                                          description: |-
+                                                            Set the authentication type. Defaults to Bearer, Basic will cause an
+                                                            error
                                                           type: string
                                                       type: object
                                                     basicAuth:
-                                                      description: BasicAuth for the client. This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
+                                                      description: |-
+                                                        BasicAuth for the client.
+                                                        This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
                                                       properties:
                                                         password:
-                                                          description: The secret in the service monitor namespace that contains the password for authentication.
+                                                          description: |-
+                                                            The secret in the service monitor namespace that contains the password
+                                                            for authentication.
                                                           properties:
                                                             key:
                                                               description: The key of the secret to select from.  Must be a valid secret key.
                                                               type: string
                                                             name:
-                                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                              description: |-
+                                                                Name of the referent.
+                                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                                               type: string
                                                             optional:
                                                               description: Specify whether the Secret or its key must be defined
@@ -1706,13 +2033,18 @@ spec:
                                                           type: object
                                                           x-kubernetes-map-type: atomic
                                                         username:
-                                                          description: The secret in the service monitor namespace that contains the username for authentication.
+                                                          description: |-
+                                                            The secret in the service monitor namespace that contains the username
+                                                            for authentication.
                                                           properties:
                                                             key:
                                                               description: The key of the secret to select from.  Must be a valid secret key.
                                                               type: string
                                                             name:
-                                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                              description: |-
+                                                                Name of the referent.
+                                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                                               type: string
                                                             optional:
                                                               description: Specify whether the Secret or its key must be defined
@@ -1723,13 +2055,20 @@ spec:
                                                           x-kubernetes-map-type: atomic
                                                       type: object
                                                     bearerTokenSecret:
-                                                      description: The secret's key that contains the bearer token to be used by the client for authentication. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.
+                                                      description: |-
+                                                        The secret's key that contains the bearer token to be used by the client
+                                                        for authentication.
+                                                        The secret needs to be in the same namespace as the AlertmanagerConfig
+                                                        object and accessible by the Prometheus Operator.
                                                       properties:
                                                         key:
                                                           description: The key of the secret to select from.  Must be a valid secret key.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the Secret or its key must be defined
@@ -1754,7 +2093,10 @@ spec:
                                                                   description: The key to select.
                                                                   type: string
                                                                 name:
-                                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                                  description: |-
+                                                                    Name of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                                   type: string
                                                                 optional:
                                                                   description: Specify whether the ConfigMap or its key must be defined
@@ -1770,7 +2112,10 @@ spec:
                                                                   description: The key of the secret to select from.  Must be a valid secret key.
                                                                   type: string
                                                                 name:
-                                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                                  description: |-
+                                                                    Name of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                                   type: string
                                                                 optional:
                                                                   description: Specify whether the Secret or its key must be defined
@@ -1787,7 +2132,10 @@ spec:
                                                               description: The key of the secret to select from.  Must be a valid secret key.
                                                               type: string
                                                             name:
-                                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                              description: |-
+                                                                Name of the referent.
+                                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                                               type: string
                                                             optional:
                                                               description: Specify whether the Secret or its key must be defined
@@ -1831,7 +2179,10 @@ spec:
                                                                   description: The key to select.
                                                                   type: string
                                                                 name:
-                                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                                  description: |-
+                                                                    Name of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                                   type: string
                                                                 optional:
                                                                   description: Specify whether the ConfigMap or its key must be defined
@@ -1847,7 +2198,10 @@ spec:
                                                                   description: The key of the secret to select from.  Must be a valid secret key.
                                                                   type: string
                                                                 name:
-                                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                                  description: |-
+                                                                    Name of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                                   type: string
                                                                 optional:
                                                                   description: Specify whether the Secret or its key must be defined
@@ -1867,7 +2221,10 @@ spec:
                                                                   description: The key to select.
                                                                   type: string
                                                                 name:
-                                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                                  description: |-
+                                                                    Name of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                                   type: string
                                                                 optional:
                                                                   description: Specify whether the ConfigMap or its key must be defined
@@ -1883,7 +2240,10 @@ spec:
                                                                   description: The key of the secret to select from.  Must be a valid secret key.
                                                                   type: string
                                                                 name:
-                                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                                  description: |-
+                                                                    Name of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                                   type: string
                                                                 optional:
                                                                   description: Specify whether the Secret or its key must be defined
@@ -1903,7 +2263,10 @@ spec:
                                                               description: The key of the secret to select from.  Must be a valid secret key.
                                                               type: string
                                                             name:
-                                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                              description: |-
+                                                                Name of the referent.
+                                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                                               type: string
                                                             optional:
                                                               description: Specify whether the Secret or its key must be defined
@@ -1951,10 +2314,14 @@ spec:
                                           snsConfigs:
                                             description: List of SNS configurations
                                             items:
-                                              description: SNSConfig configures notifications via AWS SNS. See https://prometheus.io/docs/alerting/latest/configuration/#sns_configs
+                                              description: |-
+                                                SNSConfig configures notifications via AWS SNS.
+                                                See https://prometheus.io/docs/alerting/latest/configuration/#sns_configs
                                               properties:
                                                 apiURL:
-                                                  description: The SNS API URL i.e. https://sns.us-east-2.amazonaws.com. If not specified, the SNS API URL from the SNS SDK will be used.
+                                                  description: |-
+                                                    The SNS API URL i.e. https://sns.us-east-2.amazonaws.com.
+                                                    If not specified, the SNS API URL from the SNS SDK will be used.
                                                   type: string
                                                 attributes:
                                                   additionalProperties:
@@ -1965,7 +2332,9 @@ spec:
                                                   description: HTTP client configuration.
                                                   properties:
                                                     authorization:
-                                                      description: Authorization header configuration for the client. This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
+                                                      description: |-
+                                                        Authorization header configuration for the client.
+                                                        This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
                                                       properties:
                                                         credentials:
                                                           description: The secret's key that contains the credentials of the request
@@ -1974,7 +2343,10 @@ spec:
                                                               description: The key of the secret to select from.  Must be a valid secret key.
                                                               type: string
                                                             name:
-                                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                              description: |-
+                                                                Name of the referent.
+                                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                                               type: string
                                                             optional:
                                                               description: Specify whether the Secret or its key must be defined
@@ -1984,20 +2356,29 @@ spec:
                                                           type: object
                                                           x-kubernetes-map-type: atomic
                                                         type:
-                                                          description: Set the authentication type. Defaults to Bearer, Basic will cause an error
+                                                          description: |-
+                                                            Set the authentication type. Defaults to Bearer, Basic will cause an
+                                                            error
                                                           type: string
                                                       type: object
                                                     basicAuth:
-                                                      description: BasicAuth for the client. This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
+                                                      description: |-
+                                                        BasicAuth for the client.
+                                                        This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
                                                       properties:
                                                         password:
-                                                          description: The secret in the service monitor namespace that contains the password for authentication.
+                                                          description: |-
+                                                            The secret in the service monitor namespace that contains the password
+                                                            for authentication.
                                                           properties:
                                                             key:
                                                               description: The key of the secret to select from.  Must be a valid secret key.
                                                               type: string
                                                             name:
-                                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                              description: |-
+                                                                Name of the referent.
+                                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                                               type: string
                                                             optional:
                                                               description: Specify whether the Secret or its key must be defined
@@ -2007,13 +2388,18 @@ spec:
                                                           type: object
                                                           x-kubernetes-map-type: atomic
                                                         username:
-                                                          description: The secret in the service monitor namespace that contains the username for authentication.
+                                                          description: |-
+                                                            The secret in the service monitor namespace that contains the username
+                                                            for authentication.
                                                           properties:
                                                             key:
                                                               description: The key of the secret to select from.  Must be a valid secret key.
                                                               type: string
                                                             name:
-                                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                              description: |-
+                                                                Name of the referent.
+                                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                                               type: string
                                                             optional:
                                                               description: Specify whether the Secret or its key must be defined
@@ -2024,13 +2410,20 @@ spec:
                                                           x-kubernetes-map-type: atomic
                                                       type: object
                                                     bearerTokenSecret:
-                                                      description: The secret's key that contains the bearer token to be used by the client for authentication. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.
+                                                      description: |-
+                                                        The secret's key that contains the bearer token to be used by the client
+                                                        for authentication.
+                                                        The secret needs to be in the same namespace as the AlertmanagerConfig
+                                                        object and accessible by the Prometheus Operator.
                                                       properties:
                                                         key:
                                                           description: The key of the secret to select from.  Must be a valid secret key.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the Secret or its key must be defined
@@ -2055,7 +2448,10 @@ spec:
                                                                   description: The key to select.
                                                                   type: string
                                                                 name:
-                                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                                  description: |-
+                                                                    Name of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                                   type: string
                                                                 optional:
                                                                   description: Specify whether the ConfigMap or its key must be defined
@@ -2071,7 +2467,10 @@ spec:
                                                                   description: The key of the secret to select from.  Must be a valid secret key.
                                                                   type: string
                                                                 name:
-                                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                                  description: |-
+                                                                    Name of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                                   type: string
                                                                 optional:
                                                                   description: Specify whether the Secret or its key must be defined
@@ -2088,7 +2487,10 @@ spec:
                                                               description: The key of the secret to select from.  Must be a valid secret key.
                                                               type: string
                                                             name:
-                                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                              description: |-
+                                                                Name of the referent.
+                                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                                               type: string
                                                             optional:
                                                               description: Specify whether the Secret or its key must be defined
@@ -2132,7 +2534,10 @@ spec:
                                                                   description: The key to select.
                                                                   type: string
                                                                 name:
-                                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                                  description: |-
+                                                                    Name of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                                   type: string
                                                                 optional:
                                                                   description: Specify whether the ConfigMap or its key must be defined
@@ -2148,7 +2553,10 @@ spec:
                                                                   description: The key of the secret to select from.  Must be a valid secret key.
                                                                   type: string
                                                                 name:
-                                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                                  description: |-
+                                                                    Name of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                                   type: string
                                                                 optional:
                                                                   description: Specify whether the Secret or its key must be defined
@@ -2168,7 +2576,10 @@ spec:
                                                                   description: The key to select.
                                                                   type: string
                                                                 name:
-                                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                                  description: |-
+                                                                    Name of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                                   type: string
                                                                 optional:
                                                                   description: Specify whether the ConfigMap or its key must be defined
@@ -2184,7 +2595,10 @@ spec:
                                                                   description: The key of the secret to select from.  Must be a valid secret key.
                                                                   type: string
                                                                 name:
-                                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                                  description: |-
+                                                                    Name of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                                   type: string
                                                                 optional:
                                                                   description: Specify whether the Secret or its key must be defined
@@ -2204,7 +2618,10 @@ spec:
                                                               description: The key of the secret to select from.  Must be a valid secret key.
                                                               type: string
                                                             name:
-                                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                              description: |-
+                                                                Name of the referent.
+                                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                                               type: string
                                                             optional:
                                                               description: Specify whether the Secret or its key must be defined
@@ -2222,7 +2639,9 @@ spec:
                                                   description: The message content of the SNS notification.
                                                   type: string
                                                 phoneNumber:
-                                                  description: Phone number if message is delivered via SMS in E.164 format. If you don't specify this value, you must specify a value for the TopicARN or TargetARN.
+                                                  description: |-
+                                                    Phone number if message is delivered via SMS in E.164 format.
+                                                    If you don't specify this value, you must specify a value for the TopicARN or TargetARN.
                                                   type: string
                                                 sendResolved:
                                                   description: Whether or not to notify about resolved alerts.
@@ -2237,7 +2656,10 @@ spec:
                                                           description: The key of the secret to select from.  Must be a valid secret key.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the Secret or its key must be defined
@@ -2262,7 +2684,10 @@ spec:
                                                           description: The key of the secret to select from.  Must be a valid secret key.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the Secret or its key must be defined
@@ -2276,29 +2701,43 @@ spec:
                                                   description: Subject line when the message is delivered to email endpoints.
                                                   type: string
                                                 targetARN:
-                                                  description: The  mobile platform endpoint ARN if message is delivered via mobile notifications. If you don't specify this value, you must specify a value for the topic_arn or PhoneNumber.
+                                                  description: |-
+                                                    The  mobile platform endpoint ARN if message is delivered via mobile notifications.
+                                                    If you don't specify this value, you must specify a value for the topic_arn or PhoneNumber.
                                                   type: string
                                                 topicARN:
-                                                  description: SNS topic ARN, i.e. arn:aws:sns:us-east-2:698519295917:My-Topic If you don't specify this value, you must specify a value for the PhoneNumber or TargetARN.
+                                                  description: |-
+                                                    SNS topic ARN, i.e. arn:aws:sns:us-east-2:698519295917:My-Topic
+                                                    If you don't specify this value, you must specify a value for the PhoneNumber or TargetARN.
                                                   type: string
                                               type: object
                                             type: array
                                           telegramConfigs:
                                             description: List of Telegram configurations.
                                             items:
-                                              description: TelegramConfig configures notifications via Telegram. See https://prometheus.io/docs/alerting/latest/configuration/#telegram_config
+                                              description: |-
+                                                TelegramConfig configures notifications via Telegram.
+                                                See https://prometheus.io/docs/alerting/latest/configuration/#telegram_config
                                               properties:
                                                 apiURL:
-                                                  description: The Telegram API URL i.e. https://api.telegram.org. If not specified, default API URL will be used.
+                                                  description: |-
+                                                    The Telegram API URL i.e. https://api.telegram.org.
+                                                    If not specified, default API URL will be used.
                                                   type: string
                                                 botToken:
-                                                  description: Telegram bot token The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.
+                                                  description: |-
+                                                    Telegram bot token
+                                                    The secret needs to be in the same namespace as the AlertmanagerConfig
+                                                    object and accessible by the Prometheus Operator.
                                                   properties:
                                                     key:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -2318,7 +2757,9 @@ spec:
                                                   description: HTTP client configuration.
                                                   properties:
                                                     authorization:
-                                                      description: Authorization header configuration for the client. This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
+                                                      description: |-
+                                                        Authorization header configuration for the client.
+                                                        This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
                                                       properties:
                                                         credentials:
                                                           description: The secret's key that contains the credentials of the request
@@ -2327,7 +2768,10 @@ spec:
                                                               description: The key of the secret to select from.  Must be a valid secret key.
                                                               type: string
                                                             name:
-                                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                              description: |-
+                                                                Name of the referent.
+                                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                                               type: string
                                                             optional:
                                                               description: Specify whether the Secret or its key must be defined
@@ -2337,20 +2781,29 @@ spec:
                                                           type: object
                                                           x-kubernetes-map-type: atomic
                                                         type:
-                                                          description: Set the authentication type. Defaults to Bearer, Basic will cause an error
+                                                          description: |-
+                                                            Set the authentication type. Defaults to Bearer, Basic will cause an
+                                                            error
                                                           type: string
                                                       type: object
                                                     basicAuth:
-                                                      description: BasicAuth for the client. This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
+                                                      description: |-
+                                                        BasicAuth for the client.
+                                                        This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
                                                       properties:
                                                         password:
-                                                          description: The secret in the service monitor namespace that contains the password for authentication.
+                                                          description: |-
+                                                            The secret in the service monitor namespace that contains the password
+                                                            for authentication.
                                                           properties:
                                                             key:
                                                               description: The key of the secret to select from.  Must be a valid secret key.
                                                               type: string
                                                             name:
-                                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                              description: |-
+                                                                Name of the referent.
+                                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                                               type: string
                                                             optional:
                                                               description: Specify whether the Secret or its key must be defined
@@ -2360,13 +2813,18 @@ spec:
                                                           type: object
                                                           x-kubernetes-map-type: atomic
                                                         username:
-                                                          description: The secret in the service monitor namespace that contains the username for authentication.
+                                                          description: |-
+                                                            The secret in the service monitor namespace that contains the username
+                                                            for authentication.
                                                           properties:
                                                             key:
                                                               description: The key of the secret to select from.  Must be a valid secret key.
                                                               type: string
                                                             name:
-                                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                              description: |-
+                                                                Name of the referent.
+                                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                                               type: string
                                                             optional:
                                                               description: Specify whether the Secret or its key must be defined
@@ -2377,13 +2835,20 @@ spec:
                                                           x-kubernetes-map-type: atomic
                                                       type: object
                                                     bearerTokenSecret:
-                                                      description: The secret's key that contains the bearer token to be used by the client for authentication. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.
+                                                      description: |-
+                                                        The secret's key that contains the bearer token to be used by the client
+                                                        for authentication.
+                                                        The secret needs to be in the same namespace as the AlertmanagerConfig
+                                                        object and accessible by the Prometheus Operator.
                                                       properties:
                                                         key:
                                                           description: The key of the secret to select from.  Must be a valid secret key.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the Secret or its key must be defined
@@ -2408,7 +2873,10 @@ spec:
                                                                   description: The key to select.
                                                                   type: string
                                                                 name:
-                                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                                  description: |-
+                                                                    Name of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                                   type: string
                                                                 optional:
                                                                   description: Specify whether the ConfigMap or its key must be defined
@@ -2424,7 +2892,10 @@ spec:
                                                                   description: The key of the secret to select from.  Must be a valid secret key.
                                                                   type: string
                                                                 name:
-                                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                                  description: |-
+                                                                    Name of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                                   type: string
                                                                 optional:
                                                                   description: Specify whether the Secret or its key must be defined
@@ -2441,7 +2912,10 @@ spec:
                                                               description: The key of the secret to select from.  Must be a valid secret key.
                                                               type: string
                                                             name:
-                                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                              description: |-
+                                                                Name of the referent.
+                                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                                               type: string
                                                             optional:
                                                               description: Specify whether the Secret or its key must be defined
@@ -2485,7 +2959,10 @@ spec:
                                                                   description: The key to select.
                                                                   type: string
                                                                 name:
-                                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                                  description: |-
+                                                                    Name of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                                   type: string
                                                                 optional:
                                                                   description: Specify whether the ConfigMap or its key must be defined
@@ -2501,7 +2978,10 @@ spec:
                                                                   description: The key of the secret to select from.  Must be a valid secret key.
                                                                   type: string
                                                                 name:
-                                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                                  description: |-
+                                                                    Name of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                                   type: string
                                                                 optional:
                                                                   description: Specify whether the Secret or its key must be defined
@@ -2521,7 +3001,10 @@ spec:
                                                                   description: The key to select.
                                                                   type: string
                                                                 name:
-                                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                                  description: |-
+                                                                    Name of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                                   type: string
                                                                 optional:
                                                                   description: Specify whether the ConfigMap or its key must be defined
@@ -2537,7 +3020,10 @@ spec:
                                                                   description: The key of the secret to select from.  Must be a valid secret key.
                                                                   type: string
                                                                 name:
-                                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                                  description: |-
+                                                                    Name of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                                   type: string
                                                                 optional:
                                                                   description: Specify whether the Secret or its key must be defined
@@ -2557,7 +3043,10 @@ spec:
                                                               description: The key of the secret to select from.  Must be a valid secret key.
                                                               type: string
                                                             name:
-                                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                              description: |-
+                                                                Name of the referent.
+                                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                                               type: string
                                                             optional:
                                                               description: Specify whether the Secret or its key must be defined
@@ -2589,16 +3078,24 @@ spec:
                                           victoropsConfigs:
                                             description: List of VictorOps configurations.
                                             items:
-                                              description: VictorOpsConfig configures notifications via VictorOps. See https://prometheus.io/docs/alerting/latest/configuration/#victorops_config
+                                              description: |-
+                                                VictorOpsConfig configures notifications via VictorOps.
+                                                See https://prometheus.io/docs/alerting/latest/configuration/#victorops_config
                                               properties:
                                                 apiKey:
-                                                  description: The secret's key that contains the API key to use when talking to the VictorOps API. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.
+                                                  description: |-
+                                                    The secret's key that contains the API key to use when talking to the VictorOps API.
+                                                    The secret needs to be in the same namespace as the AlertmanagerConfig
+                                                    object and accessible by the Prometheus Operator.
                                                   properties:
                                                     key:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -2634,7 +3131,9 @@ spec:
                                                   description: The HTTP client's configuration.
                                                   properties:
                                                     authorization:
-                                                      description: Authorization header configuration for the client. This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
+                                                      description: |-
+                                                        Authorization header configuration for the client.
+                                                        This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
                                                       properties:
                                                         credentials:
                                                           description: The secret's key that contains the credentials of the request
@@ -2643,7 +3142,10 @@ spec:
                                                               description: The key of the secret to select from.  Must be a valid secret key.
                                                               type: string
                                                             name:
-                                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                              description: |-
+                                                                Name of the referent.
+                                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                                               type: string
                                                             optional:
                                                               description: Specify whether the Secret or its key must be defined
@@ -2653,20 +3155,29 @@ spec:
                                                           type: object
                                                           x-kubernetes-map-type: atomic
                                                         type:
-                                                          description: Set the authentication type. Defaults to Bearer, Basic will cause an error
+                                                          description: |-
+                                                            Set the authentication type. Defaults to Bearer, Basic will cause an
+                                                            error
                                                           type: string
                                                       type: object
                                                     basicAuth:
-                                                      description: BasicAuth for the client. This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
+                                                      description: |-
+                                                        BasicAuth for the client.
+                                                        This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
                                                       properties:
                                                         password:
-                                                          description: The secret in the service monitor namespace that contains the password for authentication.
+                                                          description: |-
+                                                            The secret in the service monitor namespace that contains the password
+                                                            for authentication.
                                                           properties:
                                                             key:
                                                               description: The key of the secret to select from.  Must be a valid secret key.
                                                               type: string
                                                             name:
-                                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                              description: |-
+                                                                Name of the referent.
+                                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                                               type: string
                                                             optional:
                                                               description: Specify whether the Secret or its key must be defined
@@ -2676,13 +3187,18 @@ spec:
                                                           type: object
                                                           x-kubernetes-map-type: atomic
                                                         username:
-                                                          description: The secret in the service monitor namespace that contains the username for authentication.
+                                                          description: |-
+                                                            The secret in the service monitor namespace that contains the username
+                                                            for authentication.
                                                           properties:
                                                             key:
                                                               description: The key of the secret to select from.  Must be a valid secret key.
                                                               type: string
                                                             name:
-                                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                              description: |-
+                                                                Name of the referent.
+                                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                                               type: string
                                                             optional:
                                                               description: Specify whether the Secret or its key must be defined
@@ -2693,13 +3209,20 @@ spec:
                                                           x-kubernetes-map-type: atomic
                                                       type: object
                                                     bearerTokenSecret:
-                                                      description: The secret's key that contains the bearer token to be used by the client for authentication. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.
+                                                      description: |-
+                                                        The secret's key that contains the bearer token to be used by the client
+                                                        for authentication.
+                                                        The secret needs to be in the same namespace as the AlertmanagerConfig
+                                                        object and accessible by the Prometheus Operator.
                                                       properties:
                                                         key:
                                                           description: The key of the secret to select from.  Must be a valid secret key.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the Secret or its key must be defined
@@ -2724,7 +3247,10 @@ spec:
                                                                   description: The key to select.
                                                                   type: string
                                                                 name:
-                                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                                  description: |-
+                                                                    Name of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                                   type: string
                                                                 optional:
                                                                   description: Specify whether the ConfigMap or its key must be defined
@@ -2740,7 +3266,10 @@ spec:
                                                                   description: The key of the secret to select from.  Must be a valid secret key.
                                                                   type: string
                                                                 name:
-                                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                                  description: |-
+                                                                    Name of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                                   type: string
                                                                 optional:
                                                                   description: Specify whether the Secret or its key must be defined
@@ -2757,7 +3286,10 @@ spec:
                                                               description: The key of the secret to select from.  Must be a valid secret key.
                                                               type: string
                                                             name:
-                                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                              description: |-
+                                                                Name of the referent.
+                                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                                               type: string
                                                             optional:
                                                               description: Specify whether the Secret or its key must be defined
@@ -2801,7 +3333,10 @@ spec:
                                                                   description: The key to select.
                                                                   type: string
                                                                 name:
-                                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                                  description: |-
+                                                                    Name of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                                   type: string
                                                                 optional:
                                                                   description: Specify whether the ConfigMap or its key must be defined
@@ -2817,7 +3352,10 @@ spec:
                                                                   description: The key of the secret to select from.  Must be a valid secret key.
                                                                   type: string
                                                                 name:
-                                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                                  description: |-
+                                                                    Name of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                                   type: string
                                                                 optional:
                                                                   description: Specify whether the Secret or its key must be defined
@@ -2837,7 +3375,10 @@ spec:
                                                                   description: The key to select.
                                                                   type: string
                                                                 name:
-                                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                                  description: |-
+                                                                    Name of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                                   type: string
                                                                 optional:
                                                                   description: Specify whether the ConfigMap or its key must be defined
@@ -2853,7 +3394,10 @@ spec:
                                                                   description: The key of the secret to select from.  Must be a valid secret key.
                                                                   type: string
                                                                 name:
-                                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                                  description: |-
+                                                                    Name of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                                   type: string
                                                                 optional:
                                                                   description: Specify whether the Secret or its key must be defined
@@ -2873,7 +3417,10 @@ spec:
                                                               description: The key of the secret to select from.  Must be a valid secret key.
                                                               type: string
                                                             name:
-                                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                              description: |-
+                                                                Name of the referent.
+                                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                                               type: string
                                                             optional:
                                                               description: Specify whether the Secret or its key must be defined
@@ -2907,13 +3454,17 @@ spec:
                                           webhookConfigs:
                                             description: List of webhook configurations.
                                             items:
-                                              description: WebhookConfig configures notifications via a generic receiver supporting the webhook payload. See https://prometheus.io/docs/alerting/latest/configuration/#webhook_config
+                                              description: |-
+                                                WebhookConfig configures notifications via a generic receiver supporting the webhook payload.
+                                                See https://prometheus.io/docs/alerting/latest/configuration/#webhook_config
                                               properties:
                                                 httpConfig:
                                                   description: HTTP client configuration.
                                                   properties:
                                                     authorization:
-                                                      description: Authorization header configuration for the client. This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
+                                                      description: |-
+                                                        Authorization header configuration for the client.
+                                                        This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
                                                       properties:
                                                         credentials:
                                                           description: The secret's key that contains the credentials of the request
@@ -2922,7 +3473,10 @@ spec:
                                                               description: The key of the secret to select from.  Must be a valid secret key.
                                                               type: string
                                                             name:
-                                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                              description: |-
+                                                                Name of the referent.
+                                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                                               type: string
                                                             optional:
                                                               description: Specify whether the Secret or its key must be defined
@@ -2932,20 +3486,29 @@ spec:
                                                           type: object
                                                           x-kubernetes-map-type: atomic
                                                         type:
-                                                          description: Set the authentication type. Defaults to Bearer, Basic will cause an error
+                                                          description: |-
+                                                            Set the authentication type. Defaults to Bearer, Basic will cause an
+                                                            error
                                                           type: string
                                                       type: object
                                                     basicAuth:
-                                                      description: BasicAuth for the client. This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
+                                                      description: |-
+                                                        BasicAuth for the client.
+                                                        This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
                                                       properties:
                                                         password:
-                                                          description: The secret in the service monitor namespace that contains the password for authentication.
+                                                          description: |-
+                                                            The secret in the service monitor namespace that contains the password
+                                                            for authentication.
                                                           properties:
                                                             key:
                                                               description: The key of the secret to select from.  Must be a valid secret key.
                                                               type: string
                                                             name:
-                                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                              description: |-
+                                                                Name of the referent.
+                                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                                               type: string
                                                             optional:
                                                               description: Specify whether the Secret or its key must be defined
@@ -2955,13 +3518,18 @@ spec:
                                                           type: object
                                                           x-kubernetes-map-type: atomic
                                                         username:
-                                                          description: The secret in the service monitor namespace that contains the username for authentication.
+                                                          description: |-
+                                                            The secret in the service monitor namespace that contains the username
+                                                            for authentication.
                                                           properties:
                                                             key:
                                                               description: The key of the secret to select from.  Must be a valid secret key.
                                                               type: string
                                                             name:
-                                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                              description: |-
+                                                                Name of the referent.
+                                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                                               type: string
                                                             optional:
                                                               description: Specify whether the Secret or its key must be defined
@@ -2972,13 +3540,20 @@ spec:
                                                           x-kubernetes-map-type: atomic
                                                       type: object
                                                     bearerTokenSecret:
-                                                      description: The secret's key that contains the bearer token to be used by the client for authentication. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.
+                                                      description: |-
+                                                        The secret's key that contains the bearer token to be used by the client
+                                                        for authentication.
+                                                        The secret needs to be in the same namespace as the AlertmanagerConfig
+                                                        object and accessible by the Prometheus Operator.
                                                       properties:
                                                         key:
                                                           description: The key of the secret to select from.  Must be a valid secret key.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the Secret or its key must be defined
@@ -3003,7 +3578,10 @@ spec:
                                                                   description: The key to select.
                                                                   type: string
                                                                 name:
-                                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                                  description: |-
+                                                                    Name of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                                   type: string
                                                                 optional:
                                                                   description: Specify whether the ConfigMap or its key must be defined
@@ -3019,7 +3597,10 @@ spec:
                                                                   description: The key of the secret to select from.  Must be a valid secret key.
                                                                   type: string
                                                                 name:
-                                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                                  description: |-
+                                                                    Name of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                                   type: string
                                                                 optional:
                                                                   description: Specify whether the Secret or its key must be defined
@@ -3036,7 +3617,10 @@ spec:
                                                               description: The key of the secret to select from.  Must be a valid secret key.
                                                               type: string
                                                             name:
-                                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                              description: |-
+                                                                Name of the referent.
+                                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                                               type: string
                                                             optional:
                                                               description: Specify whether the Secret or its key must be defined
@@ -3080,7 +3664,10 @@ spec:
                                                                   description: The key to select.
                                                                   type: string
                                                                 name:
-                                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                                  description: |-
+                                                                    Name of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                                   type: string
                                                                 optional:
                                                                   description: Specify whether the ConfigMap or its key must be defined
@@ -3096,7 +3683,10 @@ spec:
                                                                   description: The key of the secret to select from.  Must be a valid secret key.
                                                                   type: string
                                                                 name:
-                                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                                  description: |-
+                                                                    Name of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                                   type: string
                                                                 optional:
                                                                   description: Specify whether the Secret or its key must be defined
@@ -3116,7 +3706,10 @@ spec:
                                                                   description: The key to select.
                                                                   type: string
                                                                 name:
-                                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                                  description: |-
+                                                                    Name of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                                   type: string
                                                                 optional:
                                                                   description: Specify whether the ConfigMap or its key must be defined
@@ -3132,7 +3725,10 @@ spec:
                                                                   description: The key of the secret to select from.  Must be a valid secret key.
                                                                   type: string
                                                                 name:
-                                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                                  description: |-
+                                                                    Name of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                                   type: string
                                                                 optional:
                                                                   description: Specify whether the Secret or its key must be defined
@@ -3152,7 +3748,10 @@ spec:
                                                               description: The key of the secret to select from.  Must be a valid secret key.
                                                               type: string
                                                             name:
-                                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                              description: |-
+                                                                Name of the referent.
+                                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                                               type: string
                                                             optional:
                                                               description: Specify whether the Secret or its key must be defined
@@ -3175,16 +3774,26 @@ spec:
                                                   description: Whether or not to notify about resolved alerts.
                                                   type: boolean
                                                 url:
-                                                  description: The URL to send HTTP POST requests to. `urlSecret` takes precedence over `url`. One of `urlSecret` and `url` should be defined.
+                                                  description: |-
+                                                    The URL to send HTTP POST requests to. `urlSecret` takes precedence over
+                                                    `url`. One of `urlSecret` and `url` should be defined.
                                                   type: string
                                                 urlSecret:
-                                                  description: The secret's key that contains the webhook URL to send HTTP requests to. `urlSecret` takes precedence over `url`. One of `urlSecret` and `url` should be defined. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.
+                                                  description: |-
+                                                    The secret's key that contains the webhook URL to send HTTP requests to.
+                                                    `urlSecret` takes precedence over `url`. One of `urlSecret` and `url`
+                                                    should be defined.
+                                                    The secret needs to be in the same namespace as the AlertmanagerConfig
+                                                    object and accessible by the Prometheus Operator.
                                                   properties:
                                                     key:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -3198,18 +3807,26 @@ spec:
                                           wechatConfigs:
                                             description: List of WeChat configurations.
                                             items:
-                                              description: WeChatConfig configures notifications via WeChat. See https://prometheus.io/docs/alerting/latest/configuration/#wechat_config
+                                              description: |-
+                                                WeChatConfig configures notifications via WeChat.
+                                                See https://prometheus.io/docs/alerting/latest/configuration/#wechat_config
                                               properties:
                                                 agentID:
                                                   type: string
                                                 apiSecret:
-                                                  description: The secret's key that contains the WeChat API key. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.
+                                                  description: |-
+                                                    The secret's key that contains the WeChat API key.
+                                                    The secret needs to be in the same namespace as the AlertmanagerConfig
+                                                    object and accessible by the Prometheus Operator.
                                                   properties:
                                                     key:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -3228,7 +3845,9 @@ spec:
                                                   description: HTTP client configuration.
                                                   properties:
                                                     authorization:
-                                                      description: Authorization header configuration for the client. This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
+                                                      description: |-
+                                                        Authorization header configuration for the client.
+                                                        This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
                                                       properties:
                                                         credentials:
                                                           description: The secret's key that contains the credentials of the request
@@ -3237,7 +3856,10 @@ spec:
                                                               description: The key of the secret to select from.  Must be a valid secret key.
                                                               type: string
                                                             name:
-                                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                              description: |-
+                                                                Name of the referent.
+                                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                                               type: string
                                                             optional:
                                                               description: Specify whether the Secret or its key must be defined
@@ -3247,20 +3869,29 @@ spec:
                                                           type: object
                                                           x-kubernetes-map-type: atomic
                                                         type:
-                                                          description: Set the authentication type. Defaults to Bearer, Basic will cause an error
+                                                          description: |-
+                                                            Set the authentication type. Defaults to Bearer, Basic will cause an
+                                                            error
                                                           type: string
                                                       type: object
                                                     basicAuth:
-                                                      description: BasicAuth for the client. This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
+                                                      description: |-
+                                                        BasicAuth for the client.
+                                                        This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
                                                       properties:
                                                         password:
-                                                          description: The secret in the service monitor namespace that contains the password for authentication.
+                                                          description: |-
+                                                            The secret in the service monitor namespace that contains the password
+                                                            for authentication.
                                                           properties:
                                                             key:
                                                               description: The key of the secret to select from.  Must be a valid secret key.
                                                               type: string
                                                             name:
-                                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                              description: |-
+                                                                Name of the referent.
+                                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                                               type: string
                                                             optional:
                                                               description: Specify whether the Secret or its key must be defined
@@ -3270,13 +3901,18 @@ spec:
                                                           type: object
                                                           x-kubernetes-map-type: atomic
                                                         username:
-                                                          description: The secret in the service monitor namespace that contains the username for authentication.
+                                                          description: |-
+                                                            The secret in the service monitor namespace that contains the username
+                                                            for authentication.
                                                           properties:
                                                             key:
                                                               description: The key of the secret to select from.  Must be a valid secret key.
                                                               type: string
                                                             name:
-                                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                              description: |-
+                                                                Name of the referent.
+                                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                                               type: string
                                                             optional:
                                                               description: Specify whether the Secret or its key must be defined
@@ -3287,13 +3923,20 @@ spec:
                                                           x-kubernetes-map-type: atomic
                                                       type: object
                                                     bearerTokenSecret:
-                                                      description: The secret's key that contains the bearer token to be used by the client for authentication. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.
+                                                      description: |-
+                                                        The secret's key that contains the bearer token to be used by the client
+                                                        for authentication.
+                                                        The secret needs to be in the same namespace as the AlertmanagerConfig
+                                                        object and accessible by the Prometheus Operator.
                                                       properties:
                                                         key:
                                                           description: The key of the secret to select from.  Must be a valid secret key.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the Secret or its key must be defined
@@ -3318,7 +3961,10 @@ spec:
                                                                   description: The key to select.
                                                                   type: string
                                                                 name:
-                                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                                  description: |-
+                                                                    Name of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                                   type: string
                                                                 optional:
                                                                   description: Specify whether the ConfigMap or its key must be defined
@@ -3334,7 +3980,10 @@ spec:
                                                                   description: The key of the secret to select from.  Must be a valid secret key.
                                                                   type: string
                                                                 name:
-                                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                                  description: |-
+                                                                    Name of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                                   type: string
                                                                 optional:
                                                                   description: Specify whether the Secret or its key must be defined
@@ -3351,7 +4000,10 @@ spec:
                                                               description: The key of the secret to select from.  Must be a valid secret key.
                                                               type: string
                                                             name:
-                                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                              description: |-
+                                                                Name of the referent.
+                                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                                               type: string
                                                             optional:
                                                               description: Specify whether the Secret or its key must be defined
@@ -3395,7 +4047,10 @@ spec:
                                                                   description: The key to select.
                                                                   type: string
                                                                 name:
-                                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                                  description: |-
+                                                                    Name of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                                   type: string
                                                                 optional:
                                                                   description: Specify whether the ConfigMap or its key must be defined
@@ -3411,7 +4066,10 @@ spec:
                                                                   description: The key of the secret to select from.  Must be a valid secret key.
                                                                   type: string
                                                                 name:
-                                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                                  description: |-
+                                                                    Name of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                                   type: string
                                                                 optional:
                                                                   description: Specify whether the Secret or its key must be defined
@@ -3431,7 +4089,10 @@ spec:
                                                                   description: The key to select.
                                                                   type: string
                                                                 name:
-                                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                                  description: |-
+                                                                    Name of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                                   type: string
                                                                 optional:
                                                                   description: Specify whether the ConfigMap or its key must be defined
@@ -3447,7 +4108,10 @@ spec:
                                                                   description: The key of the secret to select from.  Must be a valid secret key.
                                                                   type: string
                                                                 name:
-                                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                                  description: |-
+                                                                    Name of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                                   type: string
                                                                 optional:
                                                                   description: Specify whether the Secret or its key must be defined
@@ -3467,7 +4131,10 @@ spec:
                                                               description: The key of the secret to select from.  Must be a valid secret key.
                                                               type: string
                                                             name:
-                                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                              description: |-
+                                                                Name of the referent.
+                                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                                               type: string
                                                             optional:
                                                               description: Specify whether the Secret or its key must be defined
@@ -3502,7 +4169,10 @@ spec:
                                         type: object
                                       type: array
                                     route:
-                                      description: The Alertmanager route definition for alerts matching the resource's namespace. If present, it will be added to the generated Alertmanager configuration as a first-level route.
+                                      description: |-
+                                        The Alertmanager route definition for alerts matching the resource's
+                                        namespace. If present, it will be added to the generated Alertmanager
+                                        configuration as a first-level route.
                                       properties:
                                         activeTimeIntervals:
                                           description: ActiveTimeIntervals is a list of MuteTimeInterval names when this route should be active.
@@ -3510,26 +4180,44 @@ spec:
                                             type: string
                                           type: array
                                         continue:
-                                          description: Boolean indicating whether an alert should continue matching subsequent sibling nodes. It will always be overridden to true for the first-level route by the Prometheus operator.
+                                          description: |-
+                                            Boolean indicating whether an alert should continue matching subsequent
+                                            sibling nodes. It will always be overridden to true for the first-level
+                                            route by the Prometheus operator.
                                           type: boolean
                                         groupBy:
-                                          description: List of labels to group by. Labels must not be repeated (unique list). Special label "..." (aggregate by all possible labels), if provided, must be the only element in the list.
+                                          description: |-
+                                            List of labels to group by.
+                                            Labels must not be repeated (unique list).
+                                            Special label "..." (aggregate by all possible labels), if provided, must be the only element in the list.
                                           items:
                                             type: string
                                           type: array
                                         groupInterval:
-                                          description: 'How long to wait before sending an updated notification. Must match the regular expression`^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$` Example: "5m"'
+                                          description: |-
+                                            How long to wait before sending an updated notification.
+                                            Must match the regular expression`^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$`
+                                            Example: "5m"
                                           type: string
                                         groupWait:
-                                          description: 'How long to wait before sending the initial notification. Must match the regular expression`^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$` Example: "30s"'
+                                          description: |-
+                                            How long to wait before sending the initial notification.
+                                            Must match the regular expression`^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$`
+                                            Example: "30s"
                                           type: string
                                         matchers:
-                                          description: 'List of matchers that the alert''s labels should match. For the first level route, the operator removes any existing equality and regexp matcher on the `namespace` label and adds a `namespace: <object namespace>` matcher.'
+                                          description: |-
+                                            List of matchers that the alert's labels should match. For the first
+                                            level route, the operator removes any existing equality and regexp
+                                            matcher on the `namespace` label and adds a `namespace: <object
+                                            namespace>` matcher.
                                           items:
                                             description: Matcher defines how to match on alert's labels.
                                             properties:
                                               matchType:
-                                                description: Match operation available with AlertManager >= v0.22.0 and takes precedence over Regex (deprecated) if non-empty.
+                                                description: |-
+                                                  Match operation available with AlertManager >= v0.22.0 and
+                                                  takes precedence over Regex (deprecated) if non-empty.
                                                 enum:
                                                   - '!='
                                                   - "="
@@ -3541,7 +4229,9 @@ spec:
                                                 minLength: 1
                                                 type: string
                                               regex:
-                                                description: Whether to match on equality (false) or regular-expression (true). Deprecated as of AlertManager >= v0.22.0 where a user should use MatchType instead.
+                                                description: |-
+                                                  Whether to match on equality (false) or regular-expression (true).
+                                                  Deprecated as of AlertManager >= v0.22.0 where a user should use MatchType instead.
                                                 type: boolean
                                               value:
                                                 description: Label value to match.
@@ -3551,15 +4241,28 @@ spec:
                                             type: object
                                           type: array
                                         muteTimeIntervals:
-                                          description: 'Note: this comment applies to the field definition above but appears below otherwise it gets included in the generated manifest. CRD schema doesn''t support self-referential types for now (see https://github.com/kubernetes/kubernetes/issues/62872). We have to use an alternative type to circumvent the limitation. The downside is that the Kube API can''t validate the data beyond the fact that it is a valid JSON representation. MuteTimeIntervals is a list of MuteTimeInterval names that will mute this route when matched,'
+                                          description: |-
+                                            Note: this comment applies to the field definition above but appears
+                                            below otherwise it gets included in the generated manifest.
+                                            CRD schema doesn't support self-referential types for now (see
+                                            https://github.com/kubernetes/kubernetes/issues/62872). We have to use
+                                            an alternative type to circumvent the limitation. The downside is that
+                                            the Kube API can't validate the data beyond the fact that it is a valid
+                                            JSON representation.
+                                            MuteTimeIntervals is a list of MuteTimeInterval names that will mute this route when matched,
                                           items:
                                             type: string
                                           type: array
                                         receiver:
-                                          description: Name of the receiver for this route. If not empty, it should be listed in the `receivers` field.
+                                          description: |-
+                                            Name of the receiver for this route. If not empty, it should be listed in
+                                            the `receivers` field.
                                           type: string
                                         repeatInterval:
-                                          description: 'How long to wait before repeating the last notification. Must match the regular expression`^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$` Example: "4h"'
+                                          description: |-
+                                            How long to wait before repeating the last notification.
+                                            Must match the regular expression`^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$`
+                                            Example: "4h"
                                           type: string
                                         routes:
                                           description: Child routes.
@@ -3578,23 +4281,52 @@ spec:
                                 ipFilter:
                                   default:
                                     - 0.0.0.0/0
-                                  description: IPFilter is a list of allowed IPv4 CIDR ranges that can access the service. If no IP Filter is set, you may not be able to reach the service. A value of `0.0.0.0/0` will open the service to all addresses on the public internet.
+                                  description: |-
+                                    IPFilter is a list of allowed IPv4 CIDR ranges that can access the service.
+                                    If no IP Filter is set, you may not be able to reach the service.
+                                    A value of `0.0.0.0/0` will open the service to all addresses on the public internet.
                                   items:
                                     type: string
                                   type: array
                                 serviceType:
                                   default: ClusterIP
-                                  description: 'ServiceType defines the type of the service. Possible enum values: - `"ClusterIP"` indicates that the service is only reachable from within the cluster. - `"LoadBalancer"` indicates that the service is reachable from the public internet via dedicated Ipv4 address.'
+                                  description: |-
+                                    ServiceType defines the type of the service.
+                                    Possible enum values:
+                                      - `"ClusterIP"` indicates that the service is only reachable from within the cluster.
+                                      - `"LoadBalancer"` indicates that the service is reachable from the public internet via dedicated Ipv4 address.
                                   enum:
                                     - ClusterIP
                                     - LoadBalancer
                                   type: string
                               type: object
                             replication:
-                              description: "This section allows to configure Postgres replication mode and HA roles groups. \n The main replication group is implicit and contains the total number of instances less the sum of all instances in other replication groups."
+                              description: |-
+                                This section allows to configure Postgres replication mode and HA roles groups.
+
+
+                                The main replication group is implicit and contains the total number of instances less the sum of all instances in other replication groups.
                               properties:
                                 mode:
-                                  description: "Mode defines the replication mode applied to the whole cluster. Possible values are: \"async\"(default), \"sync\", and \"strict-sync\" \n \"async\": When in asynchronous mode the cluster is allowed to lose some committed transactions. When the primary server fails or becomes unavailable for any other reason a sufficiently healthy standby will automatically be promoted to primary. Any transactions that have not been replicated to that standby remain in a “forked timeline” on the primary, and are effectively unrecoverable \n \"sync\": When in synchronous mode a standby will not be promoted unless it is certain that the standby contains all transactions that may have returned a successful commit status to client. This means that the system may be unavailable for writes even though some servers are available. \n \"strict-sync\": When it is absolutely necessary to guarantee that each write is stored durably on at least two nodes, use the strict synchronous mode. This mode prevents synchronous replication to be switched off on the primary when no synchronous standby candidates are available. As a downside, the primary will not be available for writes, blocking all client write requests until at least one synchronous replica comes up. \n NOTE: We recommend to always use three intances when setting the mode to \"strict-sync\"."
+                                  description: |-
+                                    Mode defines the replication mode applied to the whole cluster. Possible values are: "async"(default), "sync", and "strict-sync"
+
+
+                                    "async": When in asynchronous mode the cluster is allowed to lose some committed transactions.
+                                    When the primary server fails or becomes unavailable for any other reason a sufficiently healthy standby will automatically be promoted to primary.
+                                    Any transactions that have not been replicated to that standby remain in a “forked timeline” on the primary, and are effectively unrecoverable
+
+
+                                    "sync": When in synchronous mode a standby will not be promoted unless it is certain that the standby contains all transactions that may have returned a successful commit status to client.
+                                     This means that the system may be unavailable for writes even though some servers are available.
+
+
+                                    "strict-sync": When it is absolutely necessary to guarantee that each write is stored durably on at least two nodes, use the strict synchronous mode.
+                                    This mode prevents synchronous replication to be switched off on the primary when no synchronous standby candidates are available.
+                                    As a downside, the primary will not be available for writes, blocking all client write requests until at least one synchronous replica comes up.
+
+
+                                    NOTE: We recommend to always use three intances when setting the mode to "strict-sync".
                                   enum:
                                     - async
                                     - sync
@@ -3608,10 +4340,14 @@ spec:
                                   description: BackupName is the name of the specific backup you want to restore.
                                   type: string
                                 claimName:
-                                  description: ClaimName specifies the name of the instance you want to restore from. The claim has to be in the same namespace as this new instance.
+                                  description: |-
+                                    ClaimName specifies the name of the instance you want to restore from.
+                                    The claim has to be in the same namespace as this new instance.
                                   type: string
                                 recoveryTimeStamp:
-                                  description: RecoveryTimeStamp an ISO 8601 date, that holds UTC date indicating at which point-in-time the database has to be restored. This is optional and if no PIT recovery is required, it can be left empty.
+                                  description: |-
+                                    RecoveryTimeStamp an ISO 8601 date, that holds UTC date indicating at which point-in-time the database has to be restored.
+                                    This is optional and if no PIT recovery is required, it can be left empty.
                                   pattern: ^(?:[1-9]\d{3}-(?:(?:0[1-9]|1[0-2])-(?:0[1-9]|1\d|2[0-8])|(?:0[13-9]|1[0-2])-(?:29|30)|(?:0[13578]|1[02])-31)|(?:[1-9]\d(?:0[48]|[2468][048]|[13579][26])|(?:[2468][048]|[13579][26])00)-02-29)T(?:[01]\d|2[0-3]):[0-5]\d:[0-5]\d(?:Z|[+-][01]\d:[0-5]\d)$
                                   type: string
                               type: object
@@ -3633,13 +4369,17 @@ spec:
                                     description: VSHNDBaaSPostgresExtension contains the name of a single extension.
                                     properties:
                                       name:
-                                        description: Name is the name of the extension to enable. For an extensive list, please consult https://stackgres.io/doc/latest/intro/extensions/
+                                        description: |-
+                                          Name is the name of the extension to enable.
+                                          For an extensive list, please consult https://stackgres.io/doc/latest/intro/extensions/
                                         type: string
                                     type: object
                                   type: array
                                 majorVersion:
                                   default: "15"
-                                  description: MajorVersion contains supported version of PostgreSQL. Multiple versions are supported. The latest version "15" is the default version.
+                                  description: |-
+                                    MajorVersion contains supported version of PostgreSQL.
+                                    Multiple versions are supported. The latest version "15" is the default version.
                                   enum:
                                     - "12"
                                     - "13"
@@ -3650,15 +4390,27 @@ spec:
                                   description: PgBouncerSettings passes additional configuration to the pgBouncer instance.
                                   properties:
                                     databases:
-                                      description: "The `pgbouncer.ini` (Section [databases]) parameters the configuration contains, represented as an object where the keys are valid names for the `pgbouncer.ini` configuration file parameters. \n Check [pgbouncer configuration](https://www.pgbouncer.org/config.html#section-databases) for more information about supported parameters."
+                                      description: |-
+                                        The `pgbouncer.ini` (Section [databases]) parameters the configuration contains, represented as an object where the keys are valid names for the `pgbouncer.ini` configuration file parameters.
+
+
+                                        Check [pgbouncer configuration](https://www.pgbouncer.org/config.html#section-databases) for more information about supported parameters.
                                       type: object
                                       x-kubernetes-preserve-unknown-fields: true
                                     pgbouncer:
-                                      description: "The `pgbouncer.ini` (Section [pgbouncer]) parameters the configuration contains, represented as an object where the keys are valid names for the `pgbouncer.ini` configuration file parameters. \n Check [pgbouncer configuration](https://www.pgbouncer.org/config.html#generic-settings) for more information about supported parameters"
+                                      description: |-
+                                        The `pgbouncer.ini` (Section [pgbouncer]) parameters the configuration contains, represented as an object where the keys are valid names for the `pgbouncer.ini` configuration file parameters.
+
+
+                                        Check [pgbouncer configuration](https://www.pgbouncer.org/config.html#generic-settings) for more information about supported parameters
                                       type: object
                                       x-kubernetes-preserve-unknown-fields: true
                                     users:
-                                      description: "The `pgbouncer.ini` (Section [users]) parameters the configuration contains, represented as an object where the keys are valid names for the `pgbouncer.ini` configuration file parameters. \n Check [pgbouncer configuration](https://www.pgbouncer.org/config.html#section-users) for more information about supported parameters."
+                                      description: |-
+                                        The `pgbouncer.ini` (Section [users]) parameters the configuration contains, represented as an object where the keys are valid names for the `pgbouncer.ini` configuration file parameters.
+
+
+                                        Check [pgbouncer configuration](https://www.pgbouncer.org/config.html#section-users) for more information about supported parameters.
                                       type: object
                                       x-kubernetes-preserve-unknown-fields: true
                                   type: object
@@ -3705,7 +4457,11 @@ spec:
                               properties:
                                 type:
                                   default: Immediate
-                                  description: 'Type indicates the type of the UpdateStrategy. Default is OnRestart. Possible enum values: - `"OnRestart"` indicates that the changes to the spec will only be applied once the instance is restarted by other means, most likely during maintenance. - `"Immediate"` indicates that update will be applied to the instance as soon as the spec changes. Please be aware that this might lead to short downtime.'
+                                  description: |-
+                                    Type indicates the type of the UpdateStrategy. Default is OnRestart.
+                                    Possible enum values:
+                                      - `"OnRestart"` indicates that the changes to the spec will only be applied once the instance is restarted by other means, most likely during maintenance.
+                                      - `"Immediate"` indicates that update will be applied to the instance as soon as the spec changes. Please be aware that this might lead to short downtime.
                                   enum:
                                     - Immediate
                                     - OnRestart
@@ -3726,7 +4482,9 @@ spec:
                           type: string
                         version:
                           default: "23"
-                          description: Version contains supported version of keycloak. Multiple versions are supported. The latest version 23 is the default version.
+                          description: |-
+                            Version contains supported version of keycloak.
+                            Multiple versions are supported. The latest version 23 is the default version.
                           enum:
                             - "23"
                           type: string
@@ -3778,7 +4536,9 @@ spec:
                   description: WriteConnectionSecretToRef references a secret to which the connection details will be written.
                   properties:
                     name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      description: |-
+                        Name of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                       type: string
                     namespace:
                       type: string
@@ -3800,7 +4560,9 @@ spec:
                         maxLength: 32768
                         type: string
                       observedGeneration:
-                        description: ObservedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        description: |-
+                          ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                         format: int64
                         minimum: 0
                         type: integer
@@ -3835,7 +4597,9 @@ spec:
                         maxLength: 32768
                         type: string
                       observedGeneration:
-                        description: ObservedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        description: |-
+                          ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                         format: int64
                         minimum: 0
                         type: integer
@@ -3873,7 +4637,9 @@ spec:
                         maxLength: 32768
                         type: string
                       observedGeneration:
-                        description: ObservedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        description: |-
+                          ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                         format: int64
                         minimum: 0
                         type: integer
@@ -3908,7 +4674,9 @@ spec:
                         maxLength: 32768
                         type: string
                       observedGeneration:
-                        description: ObservedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        description: |-
+                          ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                         format: int64
                         minimum: 0
                         type: integer
@@ -3932,7 +4700,9 @@ spec:
                     type: object
                   type: array
                 schedules:
-                  description: Schedules keeps track of random generated schedules, is overwriten by schedules set in the service's spec.
+                  description: |-
+                    Schedules keeps track of random generated schedules, is overwriten by
+                    schedules set in the service's spec.
                   properties:
                     backup:
                       description: Backup keeps track of the backup schedule.
@@ -3941,7 +4711,9 @@ spec:
                       description: Maintenance keeps track of the maintenance schedule.
                       properties:
                         dayOfWeek:
-                          description: DayOfWeek specifies at which weekday the maintenance is held place. Allowed values are [monday, tuesday, wednesday, thursday, friday, saturday, sunday]
+                          description: |-
+                            DayOfWeek specifies at which weekday the maintenance is held place.
+                            Allowed values are [monday, tuesday, wednesday, thursday, friday, saturday, sunday]
                           enum:
                             - monday
                             - tuesday
@@ -3952,7 +4724,9 @@ spec:
                             - sunday
                           type: string
                         timeOfDay:
-                          description: 'TimeOfDay for installing updates in UTC. Format: "hh:mm:ss".'
+                          description: |-
+                            TimeOfDay for installing updates in UTC.
+                            Format: "hh:mm:ss".
                           pattern: ^([0-1]?[0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9])$
                           type: string
                       type: object
@@ -3969,7 +4743,9 @@ spec:
                         maxLength: 32768
                         type: string
                       observedGeneration:
-                        description: ObservedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        description: |-
+                          ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                         format: int64
                         minimum: 0
                         type: integer
@@ -4004,7 +4780,9 @@ spec:
                         maxLength: 32768
                         type: string
                       observedGeneration:
-                        description: ObservedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        description: |-
+                          ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                         format: int64
                         minimum: 0
                         type: integer

--- a/crds/vshn.appcat.vshn.io_vshnmariadbs.yaml
+++ b/crds/vshn.appcat.vshn.io_vshnmariadbs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: vshnmariadbs.vshn.appcat.vshn.io
 spec:
   group: vshn.appcat.vshn.io
@@ -20,10 +20,19 @@ spec:
           description: VSHNMariaDB is the API for creating MariaDB instances.
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -62,7 +71,9 @@ spec:
                       description: Maintenance contains settings to control the maintenance of an instance.
                       properties:
                         dayOfWeek:
-                          description: DayOfWeek specifies at which weekday the maintenance is held place. Allowed values are [monday, tuesday, wednesday, thursday, friday, saturday, sunday]
+                          description: |-
+                            DayOfWeek specifies at which weekday the maintenance is held place.
+                            Allowed values are [monday, tuesday, wednesday, thursday, friday, saturday, sunday]
                           enum:
                             - monday
                             - tuesday
@@ -73,7 +84,9 @@ spec:
                             - sunday
                           type: string
                         timeOfDay:
-                          description: 'TimeOfDay for installing updates in UTC. Format: "hh:mm:ss".'
+                          description: |-
+                            TimeOfDay for installing updates in UTC.
+                            Format: "hh:mm:ss".
                           pattern: ^([0-1]?[0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9])$
                           type: string
                       type: object
@@ -84,7 +97,9 @@ spec:
                           description: BackupName is the name of the specific backup you want to restore.
                           type: string
                         claimName:
-                          description: ClaimName specifies the name of the instance you want to restore from. The claim has to be in the same namespace as this new instance.
+                          description: |-
+                            ClaimName specifies the name of the instance you want to restore from.
+                            The claim has to be in the same namespace as this new instance.
                           type: string
                       type: object
                     scheduling:
@@ -111,7 +126,9 @@ spec:
                           type: string
                         version:
                           default: "11.2"
-                          description: Version contains supported version of MariaDB. Multiple versions are supported. The latest version "11.2" is the default version.
+                          description: |-
+                            Version contains supported version of MariaDB.
+                            Multiple versions are supported. The latest version "11.2" is the default version.
                           enum:
                             - "10.4"
                             - "10.5"
@@ -174,7 +191,9 @@ spec:
                   description: WriteConnectionSecretToRef references a secret to which the connection details will be written.
                   properties:
                     name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      description: |-
+                        Name of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                       type: string
                     namespace:
                       type: string
@@ -196,7 +215,9 @@ spec:
                         maxLength: 32768
                         type: string
                       observedGeneration:
-                        description: ObservedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        description: |-
+                          ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                         format: int64
                         minimum: 0
                         type: integer
@@ -231,7 +252,9 @@ spec:
                         maxLength: 32768
                         type: string
                       observedGeneration:
-                        description: ObservedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        description: |-
+                          ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                         format: int64
                         minimum: 0
                         type: integer
@@ -269,7 +292,9 @@ spec:
                         maxLength: 32768
                         type: string
                       observedGeneration:
-                        description: ObservedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        description: |-
+                          ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                         format: int64
                         minimum: 0
                         type: integer
@@ -304,7 +329,9 @@ spec:
                         maxLength: 32768
                         type: string
                       observedGeneration:
-                        description: ObservedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        description: |-
+                          ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                         format: int64
                         minimum: 0
                         type: integer
@@ -328,7 +355,9 @@ spec:
                     type: object
                   type: array
                 schedules:
-                  description: Schedules keeps track of random generated schedules, is overwriten by schedules set in the service's spec.
+                  description: |-
+                    Schedules keeps track of random generated schedules, is overwriten by
+                    schedules set in the service's spec.
                   properties:
                     backup:
                       description: Backup keeps track of the backup schedule.
@@ -337,7 +366,9 @@ spec:
                       description: Maintenance keeps track of the maintenance schedule.
                       properties:
                         dayOfWeek:
-                          description: DayOfWeek specifies at which weekday the maintenance is held place. Allowed values are [monday, tuesday, wednesday, thursday, friday, saturday, sunday]
+                          description: |-
+                            DayOfWeek specifies at which weekday the maintenance is held place.
+                            Allowed values are [monday, tuesday, wednesday, thursday, friday, saturday, sunday]
                           enum:
                             - monday
                             - tuesday
@@ -348,7 +379,9 @@ spec:
                             - sunday
                           type: string
                         timeOfDay:
-                          description: 'TimeOfDay for installing updates in UTC. Format: "hh:mm:ss".'
+                          description: |-
+                            TimeOfDay for installing updates in UTC.
+                            Format: "hh:mm:ss".
                           pattern: ^([0-1]?[0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9])$
                           type: string
                       type: object
@@ -365,7 +398,9 @@ spec:
                         maxLength: 32768
                         type: string
                       observedGeneration:
-                        description: ObservedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        description: |-
+                          ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                         format: int64
                         minimum: 0
                         type: integer
@@ -400,7 +435,9 @@ spec:
                         maxLength: 32768
                         type: string
                       observedGeneration:
-                        description: ObservedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        description: |-
+                          ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                         format: int64
                         minimum: 0
                         type: integer

--- a/crds/vshn.appcat.vshn.io_vshnminios.yaml
+++ b/crds/vshn.appcat.vshn.io_vshnminios.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: vshnminios.vshn.appcat.vshn.io
 spec:
   group: vshn.appcat.vshn.io
@@ -20,10 +20,19 @@ spec:
           description: VSHNMinio is the API for creating Minio instances.
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -60,14 +69,18 @@ spec:
                       default: {}
                     instances:
                       default: 4
-                      description: Instances configures the number of Minio instances for the cluster. Each instance contains one Minio server.
+                      description: |-
+                        Instances configures the number of Minio instances for the cluster.
+                        Each instance contains one Minio server.
                       minimum: 4
                       type: integer
                     maintenance:
                       description: Maintenance contains settings to control the maintenance of an instance.
                       properties:
                         dayOfWeek:
-                          description: DayOfWeek specifies at which weekday the maintenance is held place. Allowed values are [monday, tuesday, wednesday, thursday, friday, saturday, sunday]
+                          description: |-
+                            DayOfWeek specifies at which weekday the maintenance is held place.
+                            Allowed values are [monday, tuesday, wednesday, thursday, friday, saturday, sunday]
                           enum:
                             - monday
                             - tuesday
@@ -78,7 +91,9 @@ spec:
                             - sunday
                           type: string
                         timeOfDay:
-                          description: 'TimeOfDay for installing updates in UTC. Format: "hh:mm:ss".'
+                          description: |-
+                            TimeOfDay for installing updates in UTC.
+                            Format: "hh:mm:ss".
                           pattern: ^([0-1]?[0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9])$
                           type: string
                       type: object
@@ -89,7 +104,9 @@ spec:
                           description: BackupName is the name of the specific backup you want to restore.
                           type: string
                         claimName:
-                          description: ClaimName specifies the name of the instance you want to restore from. The claim has to be in the same namespace as this new instance.
+                          description: |-
+                            ClaimName specifies the name of the instance you want to restore from.
+                            The claim has to be in the same namespace as this new instance.
                           type: string
                       type: object
                     service:
@@ -97,7 +114,9 @@ spec:
                       properties:
                         mode:
                           default: distributed
-                          description: Mode configures the mode of MinIO. Valid values are "distributed" and "standalone".
+                          description: |-
+                            Mode configures the mode of MinIO.
+                            Valid values are "distributed" and "standalone".
                           enum:
                             - distributed
                             - standalone
@@ -139,7 +158,9 @@ spec:
                   description: WriteConnectionSecretToRef references a secret to which the connection details will be written.
                   properties:
                     name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      description: |-
+                        Name of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                       type: string
                     namespace:
                       type: string
@@ -165,7 +186,9 @@ spec:
                         maxLength: 32768
                         type: string
                       observedGeneration:
-                        description: ObservedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        description: |-
+                          ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                         format: int64
                         minimum: 0
                         type: integer
@@ -189,7 +212,9 @@ spec:
                     type: object
                   type: array
                 schedules:
-                  description: Schedules keeps track of random generated schedules, is overwriten by schedules set in the service's spec.
+                  description: |-
+                    Schedules keeps track of random generated schedules, is overwriten by
+                    schedules set in the service's spec.
                   properties:
                     backup:
                       description: Backup keeps track of the backup schedule.
@@ -198,7 +223,9 @@ spec:
                       description: Maintenance keeps track of the maintenance schedule.
                       properties:
                         dayOfWeek:
-                          description: DayOfWeek specifies at which weekday the maintenance is held place. Allowed values are [monday, tuesday, wednesday, thursday, friday, saturday, sunday]
+                          description: |-
+                            DayOfWeek specifies at which weekday the maintenance is held place.
+                            Allowed values are [monday, tuesday, wednesday, thursday, friday, saturday, sunday]
                           enum:
                             - monday
                             - tuesday
@@ -209,7 +236,9 @@ spec:
                             - sunday
                           type: string
                         timeOfDay:
-                          description: 'TimeOfDay for installing updates in UTC. Format: "hh:mm:ss".'
+                          description: |-
+                            TimeOfDay for installing updates in UTC.
+                            Format: "hh:mm:ss".
                           pattern: ^([0-1]?[0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9])$
                           type: string
                       type: object

--- a/crds/vshn.appcat.vshn.io_vshnpostgresqls.yaml
+++ b/crds/vshn.appcat.vshn.io_vshnpostgresqls.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: vshnpostgresqls.vshn.appcat.vshn.io
 spec:
   group: vshn.appcat.vshn.io
@@ -20,10 +20,19 @@ spec:
           description: VSHNPostgreSQL is the API for creating Postgresql clusters.
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -32,7 +41,14 @@ spec:
               properties:
                 deletionPolicy:
                   default: Delete
-                  description: 'DeletionPolicy specifies what will happen to the underlying external when this managed resource is deleted - either "Delete" or "Orphan" the external resource. This field is planned to be deprecated in favor of the ManagementPolicies field in a future release. Currently, both could be set independently and non-default values would be honored if the feature flag is enabled. See the design doc for more information: https://github.com/crossplane/crossplane/blob/499895a25d1a1a0ba1604944ef98ac7a1a71f197/design/design-doc-observe-only-resources.md?plain=1#L223'
+                  description: |-
+                    DeletionPolicy specifies what will happen to the underlying external
+                    when this managed resource is deleted - either "Delete" or "Orphan" the
+                    external resource.
+                    This field is planned to be deprecated in favor of the ManagementPolicies
+                    field in a future release. Currently, both could be set independently and
+                    non-default values would be honored if the feature flag is enabled.
+                    See the design doc for more information: https://github.com/crossplane/crossplane/blob/499895a25d1a1a0ba1604944ef98ac7a1a71f197/design/design-doc-observe-only-resources.md?plain=1#L223
                   enum:
                     - Orphan
                     - Delete
@@ -40,9 +56,21 @@ spec:
                 managementPolicies:
                   default:
                     - '*'
-                  description: 'THIS IS A BETA FIELD. It is on by default but can be opted out through a Crossplane feature flag. ManagementPolicies specify the array of actions Crossplane is allowed to take on the managed and external resources. This field is planned to replace the DeletionPolicy field in a future release. Currently, both could be set independently and non-default values would be honored if the feature flag is enabled. If both are custom, the DeletionPolicy field will be ignored. See the design doc for more information: https://github.com/crossplane/crossplane/blob/499895a25d1a1a0ba1604944ef98ac7a1a71f197/design/design-doc-observe-only-resources.md?plain=1#L223 and this one: https://github.com/crossplane/crossplane/blob/444267e84783136daa93568b364a5f01228cacbe/design/one-pager-ignore-changes.md'
+                  description: |-
+                    THIS IS A BETA FIELD. It is on by default but can be opted out
+                    through a Crossplane feature flag.
+                    ManagementPolicies specify the array of actions Crossplane is allowed to
+                    take on the managed and external resources.
+                    This field is planned to replace the DeletionPolicy field in a future
+                    release. Currently, both could be set independently and non-default
+                    values would be honored if the feature flag is enabled. If both are
+                    custom, the DeletionPolicy field will be ignored.
+                    See the design doc for more information: https://github.com/crossplane/crossplane/blob/499895a25d1a1a0ba1604944ef98ac7a1a71f197/design/design-doc-observe-only-resources.md?plain=1#L223
+                    and this one: https://github.com/crossplane/crossplane/blob/444267e84783136daa93568b364a5f01228cacbe/design/one-pager-ignore-changes.md
                   items:
-                    description: A ManagementAction represents an action that the Crossplane controllers can take on an external resource.
+                    description: |-
+                      A ManagementAction represents an action that the Crossplane controllers
+                      can take on an external resource.
                     enum:
                       - Observe
                       - Create
@@ -60,11 +88,15 @@ spec:
                       properties:
                         deletionProtection:
                           default: true
-                          description: DeletionProtection will protect the instance from being deleted for the given retention time. This is enabled by default.
+                          description: |-
+                            DeletionProtection will protect the instance from being deleted for the given retention time.
+                            This is enabled by default.
                           type: boolean
                         deletionRetention:
                           default: 7
-                          description: DeletionRetention specifies in days how long the instance should be kept after deletion. The default is keeping it one week.
+                          description: |-
+                            DeletionRetention specifies in days how long the instance should be kept after deletion.
+                            The default is keeping it one week.
                           type: integer
                         retention:
                           default: 6
@@ -85,7 +117,10 @@ spec:
                       type: object
                     instances:
                       default: 1
-                      description: Instances configures the number of PostgreSQL instances for the cluster. Each instance contains one Postgres server. Out of all Postgres servers, one is elected as the primary, the rest remain as read-only replicas.
+                      description: |-
+                        Instances configures the number of PostgreSQL instances for the cluster.
+                        Each instance contains one Postgres server.
+                        Out of all Postgres servers, one is elected as the primary, the rest remain as read-only replicas.
                       maximum: 3
                       minimum: 1
                       type: integer
@@ -93,7 +128,9 @@ spec:
                       description: Maintenance contains settings to control the maintenance of an instance.
                       properties:
                         dayOfWeek:
-                          description: DayOfWeek specifies at which weekday the maintenance is held place. Allowed values are [monday, tuesday, wednesday, thursday, friday, saturday, sunday]
+                          description: |-
+                            DayOfWeek specifies at which weekday the maintenance is held place.
+                            Allowed values are [monday, tuesday, wednesday, thursday, friday, saturday, sunday]
                           enum:
                             - monday
                             - tuesday
@@ -104,7 +141,9 @@ spec:
                             - sunday
                           type: string
                         timeOfDay:
-                          description: 'TimeOfDay for installing updates in UTC. Format: "hh:mm:ss".'
+                          description: |-
+                            TimeOfDay for installing updates in UTC.
+                            Format: "hh:mm:ss".
                           pattern: ^([0-1]?[0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9])$
                           type: string
                       type: object
@@ -113,31 +152,49 @@ spec:
                       description: Monitoring contains settings to control monitoring.
                       properties:
                         alertmanagerConfigRef:
-                          description: AlertmanagerConfigRef contains the name of the AlertmanagerConfig that should be copied over to the namespace of the instance.
+                          description: |-
+                            AlertmanagerConfigRef contains the name of the AlertmanagerConfig that should be copied over to the
+                            namespace of the instance.
                           type: string
                         alertmanagerConfigSecretRef:
-                          description: AlertmanagerConfigSecretRef contains the name of the secret that is used in the referenced AlertmanagerConfig
+                          description: |-
+                            AlertmanagerConfigSecretRef contains the name of the secret that is used
+                            in the referenced AlertmanagerConfig
                           type: string
                         alertmanagerConfigTemplate:
-                          description: AlertmanagerConfigSpecTemplate takes an AlertmanagerConfigSpec object. This takes precedence over the AlertmanagerConfigRef.
+                          description: |-
+                            AlertmanagerConfigSpecTemplate takes an AlertmanagerConfigSpec object.
+                            This takes precedence over the AlertmanagerConfigRef.
                           properties:
                             inhibitRules:
-                              description: List of inhibition rules. The rules will only apply to alerts matching the resource's namespace.
+                              description: |-
+                                List of inhibition rules. The rules will only apply to alerts matching
+                                the resource's namespace.
                               items:
-                                description: InhibitRule defines an inhibition rule that allows to mute alerts when other alerts are already firing. See https://prometheus.io/docs/alerting/latest/configuration/#inhibit_rule
+                                description: |-
+                                  InhibitRule defines an inhibition rule that allows to mute alerts when other
+                                  alerts are already firing.
+                                  See https://prometheus.io/docs/alerting/latest/configuration/#inhibit_rule
                                 properties:
                                   equal:
-                                    description: Labels that must have an equal value in the source and target alert for the inhibition to take effect.
+                                    description: |-
+                                      Labels that must have an equal value in the source and target alert for
+                                      the inhibition to take effect.
                                     items:
                                       type: string
                                     type: array
                                   sourceMatch:
-                                    description: Matchers for which one or more alerts have to exist for the inhibition to take effect. The operator enforces that the alert matches the resource's namespace.
+                                    description: |-
+                                      Matchers for which one or more alerts have to exist for the inhibition
+                                      to take effect. The operator enforces that the alert matches the
+                                      resource's namespace.
                                     items:
                                       description: Matcher defines how to match on alert's labels.
                                       properties:
                                         matchType:
-                                          description: Match operation available with AlertManager >= v0.22.0 and takes precedence over Regex (deprecated) if non-empty.
+                                          description: |-
+                                            Match operation available with AlertManager >= v0.22.0 and
+                                            takes precedence over Regex (deprecated) if non-empty.
                                           enum:
                                             - '!='
                                             - "="
@@ -149,7 +206,9 @@ spec:
                                           minLength: 1
                                           type: string
                                         regex:
-                                          description: Whether to match on equality (false) or regular-expression (true). Deprecated as of AlertManager >= v0.22.0 where a user should use MatchType instead.
+                                          description: |-
+                                            Whether to match on equality (false) or regular-expression (true).
+                                            Deprecated as of AlertManager >= v0.22.0 where a user should use MatchType instead.
                                           type: boolean
                                         value:
                                           description: Label value to match.
@@ -159,12 +218,16 @@ spec:
                                       type: object
                                     type: array
                                   targetMatch:
-                                    description: Matchers that have to be fulfilled in the alerts to be muted. The operator enforces that the alert matches the resource's namespace.
+                                    description: |-
+                                      Matchers that have to be fulfilled in the alerts to be muted. The
+                                      operator enforces that the alert matches the resource's namespace.
                                     items:
                                       description: Matcher defines how to match on alert's labels.
                                       properties:
                                         matchType:
-                                          description: Match operation available with AlertManager >= v0.22.0 and takes precedence over Regex (deprecated) if non-empty.
+                                          description: |-
+                                            Match operation available with AlertManager >= v0.22.0 and
+                                            takes precedence over Regex (deprecated) if non-empty.
                                           enum:
                                             - '!='
                                             - "="
@@ -176,7 +239,9 @@ spec:
                                           minLength: 1
                                           type: string
                                         regex:
-                                          description: Whether to match on equality (false) or regular-expression (true). Deprecated as of AlertManager >= v0.22.0 where a user should use MatchType instead.
+                                          description: |-
+                                            Whether to match on equality (false) or regular-expression (true).
+                                            Deprecated as of AlertManager >= v0.22.0 where a user should use MatchType instead.
                                           type: boolean
                                         value:
                                           description: Label value to match.
@@ -220,7 +285,9 @@ spec:
                                         months:
                                           description: Months is a list of MonthRange
                                           items:
-                                            description: MonthRange is an inclusive range of months of the year beginning in January Months can be specified by name (e.g 'January') by numerical month (e.g '1') or as an inclusive range (e.g 'January:March', '1:3', '1:March')
+                                            description: |-
+                                              MonthRange is an inclusive range of months of the year beginning in January
+                                              Months can be specified by name (e.g 'January') by numerical month (e.g '1') or as an inclusive range (e.g 'January:March', '1:3', '1:March')
                                             pattern: ^((?i)january|february|march|april|may|june|july|august|september|october|november|december|[1-12])(?:((:((?i)january|february|march|april|may|june|july|august|september|october|november|december|[1-12]))$)|$)
                                             type: string
                                           type: array
@@ -242,7 +309,9 @@ spec:
                                         weekdays:
                                           description: Weekdays is a list of WeekdayRange
                                           items:
-                                            description: WeekdayRange is an inclusive range of days of the week beginning on Sunday Days can be specified by name (e.g 'Sunday') or as an inclusive range (e.g 'Monday:Friday')
+                                            description: |-
+                                              WeekdayRange is an inclusive range of days of the week beginning on Sunday
+                                              Days can be specified by name (e.g 'Sunday') or as an inclusive range (e.g 'Monday:Friday')
                                             pattern: ^((?i)sun|mon|tues|wednes|thurs|fri|satur)day(?:((:(sun|mon|tues|wednes|thurs|fri|satur)day)$)|$)
                                             type: string
                                           type: array
@@ -271,13 +340,19 @@ spec:
                                           description: The identity to use for authentication.
                                           type: string
                                         authPassword:
-                                          description: The secret's key that contains the password to use for authentication. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.
+                                          description: |-
+                                            The secret's key that contains the password to use for authentication.
+                                            The secret needs to be in the same namespace as the AlertmanagerConfig
+                                            object and accessible by the Prometheus Operator.
                                           properties:
                                             key:
                                               description: The key of the secret to select from.  Must be a valid secret key.
                                               type: string
                                             name:
-                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                              description: |-
+                                                Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description: Specify whether the Secret or its key must be defined
@@ -287,13 +362,19 @@ spec:
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         authSecret:
-                                          description: The secret's key that contains the CRAM-MD5 secret. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.
+                                          description: |-
+                                            The secret's key that contains the CRAM-MD5 secret.
+                                            The secret needs to be in the same namespace as the AlertmanagerConfig
+                                            object and accessible by the Prometheus Operator.
                                           properties:
                                             key:
                                               description: The key of the secret to select from.  Must be a valid secret key.
                                               type: string
                                             name:
-                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                              description: |-
+                                                Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description: Specify whether the Secret or its key must be defined
@@ -309,7 +390,9 @@ spec:
                                           description: The sender address.
                                           type: string
                                         headers:
-                                          description: Further headers email header key/value pairs. Overrides any headers previously set by the notification implementation.
+                                          description: |-
+                                            Further headers email header key/value pairs. Overrides any headers
+                                            previously set by the notification implementation.
                                           items:
                                             description: KeyValue defines a (key, value) tuple.
                                             properties:
@@ -332,7 +415,9 @@ spec:
                                           description: The HTML body of the email notification.
                                           type: string
                                         requireTLS:
-                                          description: The SMTP TLS requirement. Note that Go does not support unencrypted connections to remote SMTP endpoints.
+                                          description: |-
+                                            The SMTP TLS requirement.
+                                            Note that Go does not support unencrypted connections to remote SMTP endpoints.
                                           type: boolean
                                         sendResolved:
                                           description: Whether or not to notify about resolved alerts.
@@ -356,7 +441,10 @@ spec:
                                                       description: The key to select.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the ConfigMap or its key must be defined
@@ -372,7 +460,10 @@ spec:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -392,7 +483,10 @@ spec:
                                                       description: The key to select.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the ConfigMap or its key must be defined
@@ -408,7 +502,10 @@ spec:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -428,7 +525,10 @@ spec:
                                                   description: The key of the secret to select from.  Must be a valid secret key.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                  description: |-
+                                                    Name of the referent.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                   type: string
                                                 optional:
                                                   description: Specify whether the Secret or its key must be defined
@@ -453,19 +553,27 @@ spec:
                                   opsgenieConfigs:
                                     description: List of OpsGenie configurations.
                                     items:
-                                      description: OpsGenieConfig configures notifications via OpsGenie. See https://prometheus.io/docs/alerting/latest/configuration/#opsgenie_config
+                                      description: |-
+                                        OpsGenieConfig configures notifications via OpsGenie.
+                                        See https://prometheus.io/docs/alerting/latest/configuration/#opsgenie_config
                                       properties:
                                         actions:
                                           description: Comma separated list of actions that will be available for the alert.
                                           type: string
                                         apiKey:
-                                          description: The secret's key that contains the OpsGenie API key. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.
+                                          description: |-
+                                            The secret's key that contains the OpsGenie API key.
+                                            The secret needs to be in the same namespace as the AlertmanagerConfig
+                                            object and accessible by the Prometheus Operator.
                                           properties:
                                             key:
                                               description: The key of the secret to select from.  Must be a valid secret key.
                                               type: string
                                             name:
-                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                              description: |-
+                                                Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description: Specify whether the Secret or its key must be defined
@@ -504,7 +612,9 @@ spec:
                                           description: HTTP client configuration.
                                           properties:
                                             authorization:
-                                              description: Authorization header configuration for the client. This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
+                                              description: |-
+                                                Authorization header configuration for the client.
+                                                This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
                                               properties:
                                                 credentials:
                                                   description: The secret's key that contains the credentials of the request
@@ -513,7 +623,10 @@ spec:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -523,20 +636,29 @@ spec:
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 type:
-                                                  description: Set the authentication type. Defaults to Bearer, Basic will cause an error
+                                                  description: |-
+                                                    Set the authentication type. Defaults to Bearer, Basic will cause an
+                                                    error
                                                   type: string
                                               type: object
                                             basicAuth:
-                                              description: BasicAuth for the client. This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
+                                              description: |-
+                                                BasicAuth for the client.
+                                                This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
                                               properties:
                                                 password:
-                                                  description: The secret in the service monitor namespace that contains the password for authentication.
+                                                  description: |-
+                                                    The secret in the service monitor namespace that contains the password
+                                                    for authentication.
                                                   properties:
                                                     key:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -546,13 +668,18 @@ spec:
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 username:
-                                                  description: The secret in the service monitor namespace that contains the username for authentication.
+                                                  description: |-
+                                                    The secret in the service monitor namespace that contains the username
+                                                    for authentication.
                                                   properties:
                                                     key:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -563,13 +690,20 @@ spec:
                                                   x-kubernetes-map-type: atomic
                                               type: object
                                             bearerTokenSecret:
-                                              description: The secret's key that contains the bearer token to be used by the client for authentication. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.
+                                              description: |-
+                                                The secret's key that contains the bearer token to be used by the client
+                                                for authentication.
+                                                The secret needs to be in the same namespace as the AlertmanagerConfig
+                                                object and accessible by the Prometheus Operator.
                                               properties:
                                                 key:
                                                   description: The key of the secret to select from.  Must be a valid secret key.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                  description: |-
+                                                    Name of the referent.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                   type: string
                                                 optional:
                                                   description: Specify whether the Secret or its key must be defined
@@ -594,7 +728,10 @@ spec:
                                                           description: The key to select.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the ConfigMap or its key must be defined
@@ -610,7 +747,10 @@ spec:
                                                           description: The key of the secret to select from.  Must be a valid secret key.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the Secret or its key must be defined
@@ -627,7 +767,10 @@ spec:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -671,7 +814,10 @@ spec:
                                                           description: The key to select.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the ConfigMap or its key must be defined
@@ -687,7 +833,10 @@ spec:
                                                           description: The key of the secret to select from.  Must be a valid secret key.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the Secret or its key must be defined
@@ -707,7 +856,10 @@ spec:
                                                           description: The key to select.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the ConfigMap or its key must be defined
@@ -723,7 +875,10 @@ spec:
                                                           description: The key of the secret to select from.  Must be a valid secret key.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the Secret or its key must be defined
@@ -743,7 +898,10 @@ spec:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -769,7 +927,9 @@ spec:
                                         responders:
                                           description: List of responders responsible for notifications.
                                           items:
-                                            description: OpsGenieConfigResponder defines a responder to an incident. One of `id`, `name` or `username` has to be defined.
+                                            description: |-
+                                              OpsGenieConfigResponder defines a responder to an incident.
+                                              One of `id`, `name` or `username` has to be defined.
                                             properties:
                                               id:
                                                 description: ID of the responder.
@@ -804,14 +964,18 @@ spec:
                                           description: Comma separated list of tags attached to the notifications.
                                           type: string
                                         updateAlerts:
-                                          description: Whether to update message and description of the alert in OpsGenie if it already exists By default, the alert is never updated in OpsGenie, the new message only appears in activity log.
+                                          description: |-
+                                            Whether to update message and description of the alert in OpsGenie if it already exists
+                                            By default, the alert is never updated in OpsGenie, the new message only appears in activity log.
                                           type: boolean
                                       type: object
                                     type: array
                                   pagerdutyConfigs:
                                     description: List of PagerDuty configurations.
                                     items:
-                                      description: PagerDutyConfig configures notifications via PagerDuty. See https://prometheus.io/docs/alerting/latest/configuration/#pagerduty_config
+                                      description: |-
+                                        PagerDutyConfig configures notifications via PagerDuty.
+                                        See https://prometheus.io/docs/alerting/latest/configuration/#pagerduty_config
                                       properties:
                                         class:
                                           description: The class/type of the event.
@@ -852,7 +1016,9 @@ spec:
                                           description: HTTP client configuration.
                                           properties:
                                             authorization:
-                                              description: Authorization header configuration for the client. This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
+                                              description: |-
+                                                Authorization header configuration for the client.
+                                                This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
                                               properties:
                                                 credentials:
                                                   description: The secret's key that contains the credentials of the request
@@ -861,7 +1027,10 @@ spec:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -871,20 +1040,29 @@ spec:
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 type:
-                                                  description: Set the authentication type. Defaults to Bearer, Basic will cause an error
+                                                  description: |-
+                                                    Set the authentication type. Defaults to Bearer, Basic will cause an
+                                                    error
                                                   type: string
                                               type: object
                                             basicAuth:
-                                              description: BasicAuth for the client. This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
+                                              description: |-
+                                                BasicAuth for the client.
+                                                This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
                                               properties:
                                                 password:
-                                                  description: The secret in the service monitor namespace that contains the password for authentication.
+                                                  description: |-
+                                                    The secret in the service monitor namespace that contains the password
+                                                    for authentication.
                                                   properties:
                                                     key:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -894,13 +1072,18 @@ spec:
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 username:
-                                                  description: The secret in the service monitor namespace that contains the username for authentication.
+                                                  description: |-
+                                                    The secret in the service monitor namespace that contains the username
+                                                    for authentication.
                                                   properties:
                                                     key:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -911,13 +1094,20 @@ spec:
                                                   x-kubernetes-map-type: atomic
                                               type: object
                                             bearerTokenSecret:
-                                              description: The secret's key that contains the bearer token to be used by the client for authentication. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.
+                                              description: |-
+                                                The secret's key that contains the bearer token to be used by the client
+                                                for authentication.
+                                                The secret needs to be in the same namespace as the AlertmanagerConfig
+                                                object and accessible by the Prometheus Operator.
                                               properties:
                                                 key:
                                                   description: The key of the secret to select from.  Must be a valid secret key.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                  description: |-
+                                                    Name of the referent.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                   type: string
                                                 optional:
                                                   description: Specify whether the Secret or its key must be defined
@@ -942,7 +1132,10 @@ spec:
                                                           description: The key to select.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the ConfigMap or its key must be defined
@@ -958,7 +1151,10 @@ spec:
                                                           description: The key of the secret to select from.  Must be a valid secret key.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the Secret or its key must be defined
@@ -975,7 +1171,10 @@ spec:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -1019,7 +1218,10 @@ spec:
                                                           description: The key to select.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the ConfigMap or its key must be defined
@@ -1035,7 +1237,10 @@ spec:
                                                           description: The key of the secret to select from.  Must be a valid secret key.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the Secret or its key must be defined
@@ -1055,7 +1260,10 @@ spec:
                                                           description: The key to select.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the ConfigMap or its key must be defined
@@ -1071,7 +1279,10 @@ spec:
                                                           description: The key of the secret to select from.  Must be a valid secret key.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the Secret or its key must be defined
@@ -1091,7 +1302,10 @@ spec:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -1135,13 +1349,20 @@ spec:
                                             type: object
                                           type: array
                                         routingKey:
-                                          description: The secret's key that contains the PagerDuty integration key (when using Events API v2). Either this field or `serviceKey` needs to be defined. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.
+                                          description: |-
+                                            The secret's key that contains the PagerDuty integration key (when using
+                                            Events API v2). Either this field or `serviceKey` needs to be defined.
+                                            The secret needs to be in the same namespace as the AlertmanagerConfig
+                                            object and accessible by the Prometheus Operator.
                                           properties:
                                             key:
                                               description: The key of the secret to select from.  Must be a valid secret key.
                                               type: string
                                             name:
-                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                              description: |-
+                                                Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description: Specify whether the Secret or its key must be defined
@@ -1154,13 +1375,21 @@ spec:
                                           description: Whether or not to notify about resolved alerts.
                                           type: boolean
                                         serviceKey:
-                                          description: The secret's key that contains the PagerDuty service key (when using integration type "Prometheus"). Either this field or `routingKey` needs to be defined. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.
+                                          description: |-
+                                            The secret's key that contains the PagerDuty service key (when using
+                                            integration type "Prometheus"). Either this field or `routingKey` needs to
+                                            be defined.
+                                            The secret needs to be in the same namespace as the AlertmanagerConfig
+                                            object and accessible by the Prometheus Operator.
                                           properties:
                                             key:
                                               description: The key of the secret to select from.  Must be a valid secret key.
                                               type: string
                                             name:
-                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                              description: |-
+                                                Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description: Specify whether the Secret or its key must be defined
@@ -1180,10 +1409,14 @@ spec:
                                   pushoverConfigs:
                                     description: List of Pushover configurations.
                                     items:
-                                      description: PushoverConfig configures notifications via Pushover. See https://prometheus.io/docs/alerting/latest/configuration/#pushover_config
+                                      description: |-
+                                        PushoverConfig configures notifications via Pushover.
+                                        See https://prometheus.io/docs/alerting/latest/configuration/#pushover_config
                                       properties:
                                         expire:
-                                          description: How long your notification will continue to be retried for, unless the user acknowledges the notification.
+                                          description: |-
+                                            How long your notification will continue to be retried for, unless the user
+                                            acknowledges the notification.
                                           pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
                                           type: string
                                         html:
@@ -1193,7 +1426,9 @@ spec:
                                           description: HTTP client configuration.
                                           properties:
                                             authorization:
-                                              description: Authorization header configuration for the client. This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
+                                              description: |-
+                                                Authorization header configuration for the client.
+                                                This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
                                               properties:
                                                 credentials:
                                                   description: The secret's key that contains the credentials of the request
@@ -1202,7 +1437,10 @@ spec:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -1212,20 +1450,29 @@ spec:
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 type:
-                                                  description: Set the authentication type. Defaults to Bearer, Basic will cause an error
+                                                  description: |-
+                                                    Set the authentication type. Defaults to Bearer, Basic will cause an
+                                                    error
                                                   type: string
                                               type: object
                                             basicAuth:
-                                              description: BasicAuth for the client. This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
+                                              description: |-
+                                                BasicAuth for the client.
+                                                This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
                                               properties:
                                                 password:
-                                                  description: The secret in the service monitor namespace that contains the password for authentication.
+                                                  description: |-
+                                                    The secret in the service monitor namespace that contains the password
+                                                    for authentication.
                                                   properties:
                                                     key:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -1235,13 +1482,18 @@ spec:
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 username:
-                                                  description: The secret in the service monitor namespace that contains the username for authentication.
+                                                  description: |-
+                                                    The secret in the service monitor namespace that contains the username
+                                                    for authentication.
                                                   properties:
                                                     key:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -1252,13 +1504,20 @@ spec:
                                                   x-kubernetes-map-type: atomic
                                               type: object
                                             bearerTokenSecret:
-                                              description: The secret's key that contains the bearer token to be used by the client for authentication. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.
+                                              description: |-
+                                                The secret's key that contains the bearer token to be used by the client
+                                                for authentication.
+                                                The secret needs to be in the same namespace as the AlertmanagerConfig
+                                                object and accessible by the Prometheus Operator.
                                               properties:
                                                 key:
                                                   description: The key of the secret to select from.  Must be a valid secret key.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                  description: |-
+                                                    Name of the referent.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                   type: string
                                                 optional:
                                                   description: Specify whether the Secret or its key must be defined
@@ -1283,7 +1542,10 @@ spec:
                                                           description: The key to select.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the ConfigMap or its key must be defined
@@ -1299,7 +1561,10 @@ spec:
                                                           description: The key of the secret to select from.  Must be a valid secret key.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the Secret or its key must be defined
@@ -1316,7 +1581,10 @@ spec:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -1360,7 +1628,10 @@ spec:
                                                           description: The key to select.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the ConfigMap or its key must be defined
@@ -1376,7 +1647,10 @@ spec:
                                                           description: The key of the secret to select from.  Must be a valid secret key.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the Secret or its key must be defined
@@ -1396,7 +1670,10 @@ spec:
                                                           description: The key to select.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the ConfigMap or its key must be defined
@@ -1412,7 +1689,10 @@ spec:
                                                           description: The key of the secret to select from.  Must be a valid secret key.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the Secret or its key must be defined
@@ -1432,7 +1712,10 @@ spec:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -1453,7 +1736,9 @@ spec:
                                           description: Priority, see https://pushover.net/api#priority
                                           type: string
                                         retry:
-                                          description: How often the Pushover servers will send the same notification to the user. Must be at least 30 seconds.
+                                          description: |-
+                                            How often the Pushover servers will send the same notification to the user.
+                                            Must be at least 30 seconds.
                                           pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
                                           type: string
                                         sendResolved:
@@ -1466,13 +1751,19 @@ spec:
                                           description: Notification title.
                                           type: string
                                         token:
-                                          description: The secret's key that contains the registered application's API token, see https://pushover.net/apps. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.
+                                          description: |-
+                                            The secret's key that contains the registered application's API token, see https://pushover.net/apps.
+                                            The secret needs to be in the same namespace as the AlertmanagerConfig
+                                            object and accessible by the Prometheus Operator.
                                           properties:
                                             key:
                                               description: The key of the secret to select from.  Must be a valid secret key.
                                               type: string
                                             name:
-                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                              description: |-
+                                                Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description: Specify whether the Secret or its key must be defined
@@ -1488,13 +1779,19 @@ spec:
                                           description: A title for supplementary URL, otherwise just the URL is shown
                                           type: string
                                         userKey:
-                                          description: The secret's key that contains the recipient user's user key. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.
+                                          description: |-
+                                            The secret's key that contains the recipient user's user key.
+                                            The secret needs to be in the same namespace as the AlertmanagerConfig
+                                            object and accessible by the Prometheus Operator.
                                           properties:
                                             key:
                                               description: The key of the secret to select from.  Must be a valid secret key.
                                               type: string
                                             name:
-                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                              description: |-
+                                                Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description: Specify whether the Secret or its key must be defined
@@ -1508,15 +1805,26 @@ spec:
                                   slackConfigs:
                                     description: List of Slack configurations.
                                     items:
-                                      description: SlackConfig configures notifications via Slack. See https://prometheus.io/docs/alerting/latest/configuration/#slack_config
+                                      description: |-
+                                        SlackConfig configures notifications via Slack.
+                                        See https://prometheus.io/docs/alerting/latest/configuration/#slack_config
                                       properties:
                                         actions:
                                           description: A list of Slack actions that are sent with each notification.
                                           items:
-                                            description: SlackAction configures a single Slack action that is sent with each notification. See https://api.slack.com/docs/message-attachments#action_fields and https://api.slack.com/docs/message-buttons for more information.
+                                            description: |-
+                                              SlackAction configures a single Slack action that is sent with each
+                                              notification.
+                                              See https://api.slack.com/docs/message-attachments#action_fields and
+                                              https://api.slack.com/docs/message-buttons for more information.
                                             properties:
                                               confirm:
-                                                description: SlackConfirmationField protect users from destructive actions or particularly distinguished decisions by asking them to confirm their button click one more time. See https://api.slack.com/docs/interactive-message-field-guide#confirmation_fields for more information.
+                                                description: |-
+                                                  SlackConfirmationField protect users from destructive actions or
+                                                  particularly distinguished decisions by asking them to confirm their button
+                                                  click one more time.
+                                                  See https://api.slack.com/docs/interactive-message-field-guide#confirmation_fields
+                                                  for more information.
                                                 properties:
                                                   dismissText:
                                                     type: string
@@ -1550,13 +1858,19 @@ spec:
                                             type: object
                                           type: array
                                         apiURL:
-                                          description: The secret's key that contains the Slack webhook URL. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.
+                                          description: |-
+                                            The secret's key that contains the Slack webhook URL.
+                                            The secret needs to be in the same namespace as the AlertmanagerConfig
+                                            object and accessible by the Prometheus Operator.
                                           properties:
                                             key:
                                               description: The key of the secret to select from.  Must be a valid secret key.
                                               type: string
                                             name:
-                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                              description: |-
+                                                Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description: Specify whether the Secret or its key must be defined
@@ -1577,7 +1891,11 @@ spec:
                                         fields:
                                           description: A list of Slack fields that are sent with each notification.
                                           items:
-                                            description: SlackField configures a single Slack field that is sent with each notification. Each field must contain a title, value, and optionally, a boolean value to indicate if the field is short enough to be displayed next to other fields designated as short. See https://api.slack.com/docs/message-attachments#fields for more information.
+                                            description: |-
+                                              SlackField configures a single Slack field that is sent with each notification.
+                                              Each field must contain a title, value, and optionally, a boolean value to indicate if the field
+                                              is short enough to be displayed next to other fields designated as short.
+                                              See https://api.slack.com/docs/message-attachments#fields for more information.
                                             properties:
                                               short:
                                                 type: boolean
@@ -1598,7 +1916,9 @@ spec:
                                           description: HTTP client configuration.
                                           properties:
                                             authorization:
-                                              description: Authorization header configuration for the client. This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
+                                              description: |-
+                                                Authorization header configuration for the client.
+                                                This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
                                               properties:
                                                 credentials:
                                                   description: The secret's key that contains the credentials of the request
@@ -1607,7 +1927,10 @@ spec:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -1617,20 +1940,29 @@ spec:
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 type:
-                                                  description: Set the authentication type. Defaults to Bearer, Basic will cause an error
+                                                  description: |-
+                                                    Set the authentication type. Defaults to Bearer, Basic will cause an
+                                                    error
                                                   type: string
                                               type: object
                                             basicAuth:
-                                              description: BasicAuth for the client. This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
+                                              description: |-
+                                                BasicAuth for the client.
+                                                This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
                                               properties:
                                                 password:
-                                                  description: The secret in the service monitor namespace that contains the password for authentication.
+                                                  description: |-
+                                                    The secret in the service monitor namespace that contains the password
+                                                    for authentication.
                                                   properties:
                                                     key:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -1640,13 +1972,18 @@ spec:
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 username:
-                                                  description: The secret in the service monitor namespace that contains the username for authentication.
+                                                  description: |-
+                                                    The secret in the service monitor namespace that contains the username
+                                                    for authentication.
                                                   properties:
                                                     key:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -1657,13 +1994,20 @@ spec:
                                                   x-kubernetes-map-type: atomic
                                               type: object
                                             bearerTokenSecret:
-                                              description: The secret's key that contains the bearer token to be used by the client for authentication. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.
+                                              description: |-
+                                                The secret's key that contains the bearer token to be used by the client
+                                                for authentication.
+                                                The secret needs to be in the same namespace as the AlertmanagerConfig
+                                                object and accessible by the Prometheus Operator.
                                               properties:
                                                 key:
                                                   description: The key of the secret to select from.  Must be a valid secret key.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                  description: |-
+                                                    Name of the referent.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                   type: string
                                                 optional:
                                                   description: Specify whether the Secret or its key must be defined
@@ -1688,7 +2032,10 @@ spec:
                                                           description: The key to select.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the ConfigMap or its key must be defined
@@ -1704,7 +2051,10 @@ spec:
                                                           description: The key of the secret to select from.  Must be a valid secret key.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the Secret or its key must be defined
@@ -1721,7 +2071,10 @@ spec:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -1765,7 +2118,10 @@ spec:
                                                           description: The key to select.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the ConfigMap or its key must be defined
@@ -1781,7 +2137,10 @@ spec:
                                                           description: The key of the secret to select from.  Must be a valid secret key.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the Secret or its key must be defined
@@ -1801,7 +2160,10 @@ spec:
                                                           description: The key to select.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the ConfigMap or its key must be defined
@@ -1817,7 +2179,10 @@ spec:
                                                           description: The key of the secret to select from.  Must be a valid secret key.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the Secret or its key must be defined
@@ -1837,7 +2202,10 @@ spec:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -1885,10 +2253,14 @@ spec:
                                   snsConfigs:
                                     description: List of SNS configurations
                                     items:
-                                      description: SNSConfig configures notifications via AWS SNS. See https://prometheus.io/docs/alerting/latest/configuration/#sns_configs
+                                      description: |-
+                                        SNSConfig configures notifications via AWS SNS.
+                                        See https://prometheus.io/docs/alerting/latest/configuration/#sns_configs
                                       properties:
                                         apiURL:
-                                          description: The SNS API URL i.e. https://sns.us-east-2.amazonaws.com. If not specified, the SNS API URL from the SNS SDK will be used.
+                                          description: |-
+                                            The SNS API URL i.e. https://sns.us-east-2.amazonaws.com.
+                                            If not specified, the SNS API URL from the SNS SDK will be used.
                                           type: string
                                         attributes:
                                           additionalProperties:
@@ -1899,7 +2271,9 @@ spec:
                                           description: HTTP client configuration.
                                           properties:
                                             authorization:
-                                              description: Authorization header configuration for the client. This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
+                                              description: |-
+                                                Authorization header configuration for the client.
+                                                This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
                                               properties:
                                                 credentials:
                                                   description: The secret's key that contains the credentials of the request
@@ -1908,7 +2282,10 @@ spec:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -1918,20 +2295,29 @@ spec:
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 type:
-                                                  description: Set the authentication type. Defaults to Bearer, Basic will cause an error
+                                                  description: |-
+                                                    Set the authentication type. Defaults to Bearer, Basic will cause an
+                                                    error
                                                   type: string
                                               type: object
                                             basicAuth:
-                                              description: BasicAuth for the client. This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
+                                              description: |-
+                                                BasicAuth for the client.
+                                                This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
                                               properties:
                                                 password:
-                                                  description: The secret in the service monitor namespace that contains the password for authentication.
+                                                  description: |-
+                                                    The secret in the service monitor namespace that contains the password
+                                                    for authentication.
                                                   properties:
                                                     key:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -1941,13 +2327,18 @@ spec:
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 username:
-                                                  description: The secret in the service monitor namespace that contains the username for authentication.
+                                                  description: |-
+                                                    The secret in the service monitor namespace that contains the username
+                                                    for authentication.
                                                   properties:
                                                     key:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -1958,13 +2349,20 @@ spec:
                                                   x-kubernetes-map-type: atomic
                                               type: object
                                             bearerTokenSecret:
-                                              description: The secret's key that contains the bearer token to be used by the client for authentication. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.
+                                              description: |-
+                                                The secret's key that contains the bearer token to be used by the client
+                                                for authentication.
+                                                The secret needs to be in the same namespace as the AlertmanagerConfig
+                                                object and accessible by the Prometheus Operator.
                                               properties:
                                                 key:
                                                   description: The key of the secret to select from.  Must be a valid secret key.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                  description: |-
+                                                    Name of the referent.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                   type: string
                                                 optional:
                                                   description: Specify whether the Secret or its key must be defined
@@ -1989,7 +2387,10 @@ spec:
                                                           description: The key to select.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the ConfigMap or its key must be defined
@@ -2005,7 +2406,10 @@ spec:
                                                           description: The key of the secret to select from.  Must be a valid secret key.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the Secret or its key must be defined
@@ -2022,7 +2426,10 @@ spec:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -2066,7 +2473,10 @@ spec:
                                                           description: The key to select.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the ConfigMap or its key must be defined
@@ -2082,7 +2492,10 @@ spec:
                                                           description: The key of the secret to select from.  Must be a valid secret key.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the Secret or its key must be defined
@@ -2102,7 +2515,10 @@ spec:
                                                           description: The key to select.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the ConfigMap or its key must be defined
@@ -2118,7 +2534,10 @@ spec:
                                                           description: The key of the secret to select from.  Must be a valid secret key.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the Secret or its key must be defined
@@ -2138,7 +2557,10 @@ spec:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -2156,7 +2578,9 @@ spec:
                                           description: The message content of the SNS notification.
                                           type: string
                                         phoneNumber:
-                                          description: Phone number if message is delivered via SMS in E.164 format. If you don't specify this value, you must specify a value for the TopicARN or TargetARN.
+                                          description: |-
+                                            Phone number if message is delivered via SMS in E.164 format.
+                                            If you don't specify this value, you must specify a value for the TopicARN or TargetARN.
                                           type: string
                                         sendResolved:
                                           description: Whether or not to notify about resolved alerts.
@@ -2171,7 +2595,10 @@ spec:
                                                   description: The key of the secret to select from.  Must be a valid secret key.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                  description: |-
+                                                    Name of the referent.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                   type: string
                                                 optional:
                                                   description: Specify whether the Secret or its key must be defined
@@ -2196,7 +2623,10 @@ spec:
                                                   description: The key of the secret to select from.  Must be a valid secret key.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                  description: |-
+                                                    Name of the referent.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                   type: string
                                                 optional:
                                                   description: Specify whether the Secret or its key must be defined
@@ -2210,29 +2640,43 @@ spec:
                                           description: Subject line when the message is delivered to email endpoints.
                                           type: string
                                         targetARN:
-                                          description: The  mobile platform endpoint ARN if message is delivered via mobile notifications. If you don't specify this value, you must specify a value for the topic_arn or PhoneNumber.
+                                          description: |-
+                                            The  mobile platform endpoint ARN if message is delivered via mobile notifications.
+                                            If you don't specify this value, you must specify a value for the topic_arn or PhoneNumber.
                                           type: string
                                         topicARN:
-                                          description: SNS topic ARN, i.e. arn:aws:sns:us-east-2:698519295917:My-Topic If you don't specify this value, you must specify a value for the PhoneNumber or TargetARN.
+                                          description: |-
+                                            SNS topic ARN, i.e. arn:aws:sns:us-east-2:698519295917:My-Topic
+                                            If you don't specify this value, you must specify a value for the PhoneNumber or TargetARN.
                                           type: string
                                       type: object
                                     type: array
                                   telegramConfigs:
                                     description: List of Telegram configurations.
                                     items:
-                                      description: TelegramConfig configures notifications via Telegram. See https://prometheus.io/docs/alerting/latest/configuration/#telegram_config
+                                      description: |-
+                                        TelegramConfig configures notifications via Telegram.
+                                        See https://prometheus.io/docs/alerting/latest/configuration/#telegram_config
                                       properties:
                                         apiURL:
-                                          description: The Telegram API URL i.e. https://api.telegram.org. If not specified, default API URL will be used.
+                                          description: |-
+                                            The Telegram API URL i.e. https://api.telegram.org.
+                                            If not specified, default API URL will be used.
                                           type: string
                                         botToken:
-                                          description: Telegram bot token The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.
+                                          description: |-
+                                            Telegram bot token
+                                            The secret needs to be in the same namespace as the AlertmanagerConfig
+                                            object and accessible by the Prometheus Operator.
                                           properties:
                                             key:
                                               description: The key of the secret to select from.  Must be a valid secret key.
                                               type: string
                                             name:
-                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                              description: |-
+                                                Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description: Specify whether the Secret or its key must be defined
@@ -2252,7 +2696,9 @@ spec:
                                           description: HTTP client configuration.
                                           properties:
                                             authorization:
-                                              description: Authorization header configuration for the client. This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
+                                              description: |-
+                                                Authorization header configuration for the client.
+                                                This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
                                               properties:
                                                 credentials:
                                                   description: The secret's key that contains the credentials of the request
@@ -2261,7 +2707,10 @@ spec:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -2271,20 +2720,29 @@ spec:
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 type:
-                                                  description: Set the authentication type. Defaults to Bearer, Basic will cause an error
+                                                  description: |-
+                                                    Set the authentication type. Defaults to Bearer, Basic will cause an
+                                                    error
                                                   type: string
                                               type: object
                                             basicAuth:
-                                              description: BasicAuth for the client. This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
+                                              description: |-
+                                                BasicAuth for the client.
+                                                This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
                                               properties:
                                                 password:
-                                                  description: The secret in the service monitor namespace that contains the password for authentication.
+                                                  description: |-
+                                                    The secret in the service monitor namespace that contains the password
+                                                    for authentication.
                                                   properties:
                                                     key:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -2294,13 +2752,18 @@ spec:
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 username:
-                                                  description: The secret in the service monitor namespace that contains the username for authentication.
+                                                  description: |-
+                                                    The secret in the service monitor namespace that contains the username
+                                                    for authentication.
                                                   properties:
                                                     key:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -2311,13 +2774,20 @@ spec:
                                                   x-kubernetes-map-type: atomic
                                               type: object
                                             bearerTokenSecret:
-                                              description: The secret's key that contains the bearer token to be used by the client for authentication. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.
+                                              description: |-
+                                                The secret's key that contains the bearer token to be used by the client
+                                                for authentication.
+                                                The secret needs to be in the same namespace as the AlertmanagerConfig
+                                                object and accessible by the Prometheus Operator.
                                               properties:
                                                 key:
                                                   description: The key of the secret to select from.  Must be a valid secret key.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                  description: |-
+                                                    Name of the referent.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                   type: string
                                                 optional:
                                                   description: Specify whether the Secret or its key must be defined
@@ -2342,7 +2812,10 @@ spec:
                                                           description: The key to select.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the ConfigMap or its key must be defined
@@ -2358,7 +2831,10 @@ spec:
                                                           description: The key of the secret to select from.  Must be a valid secret key.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the Secret or its key must be defined
@@ -2375,7 +2851,10 @@ spec:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -2419,7 +2898,10 @@ spec:
                                                           description: The key to select.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the ConfigMap or its key must be defined
@@ -2435,7 +2917,10 @@ spec:
                                                           description: The key of the secret to select from.  Must be a valid secret key.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the Secret or its key must be defined
@@ -2455,7 +2940,10 @@ spec:
                                                           description: The key to select.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the ConfigMap or its key must be defined
@@ -2471,7 +2959,10 @@ spec:
                                                           description: The key of the secret to select from.  Must be a valid secret key.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the Secret or its key must be defined
@@ -2491,7 +2982,10 @@ spec:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -2523,16 +3017,24 @@ spec:
                                   victoropsConfigs:
                                     description: List of VictorOps configurations.
                                     items:
-                                      description: VictorOpsConfig configures notifications via VictorOps. See https://prometheus.io/docs/alerting/latest/configuration/#victorops_config
+                                      description: |-
+                                        VictorOpsConfig configures notifications via VictorOps.
+                                        See https://prometheus.io/docs/alerting/latest/configuration/#victorops_config
                                       properties:
                                         apiKey:
-                                          description: The secret's key that contains the API key to use when talking to the VictorOps API. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.
+                                          description: |-
+                                            The secret's key that contains the API key to use when talking to the VictorOps API.
+                                            The secret needs to be in the same namespace as the AlertmanagerConfig
+                                            object and accessible by the Prometheus Operator.
                                           properties:
                                             key:
                                               description: The key of the secret to select from.  Must be a valid secret key.
                                               type: string
                                             name:
-                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                              description: |-
+                                                Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description: Specify whether the Secret or its key must be defined
@@ -2568,7 +3070,9 @@ spec:
                                           description: The HTTP client's configuration.
                                           properties:
                                             authorization:
-                                              description: Authorization header configuration for the client. This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
+                                              description: |-
+                                                Authorization header configuration for the client.
+                                                This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
                                               properties:
                                                 credentials:
                                                   description: The secret's key that contains the credentials of the request
@@ -2577,7 +3081,10 @@ spec:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -2587,20 +3094,29 @@ spec:
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 type:
-                                                  description: Set the authentication type. Defaults to Bearer, Basic will cause an error
+                                                  description: |-
+                                                    Set the authentication type. Defaults to Bearer, Basic will cause an
+                                                    error
                                                   type: string
                                               type: object
                                             basicAuth:
-                                              description: BasicAuth for the client. This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
+                                              description: |-
+                                                BasicAuth for the client.
+                                                This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
                                               properties:
                                                 password:
-                                                  description: The secret in the service monitor namespace that contains the password for authentication.
+                                                  description: |-
+                                                    The secret in the service monitor namespace that contains the password
+                                                    for authentication.
                                                   properties:
                                                     key:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -2610,13 +3126,18 @@ spec:
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 username:
-                                                  description: The secret in the service monitor namespace that contains the username for authentication.
+                                                  description: |-
+                                                    The secret in the service monitor namespace that contains the username
+                                                    for authentication.
                                                   properties:
                                                     key:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -2627,13 +3148,20 @@ spec:
                                                   x-kubernetes-map-type: atomic
                                               type: object
                                             bearerTokenSecret:
-                                              description: The secret's key that contains the bearer token to be used by the client for authentication. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.
+                                              description: |-
+                                                The secret's key that contains the bearer token to be used by the client
+                                                for authentication.
+                                                The secret needs to be in the same namespace as the AlertmanagerConfig
+                                                object and accessible by the Prometheus Operator.
                                               properties:
                                                 key:
                                                   description: The key of the secret to select from.  Must be a valid secret key.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                  description: |-
+                                                    Name of the referent.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                   type: string
                                                 optional:
                                                   description: Specify whether the Secret or its key must be defined
@@ -2658,7 +3186,10 @@ spec:
                                                           description: The key to select.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the ConfigMap or its key must be defined
@@ -2674,7 +3205,10 @@ spec:
                                                           description: The key of the secret to select from.  Must be a valid secret key.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the Secret or its key must be defined
@@ -2691,7 +3225,10 @@ spec:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -2735,7 +3272,10 @@ spec:
                                                           description: The key to select.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the ConfigMap or its key must be defined
@@ -2751,7 +3291,10 @@ spec:
                                                           description: The key of the secret to select from.  Must be a valid secret key.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the Secret or its key must be defined
@@ -2771,7 +3314,10 @@ spec:
                                                           description: The key to select.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the ConfigMap or its key must be defined
@@ -2787,7 +3333,10 @@ spec:
                                                           description: The key of the secret to select from.  Must be a valid secret key.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the Secret or its key must be defined
@@ -2807,7 +3356,10 @@ spec:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -2841,13 +3393,17 @@ spec:
                                   webhookConfigs:
                                     description: List of webhook configurations.
                                     items:
-                                      description: WebhookConfig configures notifications via a generic receiver supporting the webhook payload. See https://prometheus.io/docs/alerting/latest/configuration/#webhook_config
+                                      description: |-
+                                        WebhookConfig configures notifications via a generic receiver supporting the webhook payload.
+                                        See https://prometheus.io/docs/alerting/latest/configuration/#webhook_config
                                       properties:
                                         httpConfig:
                                           description: HTTP client configuration.
                                           properties:
                                             authorization:
-                                              description: Authorization header configuration for the client. This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
+                                              description: |-
+                                                Authorization header configuration for the client.
+                                                This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
                                               properties:
                                                 credentials:
                                                   description: The secret's key that contains the credentials of the request
@@ -2856,7 +3412,10 @@ spec:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -2866,20 +3425,29 @@ spec:
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 type:
-                                                  description: Set the authentication type. Defaults to Bearer, Basic will cause an error
+                                                  description: |-
+                                                    Set the authentication type. Defaults to Bearer, Basic will cause an
+                                                    error
                                                   type: string
                                               type: object
                                             basicAuth:
-                                              description: BasicAuth for the client. This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
+                                              description: |-
+                                                BasicAuth for the client.
+                                                This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
                                               properties:
                                                 password:
-                                                  description: The secret in the service monitor namespace that contains the password for authentication.
+                                                  description: |-
+                                                    The secret in the service monitor namespace that contains the password
+                                                    for authentication.
                                                   properties:
                                                     key:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -2889,13 +3457,18 @@ spec:
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 username:
-                                                  description: The secret in the service monitor namespace that contains the username for authentication.
+                                                  description: |-
+                                                    The secret in the service monitor namespace that contains the username
+                                                    for authentication.
                                                   properties:
                                                     key:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -2906,13 +3479,20 @@ spec:
                                                   x-kubernetes-map-type: atomic
                                               type: object
                                             bearerTokenSecret:
-                                              description: The secret's key that contains the bearer token to be used by the client for authentication. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.
+                                              description: |-
+                                                The secret's key that contains the bearer token to be used by the client
+                                                for authentication.
+                                                The secret needs to be in the same namespace as the AlertmanagerConfig
+                                                object and accessible by the Prometheus Operator.
                                               properties:
                                                 key:
                                                   description: The key of the secret to select from.  Must be a valid secret key.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                  description: |-
+                                                    Name of the referent.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                   type: string
                                                 optional:
                                                   description: Specify whether the Secret or its key must be defined
@@ -2937,7 +3517,10 @@ spec:
                                                           description: The key to select.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the ConfigMap or its key must be defined
@@ -2953,7 +3536,10 @@ spec:
                                                           description: The key of the secret to select from.  Must be a valid secret key.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the Secret or its key must be defined
@@ -2970,7 +3556,10 @@ spec:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -3014,7 +3603,10 @@ spec:
                                                           description: The key to select.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the ConfigMap or its key must be defined
@@ -3030,7 +3622,10 @@ spec:
                                                           description: The key of the secret to select from.  Must be a valid secret key.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the Secret or its key must be defined
@@ -3050,7 +3645,10 @@ spec:
                                                           description: The key to select.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the ConfigMap or its key must be defined
@@ -3066,7 +3664,10 @@ spec:
                                                           description: The key of the secret to select from.  Must be a valid secret key.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the Secret or its key must be defined
@@ -3086,7 +3687,10 @@ spec:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -3109,16 +3713,26 @@ spec:
                                           description: Whether or not to notify about resolved alerts.
                                           type: boolean
                                         url:
-                                          description: The URL to send HTTP POST requests to. `urlSecret` takes precedence over `url`. One of `urlSecret` and `url` should be defined.
+                                          description: |-
+                                            The URL to send HTTP POST requests to. `urlSecret` takes precedence over
+                                            `url`. One of `urlSecret` and `url` should be defined.
                                           type: string
                                         urlSecret:
-                                          description: The secret's key that contains the webhook URL to send HTTP requests to. `urlSecret` takes precedence over `url`. One of `urlSecret` and `url` should be defined. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.
+                                          description: |-
+                                            The secret's key that contains the webhook URL to send HTTP requests to.
+                                            `urlSecret` takes precedence over `url`. One of `urlSecret` and `url`
+                                            should be defined.
+                                            The secret needs to be in the same namespace as the AlertmanagerConfig
+                                            object and accessible by the Prometheus Operator.
                                           properties:
                                             key:
                                               description: The key of the secret to select from.  Must be a valid secret key.
                                               type: string
                                             name:
-                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                              description: |-
+                                                Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description: Specify whether the Secret or its key must be defined
@@ -3132,18 +3746,26 @@ spec:
                                   wechatConfigs:
                                     description: List of WeChat configurations.
                                     items:
-                                      description: WeChatConfig configures notifications via WeChat. See https://prometheus.io/docs/alerting/latest/configuration/#wechat_config
+                                      description: |-
+                                        WeChatConfig configures notifications via WeChat.
+                                        See https://prometheus.io/docs/alerting/latest/configuration/#wechat_config
                                       properties:
                                         agentID:
                                           type: string
                                         apiSecret:
-                                          description: The secret's key that contains the WeChat API key. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.
+                                          description: |-
+                                            The secret's key that contains the WeChat API key.
+                                            The secret needs to be in the same namespace as the AlertmanagerConfig
+                                            object and accessible by the Prometheus Operator.
                                           properties:
                                             key:
                                               description: The key of the secret to select from.  Must be a valid secret key.
                                               type: string
                                             name:
-                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                              description: |-
+                                                Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description: Specify whether the Secret or its key must be defined
@@ -3162,7 +3784,9 @@ spec:
                                           description: HTTP client configuration.
                                           properties:
                                             authorization:
-                                              description: Authorization header configuration for the client. This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
+                                              description: |-
+                                                Authorization header configuration for the client.
+                                                This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
                                               properties:
                                                 credentials:
                                                   description: The secret's key that contains the credentials of the request
@@ -3171,7 +3795,10 @@ spec:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -3181,20 +3808,29 @@ spec:
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 type:
-                                                  description: Set the authentication type. Defaults to Bearer, Basic will cause an error
+                                                  description: |-
+                                                    Set the authentication type. Defaults to Bearer, Basic will cause an
+                                                    error
                                                   type: string
                                               type: object
                                             basicAuth:
-                                              description: BasicAuth for the client. This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
+                                              description: |-
+                                                BasicAuth for the client.
+                                                This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
                                               properties:
                                                 password:
-                                                  description: The secret in the service monitor namespace that contains the password for authentication.
+                                                  description: |-
+                                                    The secret in the service monitor namespace that contains the password
+                                                    for authentication.
                                                   properties:
                                                     key:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -3204,13 +3840,18 @@ spec:
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 username:
-                                                  description: The secret in the service monitor namespace that contains the username for authentication.
+                                                  description: |-
+                                                    The secret in the service monitor namespace that contains the username
+                                                    for authentication.
                                                   properties:
                                                     key:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -3221,13 +3862,20 @@ spec:
                                                   x-kubernetes-map-type: atomic
                                               type: object
                                             bearerTokenSecret:
-                                              description: The secret's key that contains the bearer token to be used by the client for authentication. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.
+                                              description: |-
+                                                The secret's key that contains the bearer token to be used by the client
+                                                for authentication.
+                                                The secret needs to be in the same namespace as the AlertmanagerConfig
+                                                object and accessible by the Prometheus Operator.
                                               properties:
                                                 key:
                                                   description: The key of the secret to select from.  Must be a valid secret key.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                  description: |-
+                                                    Name of the referent.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                   type: string
                                                 optional:
                                                   description: Specify whether the Secret or its key must be defined
@@ -3252,7 +3900,10 @@ spec:
                                                           description: The key to select.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the ConfigMap or its key must be defined
@@ -3268,7 +3919,10 @@ spec:
                                                           description: The key of the secret to select from.  Must be a valid secret key.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the Secret or its key must be defined
@@ -3285,7 +3939,10 @@ spec:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -3329,7 +3986,10 @@ spec:
                                                           description: The key to select.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the ConfigMap or its key must be defined
@@ -3345,7 +4005,10 @@ spec:
                                                           description: The key of the secret to select from.  Must be a valid secret key.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the Secret or its key must be defined
@@ -3365,7 +4028,10 @@ spec:
                                                           description: The key to select.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the ConfigMap or its key must be defined
@@ -3381,7 +4047,10 @@ spec:
                                                           description: The key of the secret to select from.  Must be a valid secret key.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the Secret or its key must be defined
@@ -3401,7 +4070,10 @@ spec:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -3436,7 +4108,10 @@ spec:
                                 type: object
                               type: array
                             route:
-                              description: The Alertmanager route definition for alerts matching the resource's namespace. If present, it will be added to the generated Alertmanager configuration as a first-level route.
+                              description: |-
+                                The Alertmanager route definition for alerts matching the resource's
+                                namespace. If present, it will be added to the generated Alertmanager
+                                configuration as a first-level route.
                               properties:
                                 activeTimeIntervals:
                                   description: ActiveTimeIntervals is a list of MuteTimeInterval names when this route should be active.
@@ -3444,26 +4119,44 @@ spec:
                                     type: string
                                   type: array
                                 continue:
-                                  description: Boolean indicating whether an alert should continue matching subsequent sibling nodes. It will always be overridden to true for the first-level route by the Prometheus operator.
+                                  description: |-
+                                    Boolean indicating whether an alert should continue matching subsequent
+                                    sibling nodes. It will always be overridden to true for the first-level
+                                    route by the Prometheus operator.
                                   type: boolean
                                 groupBy:
-                                  description: List of labels to group by. Labels must not be repeated (unique list). Special label "..." (aggregate by all possible labels), if provided, must be the only element in the list.
+                                  description: |-
+                                    List of labels to group by.
+                                    Labels must not be repeated (unique list).
+                                    Special label "..." (aggregate by all possible labels), if provided, must be the only element in the list.
                                   items:
                                     type: string
                                   type: array
                                 groupInterval:
-                                  description: 'How long to wait before sending an updated notification. Must match the regular expression`^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$` Example: "5m"'
+                                  description: |-
+                                    How long to wait before sending an updated notification.
+                                    Must match the regular expression`^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$`
+                                    Example: "5m"
                                   type: string
                                 groupWait:
-                                  description: 'How long to wait before sending the initial notification. Must match the regular expression`^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$` Example: "30s"'
+                                  description: |-
+                                    How long to wait before sending the initial notification.
+                                    Must match the regular expression`^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$`
+                                    Example: "30s"
                                   type: string
                                 matchers:
-                                  description: 'List of matchers that the alert''s labels should match. For the first level route, the operator removes any existing equality and regexp matcher on the `namespace` label and adds a `namespace: <object namespace>` matcher.'
+                                  description: |-
+                                    List of matchers that the alert's labels should match. For the first
+                                    level route, the operator removes any existing equality and regexp
+                                    matcher on the `namespace` label and adds a `namespace: <object
+                                    namespace>` matcher.
                                   items:
                                     description: Matcher defines how to match on alert's labels.
                                     properties:
                                       matchType:
-                                        description: Match operation available with AlertManager >= v0.22.0 and takes precedence over Regex (deprecated) if non-empty.
+                                        description: |-
+                                          Match operation available with AlertManager >= v0.22.0 and
+                                          takes precedence over Regex (deprecated) if non-empty.
                                         enum:
                                           - '!='
                                           - "="
@@ -3475,7 +4168,9 @@ spec:
                                         minLength: 1
                                         type: string
                                       regex:
-                                        description: Whether to match on equality (false) or regular-expression (true). Deprecated as of AlertManager >= v0.22.0 where a user should use MatchType instead.
+                                        description: |-
+                                          Whether to match on equality (false) or regular-expression (true).
+                                          Deprecated as of AlertManager >= v0.22.0 where a user should use MatchType instead.
                                         type: boolean
                                       value:
                                         description: Label value to match.
@@ -3485,15 +4180,28 @@ spec:
                                     type: object
                                   type: array
                                 muteTimeIntervals:
-                                  description: 'Note: this comment applies to the field definition above but appears below otherwise it gets included in the generated manifest. CRD schema doesn''t support self-referential types for now (see https://github.com/kubernetes/kubernetes/issues/62872). We have to use an alternative type to circumvent the limitation. The downside is that the Kube API can''t validate the data beyond the fact that it is a valid JSON representation. MuteTimeIntervals is a list of MuteTimeInterval names that will mute this route when matched,'
+                                  description: |-
+                                    Note: this comment applies to the field definition above but appears
+                                    below otherwise it gets included in the generated manifest.
+                                    CRD schema doesn't support self-referential types for now (see
+                                    https://github.com/kubernetes/kubernetes/issues/62872). We have to use
+                                    an alternative type to circumvent the limitation. The downside is that
+                                    the Kube API can't validate the data beyond the fact that it is a valid
+                                    JSON representation.
+                                    MuteTimeIntervals is a list of MuteTimeInterval names that will mute this route when matched,
                                   items:
                                     type: string
                                   type: array
                                 receiver:
-                                  description: Name of the receiver for this route. If not empty, it should be listed in the `receivers` field.
+                                  description: |-
+                                    Name of the receiver for this route. If not empty, it should be listed in
+                                    the `receivers` field.
                                   type: string
                                 repeatInterval:
-                                  description: 'How long to wait before repeating the last notification. Must match the regular expression`^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$` Example: "4h"'
+                                  description: |-
+                                    How long to wait before repeating the last notification.
+                                    Must match the regular expression`^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$`
+                                    Example: "4h"
                                   type: string
                                 routes:
                                   description: Child routes.
@@ -3512,23 +4220,52 @@ spec:
                         ipFilter:
                           default:
                             - 0.0.0.0/0
-                          description: IPFilter is a list of allowed IPv4 CIDR ranges that can access the service. If no IP Filter is set, you may not be able to reach the service. A value of `0.0.0.0/0` will open the service to all addresses on the public internet.
+                          description: |-
+                            IPFilter is a list of allowed IPv4 CIDR ranges that can access the service.
+                            If no IP Filter is set, you may not be able to reach the service.
+                            A value of `0.0.0.0/0` will open the service to all addresses on the public internet.
                           items:
                             type: string
                           type: array
                         serviceType:
                           default: ClusterIP
-                          description: 'ServiceType defines the type of the service. Possible enum values: - `"ClusterIP"` indicates that the service is only reachable from within the cluster. - `"LoadBalancer"` indicates that the service is reachable from the public internet via dedicated Ipv4 address.'
+                          description: |-
+                            ServiceType defines the type of the service.
+                            Possible enum values:
+                              - `"ClusterIP"` indicates that the service is only reachable from within the cluster.
+                              - `"LoadBalancer"` indicates that the service is reachable from the public internet via dedicated Ipv4 address.
                           enum:
                             - ClusterIP
                             - LoadBalancer
                           type: string
                       type: object
                     replication:
-                      description: "This section allows to configure Postgres replication mode and HA roles groups. \n The main replication group is implicit and contains the total number of instances less the sum of all instances in other replication groups."
+                      description: |-
+                        This section allows to configure Postgres replication mode and HA roles groups.
+
+
+                        The main replication group is implicit and contains the total number of instances less the sum of all instances in other replication groups.
                       properties:
                         mode:
-                          description: "Mode defines the replication mode applied to the whole cluster. Possible values are: \"async\"(default), \"sync\", and \"strict-sync\" \n \"async\": When in asynchronous mode the cluster is allowed to lose some committed transactions. When the primary server fails or becomes unavailable for any other reason a sufficiently healthy standby will automatically be promoted to primary. Any transactions that have not been replicated to that standby remain in a “forked timeline” on the primary, and are effectively unrecoverable \n \"sync\": When in synchronous mode a standby will not be promoted unless it is certain that the standby contains all transactions that may have returned a successful commit status to client. This means that the system may be unavailable for writes even though some servers are available. \n \"strict-sync\": When it is absolutely necessary to guarantee that each write is stored durably on at least two nodes, use the strict synchronous mode. This mode prevents synchronous replication to be switched off on the primary when no synchronous standby candidates are available. As a downside, the primary will not be available for writes, blocking all client write requests until at least one synchronous replica comes up. \n NOTE: We recommend to always use three intances when setting the mode to \"strict-sync\"."
+                          description: |-
+                            Mode defines the replication mode applied to the whole cluster. Possible values are: "async"(default), "sync", and "strict-sync"
+
+
+                            "async": When in asynchronous mode the cluster is allowed to lose some committed transactions.
+                            When the primary server fails or becomes unavailable for any other reason a sufficiently healthy standby will automatically be promoted to primary.
+                            Any transactions that have not been replicated to that standby remain in a “forked timeline” on the primary, and are effectively unrecoverable
+
+
+                            "sync": When in synchronous mode a standby will not be promoted unless it is certain that the standby contains all transactions that may have returned a successful commit status to client.
+                             This means that the system may be unavailable for writes even though some servers are available.
+
+
+                            "strict-sync": When it is absolutely necessary to guarantee that each write is stored durably on at least two nodes, use the strict synchronous mode.
+                            This mode prevents synchronous replication to be switched off on the primary when no synchronous standby candidates are available.
+                            As a downside, the primary will not be available for writes, blocking all client write requests until at least one synchronous replica comes up.
+
+
+                            NOTE: We recommend to always use three intances when setting the mode to "strict-sync".
                           enum:
                             - async
                             - sync
@@ -3542,10 +4279,14 @@ spec:
                           description: BackupName is the name of the specific backup you want to restore.
                           type: string
                         claimName:
-                          description: ClaimName specifies the name of the instance you want to restore from. The claim has to be in the same namespace as this new instance.
+                          description: |-
+                            ClaimName specifies the name of the instance you want to restore from.
+                            The claim has to be in the same namespace as this new instance.
                           type: string
                         recoveryTimeStamp:
-                          description: RecoveryTimeStamp an ISO 8601 date, that holds UTC date indicating at which point-in-time the database has to be restored. This is optional and if no PIT recovery is required, it can be left empty.
+                          description: |-
+                            RecoveryTimeStamp an ISO 8601 date, that holds UTC date indicating at which point-in-time the database has to be restored.
+                            This is optional and if no PIT recovery is required, it can be left empty.
                           pattern: ^(?:[1-9]\d{3}-(?:(?:0[1-9]|1[0-2])-(?:0[1-9]|1\d|2[0-8])|(?:0[13-9]|1[0-2])-(?:29|30)|(?:0[13578]|1[02])-31)|(?:[1-9]\d(?:0[48]|[2468][048]|[13579][26])|(?:[2468][048]|[13579][26])00)-02-29)T(?:[01]\d|2[0-3]):[0-5]\d:[0-5]\d(?:Z|[+-][01]\d:[0-5]\d)$
                           type: string
                       type: object
@@ -3567,13 +4308,17 @@ spec:
                             description: VSHNDBaaSPostgresExtension contains the name of a single extension.
                             properties:
                               name:
-                                description: Name is the name of the extension to enable. For an extensive list, please consult https://stackgres.io/doc/latest/intro/extensions/
+                                description: |-
+                                  Name is the name of the extension to enable.
+                                  For an extensive list, please consult https://stackgres.io/doc/latest/intro/extensions/
                                 type: string
                             type: object
                           type: array
                         majorVersion:
                           default: "15"
-                          description: MajorVersion contains supported version of PostgreSQL. Multiple versions are supported. The latest version "15" is the default version.
+                          description: |-
+                            MajorVersion contains supported version of PostgreSQL.
+                            Multiple versions are supported. The latest version "15" is the default version.
                           enum:
                             - "12"
                             - "13"
@@ -3584,15 +4329,27 @@ spec:
                           description: PgBouncerSettings passes additional configuration to the pgBouncer instance.
                           properties:
                             databases:
-                              description: "The `pgbouncer.ini` (Section [databases]) parameters the configuration contains, represented as an object where the keys are valid names for the `pgbouncer.ini` configuration file parameters. \n Check [pgbouncer configuration](https://www.pgbouncer.org/config.html#section-databases) for more information about supported parameters."
+                              description: |-
+                                The `pgbouncer.ini` (Section [databases]) parameters the configuration contains, represented as an object where the keys are valid names for the `pgbouncer.ini` configuration file parameters.
+
+
+                                Check [pgbouncer configuration](https://www.pgbouncer.org/config.html#section-databases) for more information about supported parameters.
                               type: object
                               x-kubernetes-preserve-unknown-fields: true
                             pgbouncer:
-                              description: "The `pgbouncer.ini` (Section [pgbouncer]) parameters the configuration contains, represented as an object where the keys are valid names for the `pgbouncer.ini` configuration file parameters. \n Check [pgbouncer configuration](https://www.pgbouncer.org/config.html#generic-settings) for more information about supported parameters"
+                              description: |-
+                                The `pgbouncer.ini` (Section [pgbouncer]) parameters the configuration contains, represented as an object where the keys are valid names for the `pgbouncer.ini` configuration file parameters.
+
+
+                                Check [pgbouncer configuration](https://www.pgbouncer.org/config.html#generic-settings) for more information about supported parameters
                               type: object
                               x-kubernetes-preserve-unknown-fields: true
                             users:
-                              description: "The `pgbouncer.ini` (Section [users]) parameters the configuration contains, represented as an object where the keys are valid names for the `pgbouncer.ini` configuration file parameters. \n Check [pgbouncer configuration](https://www.pgbouncer.org/config.html#section-users) for more information about supported parameters."
+                              description: |-
+                                The `pgbouncer.ini` (Section [users]) parameters the configuration contains, represented as an object where the keys are valid names for the `pgbouncer.ini` configuration file parameters.
+
+
+                                Check [pgbouncer configuration](https://www.pgbouncer.org/config.html#section-users) for more information about supported parameters.
                               type: object
                               x-kubernetes-preserve-unknown-fields: true
                           type: object
@@ -3641,7 +4398,11 @@ spec:
                       properties:
                         type:
                           default: Immediate
-                          description: 'Type indicates the type of the UpdateStrategy. Default is OnRestart. Possible enum values: - `"OnRestart"` indicates that the changes to the spec will only be applied once the instance is restarted by other means, most likely during maintenance. - `"Immediate"` indicates that update will be applied to the instance as soon as the spec changes. Please be aware that this might lead to short downtime.'
+                          description: |-
+                            Type indicates the type of the UpdateStrategy. Default is OnRestart.
+                            Possible enum values:
+                              - `"OnRestart"` indicates that the changes to the spec will only be applied once the instance is restarted by other means, most likely during maintenance.
+                              - `"Immediate"` indicates that update will be applied to the instance as soon as the spec changes. Please be aware that this might lead to short downtime.
                           enum:
                             - Immediate
                             - OnRestart
@@ -3652,7 +4413,10 @@ spec:
                 providerConfigRef:
                   default:
                     name: default
-                  description: ProviderConfigReference specifies how the provider that will be used to create, observe, update, and delete this managed resource should be configured.
+                  description: |-
+                    ProviderConfigReference specifies how the provider that will be used to
+                    create, observe, update, and delete this managed resource should be
+                    configured.
                   properties:
                     name:
                       description: Name of the referenced object.
@@ -3662,13 +4426,21 @@ spec:
                       properties:
                         resolution:
                           default: Required
-                          description: Resolution specifies whether resolution of this reference is required. The default is 'Required', which means the reconcile will fail if the reference cannot be resolved. 'Optional' means this reference will be a no-op if it cannot be resolved.
+                          description: |-
+                            Resolution specifies whether resolution of this reference is required.
+                            The default is 'Required', which means the reconcile will fail if the
+                            reference cannot be resolved. 'Optional' means this reference will be
+                            a no-op if it cannot be resolved.
                           enum:
                             - Required
                             - Optional
                           type: string
                         resolve:
-                          description: Resolve specifies when this reference should be resolved. The default is 'IfNotPresent', which will attempt to resolve the reference only when the corresponding field is not present. Use 'Always' to resolve the reference on every reconcile.
+                          description: |-
+                            Resolve specifies when this reference should be resolved. The default
+                            is 'IfNotPresent', which will attempt to resolve the reference only when
+                            the corresponding field is not present. Use 'Always' to resolve the
+                            reference on every reconcile.
                           enum:
                             - Always
                             - IfNotPresent
@@ -3678,12 +4450,19 @@ spec:
                     - name
                   type: object
                 publishConnectionDetailsTo:
-                  description: PublishConnectionDetailsTo specifies the connection secret config which contains a name, metadata and a reference to secret store config to which any connection details for this managed resource should be written. Connection details frequently include the endpoint, username, and password required to connect to the managed resource.
+                  description: |-
+                    PublishConnectionDetailsTo specifies the connection secret config which
+                    contains a name, metadata and a reference to secret store config to
+                    which any connection details for this managed resource should be written.
+                    Connection details frequently include the endpoint, username,
+                    and password required to connect to the managed resource.
                   properties:
                     configRef:
                       default:
                         name: default
-                      description: SecretStoreConfigRef specifies which secret store config should be used for this ConnectionSecret.
+                      description: |-
+                        SecretStoreConfigRef specifies which secret store config should be used
+                        for this ConnectionSecret.
                       properties:
                         name:
                           description: Name of the referenced object.
@@ -3693,13 +4472,21 @@ spec:
                           properties:
                             resolution:
                               default: Required
-                              description: Resolution specifies whether resolution of this reference is required. The default is 'Required', which means the reconcile will fail if the reference cannot be resolved. 'Optional' means this reference will be a no-op if it cannot be resolved.
+                              description: |-
+                                Resolution specifies whether resolution of this reference is required.
+                                The default is 'Required', which means the reconcile will fail if the
+                                reference cannot be resolved. 'Optional' means this reference will be
+                                a no-op if it cannot be resolved.
                               enum:
                                 - Required
                                 - Optional
                               type: string
                             resolve:
-                              description: Resolve specifies when this reference should be resolved. The default is 'IfNotPresent', which will attempt to resolve the reference only when the corresponding field is not present. Use 'Always' to resolve the reference on every reconcile.
+                              description: |-
+                                Resolve specifies when this reference should be resolved. The default
+                                is 'IfNotPresent', which will attempt to resolve the reference only when
+                                the corresponding field is not present. Use 'Always' to resolve the
+                                reference on every reconcile.
                               enum:
                                 - Always
                                 - IfNotPresent
@@ -3714,15 +4501,23 @@ spec:
                         annotations:
                           additionalProperties:
                             type: string
-                          description: Annotations are the annotations to be added to connection secret. - For Kubernetes secrets, this will be used as "metadata.annotations". - It is up to Secret Store implementation for others store types.
+                          description: |-
+                            Annotations are the annotations to be added to connection secret.
+                            - For Kubernetes secrets, this will be used as "metadata.annotations".
+                            - It is up to Secret Store implementation for others store types.
                           type: object
                         labels:
                           additionalProperties:
                             type: string
-                          description: Labels are the labels/tags to be added to connection secret. - For Kubernetes secrets, this will be used as "metadata.labels". - It is up to Secret Store implementation for others store types.
+                          description: |-
+                            Labels are the labels/tags to be added to connection secret.
+                            - For Kubernetes secrets, this will be used as "metadata.labels".
+                            - It is up to Secret Store implementation for others store types.
                           type: object
                         type:
-                          description: Type is the SecretType for the connection secret. - Only valid for Kubernetes Secret Stores.
+                          description: |-
+                            Type is the SecretType for the connection secret.
+                            - Only valid for Kubernetes Secret Stores.
                           type: string
                       type: object
                     name:
@@ -3732,7 +4527,15 @@ spec:
                     - name
                   type: object
                 writeConnectionSecretToRef:
-                  description: WriteConnectionSecretToReference specifies the namespace and name of a Secret to which any connection details for this managed resource should be written. Connection details frequently include the endpoint, username, and password required to connect to the managed resource. This field is planned to be replaced in a future release in favor of PublishConnectionDetailsTo. Currently, both could be set independently and connection details would be published to both without affecting each other.
+                  description: |-
+                    WriteConnectionSecretToReference specifies the namespace and name of a
+                    Secret to which any connection details for this managed resource should
+                    be written. Connection details frequently include the endpoint, username,
+                    and password required to connect to the managed resource.
+                    This field is planned to be replaced in a future release in favor of
+                    PublishConnectionDetailsTo. Currently, both could be set independently
+                    and connection details would be published to both without affecting
+                    each other.
                   properties:
                     name:
                       description: Name of the secret.
@@ -3760,7 +4563,9 @@ spec:
                         maxLength: 32768
                         type: string
                       observedGeneration:
-                        description: ObservedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        description: |-
+                          ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                         format: int64
                         minimum: 0
                         type: integer
@@ -3801,7 +4606,9 @@ spec:
                         maxLength: 32768
                         type: string
                       observedGeneration:
-                        description: ObservedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        description: |-
+                          ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                         format: int64
                         minimum: 0
                         type: integer
@@ -3836,7 +4643,9 @@ spec:
                         maxLength: 32768
                         type: string
                       observedGeneration:
-                        description: ObservedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        description: |-
+                          ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                         format: int64
                         minimum: 0
                         type: integer
@@ -3871,7 +4680,9 @@ spec:
                         maxLength: 32768
                         type: string
                       observedGeneration:
-                        description: ObservedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        description: |-
+                          ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                         format: int64
                         minimum: 0
                         type: integer
@@ -3906,7 +4717,9 @@ spec:
                         maxLength: 32768
                         type: string
                       observedGeneration:
-                        description: ObservedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        description: |-
+                          ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                         format: int64
                         minimum: 0
                         type: integer
@@ -3941,7 +4754,9 @@ spec:
                         maxLength: 32768
                         type: string
                       observedGeneration:
-                        description: ObservedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        description: |-
+                          ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                         format: int64
                         minimum: 0
                         type: integer
@@ -3976,7 +4791,9 @@ spec:
                         maxLength: 32768
                         type: string
                       observedGeneration:
-                        description: ObservedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        description: |-
+                          ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                         format: int64
                         minimum: 0
                         type: integer
@@ -4011,7 +4828,9 @@ spec:
                         maxLength: 32768
                         type: string
                       observedGeneration:
-                        description: ObservedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        description: |-
+                          ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                         format: int64
                         minimum: 0
                         type: integer
@@ -4047,7 +4866,9 @@ spec:
                         maxLength: 32768
                         type: string
                       observedGeneration:
-                        description: ObservedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        description: |-
+                          ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                         format: int64
                         minimum: 0
                         type: integer
@@ -4082,7 +4903,9 @@ spec:
                         maxLength: 32768
                         type: string
                       observedGeneration:
-                        description: ObservedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        description: |-
+                          ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                         format: int64
                         minimum: 0
                         type: integer
@@ -4106,7 +4929,9 @@ spec:
                     type: object
                   type: array
                 schedules:
-                  description: Schedules keeps track of random generated schedules, is overwriten by schedules set in the service's spec.
+                  description: |-
+                    Schedules keeps track of random generated schedules, is overwriten by
+                    schedules set in the service's spec.
                   properties:
                     backup:
                       description: Backup keeps track of the backup schedule.
@@ -4115,7 +4940,9 @@ spec:
                       description: Maintenance keeps track of the maintenance schedule.
                       properties:
                         dayOfWeek:
-                          description: DayOfWeek specifies at which weekday the maintenance is held place. Allowed values are [monday, tuesday, wednesday, thursday, friday, saturday, sunday]
+                          description: |-
+                            DayOfWeek specifies at which weekday the maintenance is held place.
+                            Allowed values are [monday, tuesday, wednesday, thursday, friday, saturday, sunday]
                           enum:
                             - monday
                             - tuesday
@@ -4126,7 +4953,9 @@ spec:
                             - sunday
                           type: string
                         timeOfDay:
-                          description: 'TimeOfDay for installing updates in UTC. Format: "hh:mm:ss".'
+                          description: |-
+                            TimeOfDay for installing updates in UTC.
+                            Format: "hh:mm:ss".
                           pattern: ^([0-1]?[0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9])$
                           type: string
                       type: object
@@ -4143,7 +4972,9 @@ spec:
                         maxLength: 32768
                         type: string
                       observedGeneration:
-                        description: ObservedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        description: |-
+                          ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                         format: int64
                         minimum: 0
                         type: integer

--- a/crds/vshn.appcat.vshn.io_vshnredis.yaml
+++ b/crds/vshn.appcat.vshn.io_vshnredis.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: vshnredis.vshn.appcat.vshn.io
 spec:
   group: vshn.appcat.vshn.io
@@ -20,10 +20,19 @@ spec:
           description: VSHNRedis is the API for creating Redis clusters.
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -62,7 +71,9 @@ spec:
                       description: Maintenance contains settings to control the maintenance of an instance.
                       properties:
                         dayOfWeek:
-                          description: DayOfWeek specifies at which weekday the maintenance is held place. Allowed values are [monday, tuesday, wednesday, thursday, friday, saturday, sunday]
+                          description: |-
+                            DayOfWeek specifies at which weekday the maintenance is held place.
+                            Allowed values are [monday, tuesday, wednesday, thursday, friday, saturday, sunday]
                           enum:
                             - monday
                             - tuesday
@@ -73,7 +84,9 @@ spec:
                             - sunday
                           type: string
                         timeOfDay:
-                          description: 'TimeOfDay for installing updates in UTC. Format: "hh:mm:ss".'
+                          description: |-
+                            TimeOfDay for installing updates in UTC.
+                            Format: "hh:mm:ss".
                           pattern: ^([0-1]?[0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9])$
                           type: string
                       type: object
@@ -81,31 +94,49 @@ spec:
                       description: Monitoring contains settings to control monitoring.
                       properties:
                         alertmanagerConfigRef:
-                          description: AlertmanagerConfigRef contains the name of the AlertmanagerConfig that should be copied over to the namespace of the instance.
+                          description: |-
+                            AlertmanagerConfigRef contains the name of the AlertmanagerConfig that should be copied over to the
+                            namespace of the instance.
                           type: string
                         alertmanagerConfigSecretRef:
-                          description: AlertmanagerConfigSecretRef contains the name of the secret that is used in the referenced AlertmanagerConfig
+                          description: |-
+                            AlertmanagerConfigSecretRef contains the name of the secret that is used
+                            in the referenced AlertmanagerConfig
                           type: string
                         alertmanagerConfigTemplate:
-                          description: AlertmanagerConfigSpecTemplate takes an AlertmanagerConfigSpec object. This takes precedence over the AlertmanagerConfigRef.
+                          description: |-
+                            AlertmanagerConfigSpecTemplate takes an AlertmanagerConfigSpec object.
+                            This takes precedence over the AlertmanagerConfigRef.
                           properties:
                             inhibitRules:
-                              description: List of inhibition rules. The rules will only apply to alerts matching the resource's namespace.
+                              description: |-
+                                List of inhibition rules. The rules will only apply to alerts matching
+                                the resource's namespace.
                               items:
-                                description: InhibitRule defines an inhibition rule that allows to mute alerts when other alerts are already firing. See https://prometheus.io/docs/alerting/latest/configuration/#inhibit_rule
+                                description: |-
+                                  InhibitRule defines an inhibition rule that allows to mute alerts when other
+                                  alerts are already firing.
+                                  See https://prometheus.io/docs/alerting/latest/configuration/#inhibit_rule
                                 properties:
                                   equal:
-                                    description: Labels that must have an equal value in the source and target alert for the inhibition to take effect.
+                                    description: |-
+                                      Labels that must have an equal value in the source and target alert for
+                                      the inhibition to take effect.
                                     items:
                                       type: string
                                     type: array
                                   sourceMatch:
-                                    description: Matchers for which one or more alerts have to exist for the inhibition to take effect. The operator enforces that the alert matches the resource's namespace.
+                                    description: |-
+                                      Matchers for which one or more alerts have to exist for the inhibition
+                                      to take effect. The operator enforces that the alert matches the
+                                      resource's namespace.
                                     items:
                                       description: Matcher defines how to match on alert's labels.
                                       properties:
                                         matchType:
-                                          description: Match operation available with AlertManager >= v0.22.0 and takes precedence over Regex (deprecated) if non-empty.
+                                          description: |-
+                                            Match operation available with AlertManager >= v0.22.0 and
+                                            takes precedence over Regex (deprecated) if non-empty.
                                           enum:
                                             - '!='
                                             - "="
@@ -117,7 +148,9 @@ spec:
                                           minLength: 1
                                           type: string
                                         regex:
-                                          description: Whether to match on equality (false) or regular-expression (true). Deprecated as of AlertManager >= v0.22.0 where a user should use MatchType instead.
+                                          description: |-
+                                            Whether to match on equality (false) or regular-expression (true).
+                                            Deprecated as of AlertManager >= v0.22.0 where a user should use MatchType instead.
                                           type: boolean
                                         value:
                                           description: Label value to match.
@@ -127,12 +160,16 @@ spec:
                                       type: object
                                     type: array
                                   targetMatch:
-                                    description: Matchers that have to be fulfilled in the alerts to be muted. The operator enforces that the alert matches the resource's namespace.
+                                    description: |-
+                                      Matchers that have to be fulfilled in the alerts to be muted. The
+                                      operator enforces that the alert matches the resource's namespace.
                                     items:
                                       description: Matcher defines how to match on alert's labels.
                                       properties:
                                         matchType:
-                                          description: Match operation available with AlertManager >= v0.22.0 and takes precedence over Regex (deprecated) if non-empty.
+                                          description: |-
+                                            Match operation available with AlertManager >= v0.22.0 and
+                                            takes precedence over Regex (deprecated) if non-empty.
                                           enum:
                                             - '!='
                                             - "="
@@ -144,7 +181,9 @@ spec:
                                           minLength: 1
                                           type: string
                                         regex:
-                                          description: Whether to match on equality (false) or regular-expression (true). Deprecated as of AlertManager >= v0.22.0 where a user should use MatchType instead.
+                                          description: |-
+                                            Whether to match on equality (false) or regular-expression (true).
+                                            Deprecated as of AlertManager >= v0.22.0 where a user should use MatchType instead.
                                           type: boolean
                                         value:
                                           description: Label value to match.
@@ -188,7 +227,9 @@ spec:
                                         months:
                                           description: Months is a list of MonthRange
                                           items:
-                                            description: MonthRange is an inclusive range of months of the year beginning in January Months can be specified by name (e.g 'January') by numerical month (e.g '1') or as an inclusive range (e.g 'January:March', '1:3', '1:March')
+                                            description: |-
+                                              MonthRange is an inclusive range of months of the year beginning in January
+                                              Months can be specified by name (e.g 'January') by numerical month (e.g '1') or as an inclusive range (e.g 'January:March', '1:3', '1:March')
                                             pattern: ^((?i)january|february|march|april|may|june|july|august|september|october|november|december|[1-12])(?:((:((?i)january|february|march|april|may|june|july|august|september|october|november|december|[1-12]))$)|$)
                                             type: string
                                           type: array
@@ -210,7 +251,9 @@ spec:
                                         weekdays:
                                           description: Weekdays is a list of WeekdayRange
                                           items:
-                                            description: WeekdayRange is an inclusive range of days of the week beginning on Sunday Days can be specified by name (e.g 'Sunday') or as an inclusive range (e.g 'Monday:Friday')
+                                            description: |-
+                                              WeekdayRange is an inclusive range of days of the week beginning on Sunday
+                                              Days can be specified by name (e.g 'Sunday') or as an inclusive range (e.g 'Monday:Friday')
                                             pattern: ^((?i)sun|mon|tues|wednes|thurs|fri|satur)day(?:((:(sun|mon|tues|wednes|thurs|fri|satur)day)$)|$)
                                             type: string
                                           type: array
@@ -239,13 +282,19 @@ spec:
                                           description: The identity to use for authentication.
                                           type: string
                                         authPassword:
-                                          description: The secret's key that contains the password to use for authentication. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.
+                                          description: |-
+                                            The secret's key that contains the password to use for authentication.
+                                            The secret needs to be in the same namespace as the AlertmanagerConfig
+                                            object and accessible by the Prometheus Operator.
                                           properties:
                                             key:
                                               description: The key of the secret to select from.  Must be a valid secret key.
                                               type: string
                                             name:
-                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                              description: |-
+                                                Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description: Specify whether the Secret or its key must be defined
@@ -255,13 +304,19 @@ spec:
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         authSecret:
-                                          description: The secret's key that contains the CRAM-MD5 secret. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.
+                                          description: |-
+                                            The secret's key that contains the CRAM-MD5 secret.
+                                            The secret needs to be in the same namespace as the AlertmanagerConfig
+                                            object and accessible by the Prometheus Operator.
                                           properties:
                                             key:
                                               description: The key of the secret to select from.  Must be a valid secret key.
                                               type: string
                                             name:
-                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                              description: |-
+                                                Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description: Specify whether the Secret or its key must be defined
@@ -277,7 +332,9 @@ spec:
                                           description: The sender address.
                                           type: string
                                         headers:
-                                          description: Further headers email header key/value pairs. Overrides any headers previously set by the notification implementation.
+                                          description: |-
+                                            Further headers email header key/value pairs. Overrides any headers
+                                            previously set by the notification implementation.
                                           items:
                                             description: KeyValue defines a (key, value) tuple.
                                             properties:
@@ -300,7 +357,9 @@ spec:
                                           description: The HTML body of the email notification.
                                           type: string
                                         requireTLS:
-                                          description: The SMTP TLS requirement. Note that Go does not support unencrypted connections to remote SMTP endpoints.
+                                          description: |-
+                                            The SMTP TLS requirement.
+                                            Note that Go does not support unencrypted connections to remote SMTP endpoints.
                                           type: boolean
                                         sendResolved:
                                           description: Whether or not to notify about resolved alerts.
@@ -324,7 +383,10 @@ spec:
                                                       description: The key to select.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the ConfigMap or its key must be defined
@@ -340,7 +402,10 @@ spec:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -360,7 +425,10 @@ spec:
                                                       description: The key to select.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the ConfigMap or its key must be defined
@@ -376,7 +444,10 @@ spec:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -396,7 +467,10 @@ spec:
                                                   description: The key of the secret to select from.  Must be a valid secret key.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                  description: |-
+                                                    Name of the referent.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                   type: string
                                                 optional:
                                                   description: Specify whether the Secret or its key must be defined
@@ -421,19 +495,27 @@ spec:
                                   opsgenieConfigs:
                                     description: List of OpsGenie configurations.
                                     items:
-                                      description: OpsGenieConfig configures notifications via OpsGenie. See https://prometheus.io/docs/alerting/latest/configuration/#opsgenie_config
+                                      description: |-
+                                        OpsGenieConfig configures notifications via OpsGenie.
+                                        See https://prometheus.io/docs/alerting/latest/configuration/#opsgenie_config
                                       properties:
                                         actions:
                                           description: Comma separated list of actions that will be available for the alert.
                                           type: string
                                         apiKey:
-                                          description: The secret's key that contains the OpsGenie API key. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.
+                                          description: |-
+                                            The secret's key that contains the OpsGenie API key.
+                                            The secret needs to be in the same namespace as the AlertmanagerConfig
+                                            object and accessible by the Prometheus Operator.
                                           properties:
                                             key:
                                               description: The key of the secret to select from.  Must be a valid secret key.
                                               type: string
                                             name:
-                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                              description: |-
+                                                Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description: Specify whether the Secret or its key must be defined
@@ -472,7 +554,9 @@ spec:
                                           description: HTTP client configuration.
                                           properties:
                                             authorization:
-                                              description: Authorization header configuration for the client. This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
+                                              description: |-
+                                                Authorization header configuration for the client.
+                                                This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
                                               properties:
                                                 credentials:
                                                   description: The secret's key that contains the credentials of the request
@@ -481,7 +565,10 @@ spec:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -491,20 +578,29 @@ spec:
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 type:
-                                                  description: Set the authentication type. Defaults to Bearer, Basic will cause an error
+                                                  description: |-
+                                                    Set the authentication type. Defaults to Bearer, Basic will cause an
+                                                    error
                                                   type: string
                                               type: object
                                             basicAuth:
-                                              description: BasicAuth for the client. This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
+                                              description: |-
+                                                BasicAuth for the client.
+                                                This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
                                               properties:
                                                 password:
-                                                  description: The secret in the service monitor namespace that contains the password for authentication.
+                                                  description: |-
+                                                    The secret in the service monitor namespace that contains the password
+                                                    for authentication.
                                                   properties:
                                                     key:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -514,13 +610,18 @@ spec:
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 username:
-                                                  description: The secret in the service monitor namespace that contains the username for authentication.
+                                                  description: |-
+                                                    The secret in the service monitor namespace that contains the username
+                                                    for authentication.
                                                   properties:
                                                     key:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -531,13 +632,20 @@ spec:
                                                   x-kubernetes-map-type: atomic
                                               type: object
                                             bearerTokenSecret:
-                                              description: The secret's key that contains the bearer token to be used by the client for authentication. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.
+                                              description: |-
+                                                The secret's key that contains the bearer token to be used by the client
+                                                for authentication.
+                                                The secret needs to be in the same namespace as the AlertmanagerConfig
+                                                object and accessible by the Prometheus Operator.
                                               properties:
                                                 key:
                                                   description: The key of the secret to select from.  Must be a valid secret key.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                  description: |-
+                                                    Name of the referent.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                   type: string
                                                 optional:
                                                   description: Specify whether the Secret or its key must be defined
@@ -562,7 +670,10 @@ spec:
                                                           description: The key to select.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the ConfigMap or its key must be defined
@@ -578,7 +689,10 @@ spec:
                                                           description: The key of the secret to select from.  Must be a valid secret key.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the Secret or its key must be defined
@@ -595,7 +709,10 @@ spec:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -639,7 +756,10 @@ spec:
                                                           description: The key to select.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the ConfigMap or its key must be defined
@@ -655,7 +775,10 @@ spec:
                                                           description: The key of the secret to select from.  Must be a valid secret key.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the Secret or its key must be defined
@@ -675,7 +798,10 @@ spec:
                                                           description: The key to select.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the ConfigMap or its key must be defined
@@ -691,7 +817,10 @@ spec:
                                                           description: The key of the secret to select from.  Must be a valid secret key.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the Secret or its key must be defined
@@ -711,7 +840,10 @@ spec:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -737,7 +869,9 @@ spec:
                                         responders:
                                           description: List of responders responsible for notifications.
                                           items:
-                                            description: OpsGenieConfigResponder defines a responder to an incident. One of `id`, `name` or `username` has to be defined.
+                                            description: |-
+                                              OpsGenieConfigResponder defines a responder to an incident.
+                                              One of `id`, `name` or `username` has to be defined.
                                             properties:
                                               id:
                                                 description: ID of the responder.
@@ -772,14 +906,18 @@ spec:
                                           description: Comma separated list of tags attached to the notifications.
                                           type: string
                                         updateAlerts:
-                                          description: Whether to update message and description of the alert in OpsGenie if it already exists By default, the alert is never updated in OpsGenie, the new message only appears in activity log.
+                                          description: |-
+                                            Whether to update message and description of the alert in OpsGenie if it already exists
+                                            By default, the alert is never updated in OpsGenie, the new message only appears in activity log.
                                           type: boolean
                                       type: object
                                     type: array
                                   pagerdutyConfigs:
                                     description: List of PagerDuty configurations.
                                     items:
-                                      description: PagerDutyConfig configures notifications via PagerDuty. See https://prometheus.io/docs/alerting/latest/configuration/#pagerduty_config
+                                      description: |-
+                                        PagerDutyConfig configures notifications via PagerDuty.
+                                        See https://prometheus.io/docs/alerting/latest/configuration/#pagerduty_config
                                       properties:
                                         class:
                                           description: The class/type of the event.
@@ -820,7 +958,9 @@ spec:
                                           description: HTTP client configuration.
                                           properties:
                                             authorization:
-                                              description: Authorization header configuration for the client. This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
+                                              description: |-
+                                                Authorization header configuration for the client.
+                                                This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
                                               properties:
                                                 credentials:
                                                   description: The secret's key that contains the credentials of the request
@@ -829,7 +969,10 @@ spec:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -839,20 +982,29 @@ spec:
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 type:
-                                                  description: Set the authentication type. Defaults to Bearer, Basic will cause an error
+                                                  description: |-
+                                                    Set the authentication type. Defaults to Bearer, Basic will cause an
+                                                    error
                                                   type: string
                                               type: object
                                             basicAuth:
-                                              description: BasicAuth for the client. This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
+                                              description: |-
+                                                BasicAuth for the client.
+                                                This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
                                               properties:
                                                 password:
-                                                  description: The secret in the service monitor namespace that contains the password for authentication.
+                                                  description: |-
+                                                    The secret in the service monitor namespace that contains the password
+                                                    for authentication.
                                                   properties:
                                                     key:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -862,13 +1014,18 @@ spec:
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 username:
-                                                  description: The secret in the service monitor namespace that contains the username for authentication.
+                                                  description: |-
+                                                    The secret in the service monitor namespace that contains the username
+                                                    for authentication.
                                                   properties:
                                                     key:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -879,13 +1036,20 @@ spec:
                                                   x-kubernetes-map-type: atomic
                                               type: object
                                             bearerTokenSecret:
-                                              description: The secret's key that contains the bearer token to be used by the client for authentication. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.
+                                              description: |-
+                                                The secret's key that contains the bearer token to be used by the client
+                                                for authentication.
+                                                The secret needs to be in the same namespace as the AlertmanagerConfig
+                                                object and accessible by the Prometheus Operator.
                                               properties:
                                                 key:
                                                   description: The key of the secret to select from.  Must be a valid secret key.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                  description: |-
+                                                    Name of the referent.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                   type: string
                                                 optional:
                                                   description: Specify whether the Secret or its key must be defined
@@ -910,7 +1074,10 @@ spec:
                                                           description: The key to select.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the ConfigMap or its key must be defined
@@ -926,7 +1093,10 @@ spec:
                                                           description: The key of the secret to select from.  Must be a valid secret key.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the Secret or its key must be defined
@@ -943,7 +1113,10 @@ spec:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -987,7 +1160,10 @@ spec:
                                                           description: The key to select.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the ConfigMap or its key must be defined
@@ -1003,7 +1179,10 @@ spec:
                                                           description: The key of the secret to select from.  Must be a valid secret key.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the Secret or its key must be defined
@@ -1023,7 +1202,10 @@ spec:
                                                           description: The key to select.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the ConfigMap or its key must be defined
@@ -1039,7 +1221,10 @@ spec:
                                                           description: The key of the secret to select from.  Must be a valid secret key.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the Secret or its key must be defined
@@ -1059,7 +1244,10 @@ spec:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -1103,13 +1291,20 @@ spec:
                                             type: object
                                           type: array
                                         routingKey:
-                                          description: The secret's key that contains the PagerDuty integration key (when using Events API v2). Either this field or `serviceKey` needs to be defined. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.
+                                          description: |-
+                                            The secret's key that contains the PagerDuty integration key (when using
+                                            Events API v2). Either this field or `serviceKey` needs to be defined.
+                                            The secret needs to be in the same namespace as the AlertmanagerConfig
+                                            object and accessible by the Prometheus Operator.
                                           properties:
                                             key:
                                               description: The key of the secret to select from.  Must be a valid secret key.
                                               type: string
                                             name:
-                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                              description: |-
+                                                Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description: Specify whether the Secret or its key must be defined
@@ -1122,13 +1317,21 @@ spec:
                                           description: Whether or not to notify about resolved alerts.
                                           type: boolean
                                         serviceKey:
-                                          description: The secret's key that contains the PagerDuty service key (when using integration type "Prometheus"). Either this field or `routingKey` needs to be defined. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.
+                                          description: |-
+                                            The secret's key that contains the PagerDuty service key (when using
+                                            integration type "Prometheus"). Either this field or `routingKey` needs to
+                                            be defined.
+                                            The secret needs to be in the same namespace as the AlertmanagerConfig
+                                            object and accessible by the Prometheus Operator.
                                           properties:
                                             key:
                                               description: The key of the secret to select from.  Must be a valid secret key.
                                               type: string
                                             name:
-                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                              description: |-
+                                                Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description: Specify whether the Secret or its key must be defined
@@ -1148,10 +1351,14 @@ spec:
                                   pushoverConfigs:
                                     description: List of Pushover configurations.
                                     items:
-                                      description: PushoverConfig configures notifications via Pushover. See https://prometheus.io/docs/alerting/latest/configuration/#pushover_config
+                                      description: |-
+                                        PushoverConfig configures notifications via Pushover.
+                                        See https://prometheus.io/docs/alerting/latest/configuration/#pushover_config
                                       properties:
                                         expire:
-                                          description: How long your notification will continue to be retried for, unless the user acknowledges the notification.
+                                          description: |-
+                                            How long your notification will continue to be retried for, unless the user
+                                            acknowledges the notification.
                                           pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
                                           type: string
                                         html:
@@ -1161,7 +1368,9 @@ spec:
                                           description: HTTP client configuration.
                                           properties:
                                             authorization:
-                                              description: Authorization header configuration for the client. This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
+                                              description: |-
+                                                Authorization header configuration for the client.
+                                                This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
                                               properties:
                                                 credentials:
                                                   description: The secret's key that contains the credentials of the request
@@ -1170,7 +1379,10 @@ spec:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -1180,20 +1392,29 @@ spec:
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 type:
-                                                  description: Set the authentication type. Defaults to Bearer, Basic will cause an error
+                                                  description: |-
+                                                    Set the authentication type. Defaults to Bearer, Basic will cause an
+                                                    error
                                                   type: string
                                               type: object
                                             basicAuth:
-                                              description: BasicAuth for the client. This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
+                                              description: |-
+                                                BasicAuth for the client.
+                                                This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
                                               properties:
                                                 password:
-                                                  description: The secret in the service monitor namespace that contains the password for authentication.
+                                                  description: |-
+                                                    The secret in the service monitor namespace that contains the password
+                                                    for authentication.
                                                   properties:
                                                     key:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -1203,13 +1424,18 @@ spec:
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 username:
-                                                  description: The secret in the service monitor namespace that contains the username for authentication.
+                                                  description: |-
+                                                    The secret in the service monitor namespace that contains the username
+                                                    for authentication.
                                                   properties:
                                                     key:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -1220,13 +1446,20 @@ spec:
                                                   x-kubernetes-map-type: atomic
                                               type: object
                                             bearerTokenSecret:
-                                              description: The secret's key that contains the bearer token to be used by the client for authentication. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.
+                                              description: |-
+                                                The secret's key that contains the bearer token to be used by the client
+                                                for authentication.
+                                                The secret needs to be in the same namespace as the AlertmanagerConfig
+                                                object and accessible by the Prometheus Operator.
                                               properties:
                                                 key:
                                                   description: The key of the secret to select from.  Must be a valid secret key.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                  description: |-
+                                                    Name of the referent.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                   type: string
                                                 optional:
                                                   description: Specify whether the Secret or its key must be defined
@@ -1251,7 +1484,10 @@ spec:
                                                           description: The key to select.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the ConfigMap or its key must be defined
@@ -1267,7 +1503,10 @@ spec:
                                                           description: The key of the secret to select from.  Must be a valid secret key.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the Secret or its key must be defined
@@ -1284,7 +1523,10 @@ spec:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -1328,7 +1570,10 @@ spec:
                                                           description: The key to select.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the ConfigMap or its key must be defined
@@ -1344,7 +1589,10 @@ spec:
                                                           description: The key of the secret to select from.  Must be a valid secret key.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the Secret or its key must be defined
@@ -1364,7 +1612,10 @@ spec:
                                                           description: The key to select.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the ConfigMap or its key must be defined
@@ -1380,7 +1631,10 @@ spec:
                                                           description: The key of the secret to select from.  Must be a valid secret key.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the Secret or its key must be defined
@@ -1400,7 +1654,10 @@ spec:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -1421,7 +1678,9 @@ spec:
                                           description: Priority, see https://pushover.net/api#priority
                                           type: string
                                         retry:
-                                          description: How often the Pushover servers will send the same notification to the user. Must be at least 30 seconds.
+                                          description: |-
+                                            How often the Pushover servers will send the same notification to the user.
+                                            Must be at least 30 seconds.
                                           pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
                                           type: string
                                         sendResolved:
@@ -1434,13 +1693,19 @@ spec:
                                           description: Notification title.
                                           type: string
                                         token:
-                                          description: The secret's key that contains the registered application's API token, see https://pushover.net/apps. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.
+                                          description: |-
+                                            The secret's key that contains the registered application's API token, see https://pushover.net/apps.
+                                            The secret needs to be in the same namespace as the AlertmanagerConfig
+                                            object and accessible by the Prometheus Operator.
                                           properties:
                                             key:
                                               description: The key of the secret to select from.  Must be a valid secret key.
                                               type: string
                                             name:
-                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                              description: |-
+                                                Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description: Specify whether the Secret or its key must be defined
@@ -1456,13 +1721,19 @@ spec:
                                           description: A title for supplementary URL, otherwise just the URL is shown
                                           type: string
                                         userKey:
-                                          description: The secret's key that contains the recipient user's user key. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.
+                                          description: |-
+                                            The secret's key that contains the recipient user's user key.
+                                            The secret needs to be in the same namespace as the AlertmanagerConfig
+                                            object and accessible by the Prometheus Operator.
                                           properties:
                                             key:
                                               description: The key of the secret to select from.  Must be a valid secret key.
                                               type: string
                                             name:
-                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                              description: |-
+                                                Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description: Specify whether the Secret or its key must be defined
@@ -1476,15 +1747,26 @@ spec:
                                   slackConfigs:
                                     description: List of Slack configurations.
                                     items:
-                                      description: SlackConfig configures notifications via Slack. See https://prometheus.io/docs/alerting/latest/configuration/#slack_config
+                                      description: |-
+                                        SlackConfig configures notifications via Slack.
+                                        See https://prometheus.io/docs/alerting/latest/configuration/#slack_config
                                       properties:
                                         actions:
                                           description: A list of Slack actions that are sent with each notification.
                                           items:
-                                            description: SlackAction configures a single Slack action that is sent with each notification. See https://api.slack.com/docs/message-attachments#action_fields and https://api.slack.com/docs/message-buttons for more information.
+                                            description: |-
+                                              SlackAction configures a single Slack action that is sent with each
+                                              notification.
+                                              See https://api.slack.com/docs/message-attachments#action_fields and
+                                              https://api.slack.com/docs/message-buttons for more information.
                                             properties:
                                               confirm:
-                                                description: SlackConfirmationField protect users from destructive actions or particularly distinguished decisions by asking them to confirm their button click one more time. See https://api.slack.com/docs/interactive-message-field-guide#confirmation_fields for more information.
+                                                description: |-
+                                                  SlackConfirmationField protect users from destructive actions or
+                                                  particularly distinguished decisions by asking them to confirm their button
+                                                  click one more time.
+                                                  See https://api.slack.com/docs/interactive-message-field-guide#confirmation_fields
+                                                  for more information.
                                                 properties:
                                                   dismissText:
                                                     type: string
@@ -1518,13 +1800,19 @@ spec:
                                             type: object
                                           type: array
                                         apiURL:
-                                          description: The secret's key that contains the Slack webhook URL. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.
+                                          description: |-
+                                            The secret's key that contains the Slack webhook URL.
+                                            The secret needs to be in the same namespace as the AlertmanagerConfig
+                                            object and accessible by the Prometheus Operator.
                                           properties:
                                             key:
                                               description: The key of the secret to select from.  Must be a valid secret key.
                                               type: string
                                             name:
-                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                              description: |-
+                                                Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description: Specify whether the Secret or its key must be defined
@@ -1545,7 +1833,11 @@ spec:
                                         fields:
                                           description: A list of Slack fields that are sent with each notification.
                                           items:
-                                            description: SlackField configures a single Slack field that is sent with each notification. Each field must contain a title, value, and optionally, a boolean value to indicate if the field is short enough to be displayed next to other fields designated as short. See https://api.slack.com/docs/message-attachments#fields for more information.
+                                            description: |-
+                                              SlackField configures a single Slack field that is sent with each notification.
+                                              Each field must contain a title, value, and optionally, a boolean value to indicate if the field
+                                              is short enough to be displayed next to other fields designated as short.
+                                              See https://api.slack.com/docs/message-attachments#fields for more information.
                                             properties:
                                               short:
                                                 type: boolean
@@ -1566,7 +1858,9 @@ spec:
                                           description: HTTP client configuration.
                                           properties:
                                             authorization:
-                                              description: Authorization header configuration for the client. This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
+                                              description: |-
+                                                Authorization header configuration for the client.
+                                                This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
                                               properties:
                                                 credentials:
                                                   description: The secret's key that contains the credentials of the request
@@ -1575,7 +1869,10 @@ spec:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -1585,20 +1882,29 @@ spec:
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 type:
-                                                  description: Set the authentication type. Defaults to Bearer, Basic will cause an error
+                                                  description: |-
+                                                    Set the authentication type. Defaults to Bearer, Basic will cause an
+                                                    error
                                                   type: string
                                               type: object
                                             basicAuth:
-                                              description: BasicAuth for the client. This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
+                                              description: |-
+                                                BasicAuth for the client.
+                                                This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
                                               properties:
                                                 password:
-                                                  description: The secret in the service monitor namespace that contains the password for authentication.
+                                                  description: |-
+                                                    The secret in the service monitor namespace that contains the password
+                                                    for authentication.
                                                   properties:
                                                     key:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -1608,13 +1914,18 @@ spec:
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 username:
-                                                  description: The secret in the service monitor namespace that contains the username for authentication.
+                                                  description: |-
+                                                    The secret in the service monitor namespace that contains the username
+                                                    for authentication.
                                                   properties:
                                                     key:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -1625,13 +1936,20 @@ spec:
                                                   x-kubernetes-map-type: atomic
                                               type: object
                                             bearerTokenSecret:
-                                              description: The secret's key that contains the bearer token to be used by the client for authentication. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.
+                                              description: |-
+                                                The secret's key that contains the bearer token to be used by the client
+                                                for authentication.
+                                                The secret needs to be in the same namespace as the AlertmanagerConfig
+                                                object and accessible by the Prometheus Operator.
                                               properties:
                                                 key:
                                                   description: The key of the secret to select from.  Must be a valid secret key.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                  description: |-
+                                                    Name of the referent.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                   type: string
                                                 optional:
                                                   description: Specify whether the Secret or its key must be defined
@@ -1656,7 +1974,10 @@ spec:
                                                           description: The key to select.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the ConfigMap or its key must be defined
@@ -1672,7 +1993,10 @@ spec:
                                                           description: The key of the secret to select from.  Must be a valid secret key.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the Secret or its key must be defined
@@ -1689,7 +2013,10 @@ spec:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -1733,7 +2060,10 @@ spec:
                                                           description: The key to select.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the ConfigMap or its key must be defined
@@ -1749,7 +2079,10 @@ spec:
                                                           description: The key of the secret to select from.  Must be a valid secret key.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the Secret or its key must be defined
@@ -1769,7 +2102,10 @@ spec:
                                                           description: The key to select.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the ConfigMap or its key must be defined
@@ -1785,7 +2121,10 @@ spec:
                                                           description: The key of the secret to select from.  Must be a valid secret key.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the Secret or its key must be defined
@@ -1805,7 +2144,10 @@ spec:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -1853,10 +2195,14 @@ spec:
                                   snsConfigs:
                                     description: List of SNS configurations
                                     items:
-                                      description: SNSConfig configures notifications via AWS SNS. See https://prometheus.io/docs/alerting/latest/configuration/#sns_configs
+                                      description: |-
+                                        SNSConfig configures notifications via AWS SNS.
+                                        See https://prometheus.io/docs/alerting/latest/configuration/#sns_configs
                                       properties:
                                         apiURL:
-                                          description: The SNS API URL i.e. https://sns.us-east-2.amazonaws.com. If not specified, the SNS API URL from the SNS SDK will be used.
+                                          description: |-
+                                            The SNS API URL i.e. https://sns.us-east-2.amazonaws.com.
+                                            If not specified, the SNS API URL from the SNS SDK will be used.
                                           type: string
                                         attributes:
                                           additionalProperties:
@@ -1867,7 +2213,9 @@ spec:
                                           description: HTTP client configuration.
                                           properties:
                                             authorization:
-                                              description: Authorization header configuration for the client. This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
+                                              description: |-
+                                                Authorization header configuration for the client.
+                                                This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
                                               properties:
                                                 credentials:
                                                   description: The secret's key that contains the credentials of the request
@@ -1876,7 +2224,10 @@ spec:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -1886,20 +2237,29 @@ spec:
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 type:
-                                                  description: Set the authentication type. Defaults to Bearer, Basic will cause an error
+                                                  description: |-
+                                                    Set the authentication type. Defaults to Bearer, Basic will cause an
+                                                    error
                                                   type: string
                                               type: object
                                             basicAuth:
-                                              description: BasicAuth for the client. This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
+                                              description: |-
+                                                BasicAuth for the client.
+                                                This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
                                               properties:
                                                 password:
-                                                  description: The secret in the service monitor namespace that contains the password for authentication.
+                                                  description: |-
+                                                    The secret in the service monitor namespace that contains the password
+                                                    for authentication.
                                                   properties:
                                                     key:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -1909,13 +2269,18 @@ spec:
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 username:
-                                                  description: The secret in the service monitor namespace that contains the username for authentication.
+                                                  description: |-
+                                                    The secret in the service monitor namespace that contains the username
+                                                    for authentication.
                                                   properties:
                                                     key:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -1926,13 +2291,20 @@ spec:
                                                   x-kubernetes-map-type: atomic
                                               type: object
                                             bearerTokenSecret:
-                                              description: The secret's key that contains the bearer token to be used by the client for authentication. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.
+                                              description: |-
+                                                The secret's key that contains the bearer token to be used by the client
+                                                for authentication.
+                                                The secret needs to be in the same namespace as the AlertmanagerConfig
+                                                object and accessible by the Prometheus Operator.
                                               properties:
                                                 key:
                                                   description: The key of the secret to select from.  Must be a valid secret key.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                  description: |-
+                                                    Name of the referent.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                   type: string
                                                 optional:
                                                   description: Specify whether the Secret or its key must be defined
@@ -1957,7 +2329,10 @@ spec:
                                                           description: The key to select.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the ConfigMap or its key must be defined
@@ -1973,7 +2348,10 @@ spec:
                                                           description: The key of the secret to select from.  Must be a valid secret key.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the Secret or its key must be defined
@@ -1990,7 +2368,10 @@ spec:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -2034,7 +2415,10 @@ spec:
                                                           description: The key to select.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the ConfigMap or its key must be defined
@@ -2050,7 +2434,10 @@ spec:
                                                           description: The key of the secret to select from.  Must be a valid secret key.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the Secret or its key must be defined
@@ -2070,7 +2457,10 @@ spec:
                                                           description: The key to select.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the ConfigMap or its key must be defined
@@ -2086,7 +2476,10 @@ spec:
                                                           description: The key of the secret to select from.  Must be a valid secret key.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the Secret or its key must be defined
@@ -2106,7 +2499,10 @@ spec:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -2124,7 +2520,9 @@ spec:
                                           description: The message content of the SNS notification.
                                           type: string
                                         phoneNumber:
-                                          description: Phone number if message is delivered via SMS in E.164 format. If you don't specify this value, you must specify a value for the TopicARN or TargetARN.
+                                          description: |-
+                                            Phone number if message is delivered via SMS in E.164 format.
+                                            If you don't specify this value, you must specify a value for the TopicARN or TargetARN.
                                           type: string
                                         sendResolved:
                                           description: Whether or not to notify about resolved alerts.
@@ -2139,7 +2537,10 @@ spec:
                                                   description: The key of the secret to select from.  Must be a valid secret key.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                  description: |-
+                                                    Name of the referent.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                   type: string
                                                 optional:
                                                   description: Specify whether the Secret or its key must be defined
@@ -2164,7 +2565,10 @@ spec:
                                                   description: The key of the secret to select from.  Must be a valid secret key.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                  description: |-
+                                                    Name of the referent.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                   type: string
                                                 optional:
                                                   description: Specify whether the Secret or its key must be defined
@@ -2178,29 +2582,43 @@ spec:
                                           description: Subject line when the message is delivered to email endpoints.
                                           type: string
                                         targetARN:
-                                          description: The  mobile platform endpoint ARN if message is delivered via mobile notifications. If you don't specify this value, you must specify a value for the topic_arn or PhoneNumber.
+                                          description: |-
+                                            The  mobile platform endpoint ARN if message is delivered via mobile notifications.
+                                            If you don't specify this value, you must specify a value for the topic_arn or PhoneNumber.
                                           type: string
                                         topicARN:
-                                          description: SNS topic ARN, i.e. arn:aws:sns:us-east-2:698519295917:My-Topic If you don't specify this value, you must specify a value for the PhoneNumber or TargetARN.
+                                          description: |-
+                                            SNS topic ARN, i.e. arn:aws:sns:us-east-2:698519295917:My-Topic
+                                            If you don't specify this value, you must specify a value for the PhoneNumber or TargetARN.
                                           type: string
                                       type: object
                                     type: array
                                   telegramConfigs:
                                     description: List of Telegram configurations.
                                     items:
-                                      description: TelegramConfig configures notifications via Telegram. See https://prometheus.io/docs/alerting/latest/configuration/#telegram_config
+                                      description: |-
+                                        TelegramConfig configures notifications via Telegram.
+                                        See https://prometheus.io/docs/alerting/latest/configuration/#telegram_config
                                       properties:
                                         apiURL:
-                                          description: The Telegram API URL i.e. https://api.telegram.org. If not specified, default API URL will be used.
+                                          description: |-
+                                            The Telegram API URL i.e. https://api.telegram.org.
+                                            If not specified, default API URL will be used.
                                           type: string
                                         botToken:
-                                          description: Telegram bot token The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.
+                                          description: |-
+                                            Telegram bot token
+                                            The secret needs to be in the same namespace as the AlertmanagerConfig
+                                            object and accessible by the Prometheus Operator.
                                           properties:
                                             key:
                                               description: The key of the secret to select from.  Must be a valid secret key.
                                               type: string
                                             name:
-                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                              description: |-
+                                                Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description: Specify whether the Secret or its key must be defined
@@ -2220,7 +2638,9 @@ spec:
                                           description: HTTP client configuration.
                                           properties:
                                             authorization:
-                                              description: Authorization header configuration for the client. This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
+                                              description: |-
+                                                Authorization header configuration for the client.
+                                                This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
                                               properties:
                                                 credentials:
                                                   description: The secret's key that contains the credentials of the request
@@ -2229,7 +2649,10 @@ spec:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -2239,20 +2662,29 @@ spec:
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 type:
-                                                  description: Set the authentication type. Defaults to Bearer, Basic will cause an error
+                                                  description: |-
+                                                    Set the authentication type. Defaults to Bearer, Basic will cause an
+                                                    error
                                                   type: string
                                               type: object
                                             basicAuth:
-                                              description: BasicAuth for the client. This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
+                                              description: |-
+                                                BasicAuth for the client.
+                                                This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
                                               properties:
                                                 password:
-                                                  description: The secret in the service monitor namespace that contains the password for authentication.
+                                                  description: |-
+                                                    The secret in the service monitor namespace that contains the password
+                                                    for authentication.
                                                   properties:
                                                     key:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -2262,13 +2694,18 @@ spec:
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 username:
-                                                  description: The secret in the service monitor namespace that contains the username for authentication.
+                                                  description: |-
+                                                    The secret in the service monitor namespace that contains the username
+                                                    for authentication.
                                                   properties:
                                                     key:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -2279,13 +2716,20 @@ spec:
                                                   x-kubernetes-map-type: atomic
                                               type: object
                                             bearerTokenSecret:
-                                              description: The secret's key that contains the bearer token to be used by the client for authentication. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.
+                                              description: |-
+                                                The secret's key that contains the bearer token to be used by the client
+                                                for authentication.
+                                                The secret needs to be in the same namespace as the AlertmanagerConfig
+                                                object and accessible by the Prometheus Operator.
                                               properties:
                                                 key:
                                                   description: The key of the secret to select from.  Must be a valid secret key.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                  description: |-
+                                                    Name of the referent.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                   type: string
                                                 optional:
                                                   description: Specify whether the Secret or its key must be defined
@@ -2310,7 +2754,10 @@ spec:
                                                           description: The key to select.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the ConfigMap or its key must be defined
@@ -2326,7 +2773,10 @@ spec:
                                                           description: The key of the secret to select from.  Must be a valid secret key.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the Secret or its key must be defined
@@ -2343,7 +2793,10 @@ spec:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -2387,7 +2840,10 @@ spec:
                                                           description: The key to select.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the ConfigMap or its key must be defined
@@ -2403,7 +2859,10 @@ spec:
                                                           description: The key of the secret to select from.  Must be a valid secret key.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the Secret or its key must be defined
@@ -2423,7 +2882,10 @@ spec:
                                                           description: The key to select.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the ConfigMap or its key must be defined
@@ -2439,7 +2901,10 @@ spec:
                                                           description: The key of the secret to select from.  Must be a valid secret key.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the Secret or its key must be defined
@@ -2459,7 +2924,10 @@ spec:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -2491,16 +2959,24 @@ spec:
                                   victoropsConfigs:
                                     description: List of VictorOps configurations.
                                     items:
-                                      description: VictorOpsConfig configures notifications via VictorOps. See https://prometheus.io/docs/alerting/latest/configuration/#victorops_config
+                                      description: |-
+                                        VictorOpsConfig configures notifications via VictorOps.
+                                        See https://prometheus.io/docs/alerting/latest/configuration/#victorops_config
                                       properties:
                                         apiKey:
-                                          description: The secret's key that contains the API key to use when talking to the VictorOps API. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.
+                                          description: |-
+                                            The secret's key that contains the API key to use when talking to the VictorOps API.
+                                            The secret needs to be in the same namespace as the AlertmanagerConfig
+                                            object and accessible by the Prometheus Operator.
                                           properties:
                                             key:
                                               description: The key of the secret to select from.  Must be a valid secret key.
                                               type: string
                                             name:
-                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                              description: |-
+                                                Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description: Specify whether the Secret or its key must be defined
@@ -2536,7 +3012,9 @@ spec:
                                           description: The HTTP client's configuration.
                                           properties:
                                             authorization:
-                                              description: Authorization header configuration for the client. This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
+                                              description: |-
+                                                Authorization header configuration for the client.
+                                                This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
                                               properties:
                                                 credentials:
                                                   description: The secret's key that contains the credentials of the request
@@ -2545,7 +3023,10 @@ spec:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -2555,20 +3036,29 @@ spec:
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 type:
-                                                  description: Set the authentication type. Defaults to Bearer, Basic will cause an error
+                                                  description: |-
+                                                    Set the authentication type. Defaults to Bearer, Basic will cause an
+                                                    error
                                                   type: string
                                               type: object
                                             basicAuth:
-                                              description: BasicAuth for the client. This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
+                                              description: |-
+                                                BasicAuth for the client.
+                                                This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
                                               properties:
                                                 password:
-                                                  description: The secret in the service monitor namespace that contains the password for authentication.
+                                                  description: |-
+                                                    The secret in the service monitor namespace that contains the password
+                                                    for authentication.
                                                   properties:
                                                     key:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -2578,13 +3068,18 @@ spec:
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 username:
-                                                  description: The secret in the service monitor namespace that contains the username for authentication.
+                                                  description: |-
+                                                    The secret in the service monitor namespace that contains the username
+                                                    for authentication.
                                                   properties:
                                                     key:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -2595,13 +3090,20 @@ spec:
                                                   x-kubernetes-map-type: atomic
                                               type: object
                                             bearerTokenSecret:
-                                              description: The secret's key that contains the bearer token to be used by the client for authentication. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.
+                                              description: |-
+                                                The secret's key that contains the bearer token to be used by the client
+                                                for authentication.
+                                                The secret needs to be in the same namespace as the AlertmanagerConfig
+                                                object and accessible by the Prometheus Operator.
                                               properties:
                                                 key:
                                                   description: The key of the secret to select from.  Must be a valid secret key.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                  description: |-
+                                                    Name of the referent.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                   type: string
                                                 optional:
                                                   description: Specify whether the Secret or its key must be defined
@@ -2626,7 +3128,10 @@ spec:
                                                           description: The key to select.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the ConfigMap or its key must be defined
@@ -2642,7 +3147,10 @@ spec:
                                                           description: The key of the secret to select from.  Must be a valid secret key.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the Secret or its key must be defined
@@ -2659,7 +3167,10 @@ spec:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -2703,7 +3214,10 @@ spec:
                                                           description: The key to select.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the ConfigMap or its key must be defined
@@ -2719,7 +3233,10 @@ spec:
                                                           description: The key of the secret to select from.  Must be a valid secret key.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the Secret or its key must be defined
@@ -2739,7 +3256,10 @@ spec:
                                                           description: The key to select.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the ConfigMap or its key must be defined
@@ -2755,7 +3275,10 @@ spec:
                                                           description: The key of the secret to select from.  Must be a valid secret key.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the Secret or its key must be defined
@@ -2775,7 +3298,10 @@ spec:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -2809,13 +3335,17 @@ spec:
                                   webhookConfigs:
                                     description: List of webhook configurations.
                                     items:
-                                      description: WebhookConfig configures notifications via a generic receiver supporting the webhook payload. See https://prometheus.io/docs/alerting/latest/configuration/#webhook_config
+                                      description: |-
+                                        WebhookConfig configures notifications via a generic receiver supporting the webhook payload.
+                                        See https://prometheus.io/docs/alerting/latest/configuration/#webhook_config
                                       properties:
                                         httpConfig:
                                           description: HTTP client configuration.
                                           properties:
                                             authorization:
-                                              description: Authorization header configuration for the client. This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
+                                              description: |-
+                                                Authorization header configuration for the client.
+                                                This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
                                               properties:
                                                 credentials:
                                                   description: The secret's key that contains the credentials of the request
@@ -2824,7 +3354,10 @@ spec:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -2834,20 +3367,29 @@ spec:
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 type:
-                                                  description: Set the authentication type. Defaults to Bearer, Basic will cause an error
+                                                  description: |-
+                                                    Set the authentication type. Defaults to Bearer, Basic will cause an
+                                                    error
                                                   type: string
                                               type: object
                                             basicAuth:
-                                              description: BasicAuth for the client. This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
+                                              description: |-
+                                                BasicAuth for the client.
+                                                This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
                                               properties:
                                                 password:
-                                                  description: The secret in the service monitor namespace that contains the password for authentication.
+                                                  description: |-
+                                                    The secret in the service monitor namespace that contains the password
+                                                    for authentication.
                                                   properties:
                                                     key:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -2857,13 +3399,18 @@ spec:
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 username:
-                                                  description: The secret in the service monitor namespace that contains the username for authentication.
+                                                  description: |-
+                                                    The secret in the service monitor namespace that contains the username
+                                                    for authentication.
                                                   properties:
                                                     key:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -2874,13 +3421,20 @@ spec:
                                                   x-kubernetes-map-type: atomic
                                               type: object
                                             bearerTokenSecret:
-                                              description: The secret's key that contains the bearer token to be used by the client for authentication. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.
+                                              description: |-
+                                                The secret's key that contains the bearer token to be used by the client
+                                                for authentication.
+                                                The secret needs to be in the same namespace as the AlertmanagerConfig
+                                                object and accessible by the Prometheus Operator.
                                               properties:
                                                 key:
                                                   description: The key of the secret to select from.  Must be a valid secret key.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                  description: |-
+                                                    Name of the referent.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                   type: string
                                                 optional:
                                                   description: Specify whether the Secret or its key must be defined
@@ -2905,7 +3459,10 @@ spec:
                                                           description: The key to select.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the ConfigMap or its key must be defined
@@ -2921,7 +3478,10 @@ spec:
                                                           description: The key of the secret to select from.  Must be a valid secret key.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the Secret or its key must be defined
@@ -2938,7 +3498,10 @@ spec:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -2982,7 +3545,10 @@ spec:
                                                           description: The key to select.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the ConfigMap or its key must be defined
@@ -2998,7 +3564,10 @@ spec:
                                                           description: The key of the secret to select from.  Must be a valid secret key.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the Secret or its key must be defined
@@ -3018,7 +3587,10 @@ spec:
                                                           description: The key to select.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the ConfigMap or its key must be defined
@@ -3034,7 +3606,10 @@ spec:
                                                           description: The key of the secret to select from.  Must be a valid secret key.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the Secret or its key must be defined
@@ -3054,7 +3629,10 @@ spec:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -3077,16 +3655,26 @@ spec:
                                           description: Whether or not to notify about resolved alerts.
                                           type: boolean
                                         url:
-                                          description: The URL to send HTTP POST requests to. `urlSecret` takes precedence over `url`. One of `urlSecret` and `url` should be defined.
+                                          description: |-
+                                            The URL to send HTTP POST requests to. `urlSecret` takes precedence over
+                                            `url`. One of `urlSecret` and `url` should be defined.
                                           type: string
                                         urlSecret:
-                                          description: The secret's key that contains the webhook URL to send HTTP requests to. `urlSecret` takes precedence over `url`. One of `urlSecret` and `url` should be defined. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.
+                                          description: |-
+                                            The secret's key that contains the webhook URL to send HTTP requests to.
+                                            `urlSecret` takes precedence over `url`. One of `urlSecret` and `url`
+                                            should be defined.
+                                            The secret needs to be in the same namespace as the AlertmanagerConfig
+                                            object and accessible by the Prometheus Operator.
                                           properties:
                                             key:
                                               description: The key of the secret to select from.  Must be a valid secret key.
                                               type: string
                                             name:
-                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                              description: |-
+                                                Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description: Specify whether the Secret or its key must be defined
@@ -3100,18 +3688,26 @@ spec:
                                   wechatConfigs:
                                     description: List of WeChat configurations.
                                     items:
-                                      description: WeChatConfig configures notifications via WeChat. See https://prometheus.io/docs/alerting/latest/configuration/#wechat_config
+                                      description: |-
+                                        WeChatConfig configures notifications via WeChat.
+                                        See https://prometheus.io/docs/alerting/latest/configuration/#wechat_config
                                       properties:
                                         agentID:
                                           type: string
                                         apiSecret:
-                                          description: The secret's key that contains the WeChat API key. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.
+                                          description: |-
+                                            The secret's key that contains the WeChat API key.
+                                            The secret needs to be in the same namespace as the AlertmanagerConfig
+                                            object and accessible by the Prometheus Operator.
                                           properties:
                                             key:
                                               description: The key of the secret to select from.  Must be a valid secret key.
                                               type: string
                                             name:
-                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                              description: |-
+                                                Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description: Specify whether the Secret or its key must be defined
@@ -3130,7 +3726,9 @@ spec:
                                           description: HTTP client configuration.
                                           properties:
                                             authorization:
-                                              description: Authorization header configuration for the client. This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
+                                              description: |-
+                                                Authorization header configuration for the client.
+                                                This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
                                               properties:
                                                 credentials:
                                                   description: The secret's key that contains the credentials of the request
@@ -3139,7 +3737,10 @@ spec:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -3149,20 +3750,29 @@ spec:
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 type:
-                                                  description: Set the authentication type. Defaults to Bearer, Basic will cause an error
+                                                  description: |-
+                                                    Set the authentication type. Defaults to Bearer, Basic will cause an
+                                                    error
                                                   type: string
                                               type: object
                                             basicAuth:
-                                              description: BasicAuth for the client. This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
+                                              description: |-
+                                                BasicAuth for the client.
+                                                This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
                                               properties:
                                                 password:
-                                                  description: The secret in the service monitor namespace that contains the password for authentication.
+                                                  description: |-
+                                                    The secret in the service monitor namespace that contains the password
+                                                    for authentication.
                                                   properties:
                                                     key:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -3172,13 +3782,18 @@ spec:
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 username:
-                                                  description: The secret in the service monitor namespace that contains the username for authentication.
+                                                  description: |-
+                                                    The secret in the service monitor namespace that contains the username
+                                                    for authentication.
                                                   properties:
                                                     key:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -3189,13 +3804,20 @@ spec:
                                                   x-kubernetes-map-type: atomic
                                               type: object
                                             bearerTokenSecret:
-                                              description: The secret's key that contains the bearer token to be used by the client for authentication. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.
+                                              description: |-
+                                                The secret's key that contains the bearer token to be used by the client
+                                                for authentication.
+                                                The secret needs to be in the same namespace as the AlertmanagerConfig
+                                                object and accessible by the Prometheus Operator.
                                               properties:
                                                 key:
                                                   description: The key of the secret to select from.  Must be a valid secret key.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                  description: |-
+                                                    Name of the referent.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                   type: string
                                                 optional:
                                                   description: Specify whether the Secret or its key must be defined
@@ -3220,7 +3842,10 @@ spec:
                                                           description: The key to select.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the ConfigMap or its key must be defined
@@ -3236,7 +3861,10 @@ spec:
                                                           description: The key of the secret to select from.  Must be a valid secret key.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the Secret or its key must be defined
@@ -3253,7 +3881,10 @@ spec:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -3297,7 +3928,10 @@ spec:
                                                           description: The key to select.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the ConfigMap or its key must be defined
@@ -3313,7 +3947,10 @@ spec:
                                                           description: The key of the secret to select from.  Must be a valid secret key.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the Secret or its key must be defined
@@ -3333,7 +3970,10 @@ spec:
                                                           description: The key to select.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the ConfigMap or its key must be defined
@@ -3349,7 +3989,10 @@ spec:
                                                           description: The key of the secret to select from.  Must be a valid secret key.
                                                           type: string
                                                         name:
-                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                                           type: string
                                                         optional:
                                                           description: Specify whether the Secret or its key must be defined
@@ -3369,7 +4012,10 @@ spec:
                                                       description: The key of the secret to select from.  Must be a valid secret key.
                                                       type: string
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                       type: string
                                                     optional:
                                                       description: Specify whether the Secret or its key must be defined
@@ -3404,7 +4050,10 @@ spec:
                                 type: object
                               type: array
                             route:
-                              description: The Alertmanager route definition for alerts matching the resource's namespace. If present, it will be added to the generated Alertmanager configuration as a first-level route.
+                              description: |-
+                                The Alertmanager route definition for alerts matching the resource's
+                                namespace. If present, it will be added to the generated Alertmanager
+                                configuration as a first-level route.
                               properties:
                                 activeTimeIntervals:
                                   description: ActiveTimeIntervals is a list of MuteTimeInterval names when this route should be active.
@@ -3412,26 +4061,44 @@ spec:
                                     type: string
                                   type: array
                                 continue:
-                                  description: Boolean indicating whether an alert should continue matching subsequent sibling nodes. It will always be overridden to true for the first-level route by the Prometheus operator.
+                                  description: |-
+                                    Boolean indicating whether an alert should continue matching subsequent
+                                    sibling nodes. It will always be overridden to true for the first-level
+                                    route by the Prometheus operator.
                                   type: boolean
                                 groupBy:
-                                  description: List of labels to group by. Labels must not be repeated (unique list). Special label "..." (aggregate by all possible labels), if provided, must be the only element in the list.
+                                  description: |-
+                                    List of labels to group by.
+                                    Labels must not be repeated (unique list).
+                                    Special label "..." (aggregate by all possible labels), if provided, must be the only element in the list.
                                   items:
                                     type: string
                                   type: array
                                 groupInterval:
-                                  description: 'How long to wait before sending an updated notification. Must match the regular expression`^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$` Example: "5m"'
+                                  description: |-
+                                    How long to wait before sending an updated notification.
+                                    Must match the regular expression`^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$`
+                                    Example: "5m"
                                   type: string
                                 groupWait:
-                                  description: 'How long to wait before sending the initial notification. Must match the regular expression`^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$` Example: "30s"'
+                                  description: |-
+                                    How long to wait before sending the initial notification.
+                                    Must match the regular expression`^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$`
+                                    Example: "30s"
                                   type: string
                                 matchers:
-                                  description: 'List of matchers that the alert''s labels should match. For the first level route, the operator removes any existing equality and regexp matcher on the `namespace` label and adds a `namespace: <object namespace>` matcher.'
+                                  description: |-
+                                    List of matchers that the alert's labels should match. For the first
+                                    level route, the operator removes any existing equality and regexp
+                                    matcher on the `namespace` label and adds a `namespace: <object
+                                    namespace>` matcher.
                                   items:
                                     description: Matcher defines how to match on alert's labels.
                                     properties:
                                       matchType:
-                                        description: Match operation available with AlertManager >= v0.22.0 and takes precedence over Regex (deprecated) if non-empty.
+                                        description: |-
+                                          Match operation available with AlertManager >= v0.22.0 and
+                                          takes precedence over Regex (deprecated) if non-empty.
                                         enum:
                                           - '!='
                                           - "="
@@ -3443,7 +4110,9 @@ spec:
                                         minLength: 1
                                         type: string
                                       regex:
-                                        description: Whether to match on equality (false) or regular-expression (true). Deprecated as of AlertManager >= v0.22.0 where a user should use MatchType instead.
+                                        description: |-
+                                          Whether to match on equality (false) or regular-expression (true).
+                                          Deprecated as of AlertManager >= v0.22.0 where a user should use MatchType instead.
                                         type: boolean
                                       value:
                                         description: Label value to match.
@@ -3453,15 +4122,28 @@ spec:
                                     type: object
                                   type: array
                                 muteTimeIntervals:
-                                  description: 'Note: this comment applies to the field definition above but appears below otherwise it gets included in the generated manifest. CRD schema doesn''t support self-referential types for now (see https://github.com/kubernetes/kubernetes/issues/62872). We have to use an alternative type to circumvent the limitation. The downside is that the Kube API can''t validate the data beyond the fact that it is a valid JSON representation. MuteTimeIntervals is a list of MuteTimeInterval names that will mute this route when matched,'
+                                  description: |-
+                                    Note: this comment applies to the field definition above but appears
+                                    below otherwise it gets included in the generated manifest.
+                                    CRD schema doesn't support self-referential types for now (see
+                                    https://github.com/kubernetes/kubernetes/issues/62872). We have to use
+                                    an alternative type to circumvent the limitation. The downside is that
+                                    the Kube API can't validate the data beyond the fact that it is a valid
+                                    JSON representation.
+                                    MuteTimeIntervals is a list of MuteTimeInterval names that will mute this route when matched,
                                   items:
                                     type: string
                                   type: array
                                 receiver:
-                                  description: Name of the receiver for this route. If not empty, it should be listed in the `receivers` field.
+                                  description: |-
+                                    Name of the receiver for this route. If not empty, it should be listed in
+                                    the `receivers` field.
                                   type: string
                                 repeatInterval:
-                                  description: 'How long to wait before repeating the last notification. Must match the regular expression`^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$` Example: "4h"'
+                                  description: |-
+                                    How long to wait before repeating the last notification.
+                                    Must match the regular expression`^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$`
+                                    Example: "4h"
                                   type: string
                                 routes:
                                   description: Child routes.
@@ -3481,7 +4163,9 @@ spec:
                           description: BackupName is the name of the specific backup you want to restore.
                           type: string
                         claimName:
-                          description: ClaimName specifies the name of the instance you want to restore from. The claim has to be in the same namespace as this new instance.
+                          description: |-
+                            ClaimName specifies the name of the instance you want to restore from.
+                            The claim has to be in the same namespace as this new instance.
                           type: string
                       type: object
                     scheduling:
@@ -3508,7 +4192,9 @@ spec:
                           type: string
                         version:
                           default: "7.0"
-                          description: Version contains supported version of Redis. Multiple versions are supported. The latest version "7.0" is the default version.
+                          description: |-
+                            Version contains supported version of Redis.
+                            Multiple versions are supported. The latest version "7.0" is the default version.
                           enum:
                             - "6.2"
                             - "7.0"
@@ -3557,7 +4243,9 @@ spec:
                   description: WriteConnectionSecretToRef references a secret to which the connection details will be written.
                   properties:
                     name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      description: |-
+                        Name of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                       type: string
                     namespace:
                       type: string
@@ -3579,7 +4267,9 @@ spec:
                         maxLength: 32768
                         type: string
                       observedGeneration:
-                        description: ObservedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        description: |-
+                          ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                         format: int64
                         minimum: 0
                         type: integer
@@ -3614,7 +4304,9 @@ spec:
                         maxLength: 32768
                         type: string
                       observedGeneration:
-                        description: ObservedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        description: |-
+                          ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                         format: int64
                         minimum: 0
                         type: integer
@@ -3652,7 +4344,9 @@ spec:
                         maxLength: 32768
                         type: string
                       observedGeneration:
-                        description: ObservedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        description: |-
+                          ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                         format: int64
                         minimum: 0
                         type: integer
@@ -3688,7 +4382,9 @@ spec:
                         maxLength: 32768
                         type: string
                       observedGeneration:
-                        description: ObservedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        description: |-
+                          ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                         format: int64
                         minimum: 0
                         type: integer
@@ -3712,7 +4408,9 @@ spec:
                     type: object
                   type: array
                 schedules:
-                  description: Schedules keeps track of random generated schedules, is overwriten by schedules set in the service's spec.
+                  description: |-
+                    Schedules keeps track of random generated schedules, is overwriten by
+                    schedules set in the service's spec.
                   properties:
                     backup:
                       description: Backup keeps track of the backup schedule.
@@ -3721,7 +4419,9 @@ spec:
                       description: Maintenance keeps track of the maintenance schedule.
                       properties:
                         dayOfWeek:
-                          description: DayOfWeek specifies at which weekday the maintenance is held place. Allowed values are [monday, tuesday, wednesday, thursday, friday, saturday, sunday]
+                          description: |-
+                            DayOfWeek specifies at which weekday the maintenance is held place.
+                            Allowed values are [monday, tuesday, wednesday, thursday, friday, saturday, sunday]
                           enum:
                             - monday
                             - tuesday
@@ -3732,7 +4432,9 @@ spec:
                             - sunday
                           type: string
                         timeOfDay:
-                          description: 'TimeOfDay for installing updates in UTC. Format: "hh:mm:ss".'
+                          description: |-
+                            TimeOfDay for installing updates in UTC.
+                            Format: "hh:mm:ss".
                           pattern: ^([0-1]?[0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9])$
                           type: string
                       type: object
@@ -3749,7 +4451,9 @@ spec:
                         maxLength: 32768
                         type: string
                       observedGeneration:
-                        description: ObservedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        description: |-
+                          ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                         format: int64
                         minimum: 0
                         type: integer
@@ -3784,7 +4488,9 @@ spec:
                         maxLength: 32768
                         type: string
                       observedGeneration:
-                        description: ObservedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        description: |-
+                          ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                         format: int64
                         minimum: 0
                         type: integer

--- a/crds/vshn.appcat.vshn.io_xvshnkeycloaks.yaml
+++ b/crds/vshn.appcat.vshn.io_xvshnkeycloaks.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: xvshnkeycloaks.vshn.appcat.vshn.io
 spec:
   group: vshn.appcat.vshn.io
@@ -20,14 +20,19 @@ spec:
         description: XVSHNKeycloak represents the internal composite of this claim
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -36,13 +41,14 @@ spec:
             properties:
               deletionPolicy:
                 default: Delete
-                description: 'DeletionPolicy specifies what will happen to the underlying
-                  external when this managed resource is deleted - either "Delete"
-                  or "Orphan" the external resource. This field is planned to be deprecated
-                  in favor of the ManagementPolicies field in a future release. Currently,
-                  both could be set independently and non-default values would be
-                  honored if the feature flag is enabled. See the design doc for more
-                  information: https://github.com/crossplane/crossplane/blob/499895a25d1a1a0ba1604944ef98ac7a1a71f197/design/design-doc-observe-only-resources.md?plain=1#L223'
+                description: |-
+                  DeletionPolicy specifies what will happen to the underlying external
+                  when this managed resource is deleted - either "Delete" or "Orphan" the
+                  external resource.
+                  This field is planned to be deprecated in favor of the ManagementPolicies
+                  field in a future release. Currently, both could be set independently and
+                  non-default values would be honored if the feature flag is enabled.
+                  See the design doc for more information: https://github.com/crossplane/crossplane/blob/499895a25d1a1a0ba1604944ef98ac7a1a71f197/design/design-doc-observe-only-resources.md?plain=1#L223
                 enum:
                 - Orphan
                 - Delete
@@ -50,19 +56,21 @@ spec:
               managementPolicies:
                 default:
                 - '*'
-                description: 'THIS IS A BETA FIELD. It is on by default but can be
-                  opted out through a Crossplane feature flag. ManagementPolicies
-                  specify the array of actions Crossplane is allowed to take on the
-                  managed and external resources. This field is planned to replace
-                  the DeletionPolicy field in a future release. Currently, both could
-                  be set independently and non-default values would be honored if
-                  the feature flag is enabled. If both are custom, the DeletionPolicy
-                  field will be ignored. See the design doc for more information:
-                  https://github.com/crossplane/crossplane/blob/499895a25d1a1a0ba1604944ef98ac7a1a71f197/design/design-doc-observe-only-resources.md?plain=1#L223
-                  and this one: https://github.com/crossplane/crossplane/blob/444267e84783136daa93568b364a5f01228cacbe/design/one-pager-ignore-changes.md'
+                description: |-
+                  THIS IS A BETA FIELD. It is on by default but can be opted out
+                  through a Crossplane feature flag.
+                  ManagementPolicies specify the array of actions Crossplane is allowed to
+                  take on the managed and external resources.
+                  This field is planned to replace the DeletionPolicy field in a future
+                  release. Currently, both could be set independently and non-default
+                  values would be honored if the feature flag is enabled. If both are
+                  custom, the DeletionPolicy field will be ignored.
+                  See the design doc for more information: https://github.com/crossplane/crossplane/blob/499895a25d1a1a0ba1604944ef98ac7a1a71f197/design/design-doc-observe-only-resources.md?plain=1#L223
+                  and this one: https://github.com/crossplane/crossplane/blob/444267e84783136daa93568b364a5f01228cacbe/design/one-pager-ignore-changes.md
                 items:
-                  description: A ManagementAction represents an action that the Crossplane
-                    controllers can take on an external resource.
+                  description: |-
+                    A ManagementAction represents an action that the Crossplane controllers
+                    can take on an external resource.
                   enum:
                   - Observe
                   - Create
@@ -108,9 +116,9 @@ spec:
                       of an instance.
                     properties:
                       dayOfWeek:
-                        description: DayOfWeek specifies at which weekday the maintenance
-                          is held place. Allowed values are [monday, tuesday, wednesday,
-                          thursday, friday, saturday, sunday]
+                        description: |-
+                          DayOfWeek specifies at which weekday the maintenance is held place.
+                          Allowed values are [monday, tuesday, wednesday, thursday, friday, saturday, sunday]
                         enum:
                         - monday
                         - tuesday
@@ -121,8 +129,9 @@ spec:
                         - sunday
                         type: string
                       timeOfDay:
-                        description: 'TimeOfDay for installing updates in UTC. Format:
-                          "hh:mm:ss".'
+                        description: |-
+                          TimeOfDay for installing updates in UTC.
+                          Format: "hh:mm:ss".
                         pattern: ^([0-1]?[0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9])$
                         type: string
                     type: object
@@ -135,9 +144,9 @@ spec:
                           you want to restore.
                         type: string
                       claimName:
-                        description: ClaimName specifies the name of the instance
-                          you want to restore from. The claim has to be in the same
-                          namespace as this new instance.
+                        description: |-
+                          ClaimName specifies the name of the instance you want to restore from.
+                          The claim has to be in the same namespace as this new instance.
                         type: string
                     type: object
                   scheduling:
@@ -155,11 +164,10 @@ spec:
                     description: Service contains keycloak DBaaS specific properties
                     properties:
                       customizationImage:
-                        description: CustomizationImage can be used to provide an
-                          image with custom themes and providers. The themes need
-                          to be be placed in the `/themes` directory of the custom
-                          image. the providers need to be placed in the `/providers`
-                          directory of the custom image.
+                        description: |-
+                          CustomizationImage can be used to provide an image with custom themes and providers.
+                          The themes need to be be placed in the `/themes` directory of the custom image.
+                          the providers need to be placed in the `/providers` directory of the custom image.
                         properties:
                           image:
                             description: Path to a valid image
@@ -179,13 +187,15 @@ spec:
                             x-kubernetes-map-type: atomic
                         type: object
                       fqdn:
-                        description: FQDN contains the FQDN which will be used for
-                          the ingress. If it's not set, no ingress will be deployed.
+                        description: |-
+                          FQDN contains the FQDN which will be used for the ingress.
+                          If it's not set, no ingress will be deployed.
                           This also enables strict hostname checking for this FQDN.
                         type: string
                       postgreSQLParameters:
-                        description: PostgreSQLParameters can be used to set any supported
-                          setting in the underlying PostgreSQL instance.
+                        description: |-
+                          PostgreSQLParameters can be used to set any supported setting in the
+                          underlying PostgreSQL instance.
                         properties:
                           backup:
                             description: Backup contains settings to control the backups
@@ -193,14 +203,14 @@ spec:
                             properties:
                               deletionProtection:
                                 default: true
-                                description: DeletionProtection will protect the instance
-                                  from being deleted for the given retention time.
+                                description: |-
+                                  DeletionProtection will protect the instance from being deleted for the given retention time.
                                   This is enabled by default.
                                 type: boolean
                               deletionRetention:
                                 default: 7
-                                description: DeletionRetention specifies in days how
-                                  long the instance should be kept after deletion.
+                                description: |-
+                                  DeletionRetention specifies in days how long the instance should be kept after deletion.
                                   The default is keeping it one week.
                                 type: integer
                               retention:
@@ -226,11 +236,10 @@ spec:
                             type: object
                           instances:
                             default: 1
-                            description: Instances configures the number of PostgreSQL
-                              instances for the cluster. Each instance contains one
-                              Postgres server. Out of all Postgres servers, one is
-                              elected as the primary, the rest remain as read-only
-                              replicas.
+                            description: |-
+                              Instances configures the number of PostgreSQL instances for the cluster.
+                              Each instance contains one Postgres server.
+                              Out of all Postgres servers, one is elected as the primary, the rest remain as read-only replicas.
                             maximum: 3
                             minimum: 1
                             type: integer
@@ -239,10 +248,9 @@ spec:
                               the maintenance of an instance.
                             properties:
                               dayOfWeek:
-                                description: DayOfWeek specifies at which weekday
-                                  the maintenance is held place. Allowed values are
-                                  [monday, tuesday, wednesday, thursday, friday, saturday,
-                                  sunday]
+                                description: |-
+                                  DayOfWeek specifies at which weekday the maintenance is held place.
+                                  Allowed values are [monday, tuesday, wednesday, thursday, friday, saturday, sunday]
                                 enum:
                                 - monday
                                 - tuesday
@@ -253,8 +261,9 @@ spec:
                                 - sunday
                                 type: string
                               timeOfDay:
-                                description: 'TimeOfDay for installing updates in
-                                  UTC. Format: "hh:mm:ss".'
+                                description: |-
+                                  TimeOfDay for installing updates in UTC.
+                                  Format: "hh:mm:ss".
                                 pattern: ^([0-1]?[0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9])$
                                 type: string
                             type: object
@@ -262,51 +271,50 @@ spec:
                             description: Monitoring contains settings to control monitoring.
                             properties:
                               alertmanagerConfigRef:
-                                description: AlertmanagerConfigRef contains the name
-                                  of the AlertmanagerConfig that should be copied
-                                  over to the namespace of the instance.
+                                description: |-
+                                  AlertmanagerConfigRef contains the name of the AlertmanagerConfig that should be copied over to the
+                                  namespace of the instance.
                                 type: string
                               alertmanagerConfigSecretRef:
-                                description: AlertmanagerConfigSecretRef contains
-                                  the name of the secret that is used in the referenced
-                                  AlertmanagerConfig
+                                description: |-
+                                  AlertmanagerConfigSecretRef contains the name of the secret that is used
+                                  in the referenced AlertmanagerConfig
                                 type: string
                               alertmanagerConfigTemplate:
-                                description: AlertmanagerConfigSpecTemplate takes
-                                  an AlertmanagerConfigSpec object. This takes precedence
-                                  over the AlertmanagerConfigRef.
+                                description: |-
+                                  AlertmanagerConfigSpecTemplate takes an AlertmanagerConfigSpec object.
+                                  This takes precedence over the AlertmanagerConfigRef.
                                 properties:
                                   inhibitRules:
-                                    description: List of inhibition rules. The rules
-                                      will only apply to alerts matching the resource's
-                                      namespace.
+                                    description: |-
+                                      List of inhibition rules. The rules will only apply to alerts matching
+                                      the resource's namespace.
                                     items:
-                                      description: InhibitRule defines an inhibition
-                                        rule that allows to mute alerts when other
-                                        alerts are already firing. See https://prometheus.io/docs/alerting/latest/configuration/#inhibit_rule
+                                      description: |-
+                                        InhibitRule defines an inhibition rule that allows to mute alerts when other
+                                        alerts are already firing.
+                                        See https://prometheus.io/docs/alerting/latest/configuration/#inhibit_rule
                                       properties:
                                         equal:
-                                          description: Labels that must have an equal
-                                            value in the source and target alert for
+                                          description: |-
+                                            Labels that must have an equal value in the source and target alert for
                                             the inhibition to take effect.
                                           items:
                                             type: string
                                           type: array
                                         sourceMatch:
-                                          description: Matchers for which one or more
-                                            alerts have to exist for the inhibition
-                                            to take effect. The operator enforces
-                                            that the alert matches the resource's
-                                            namespace.
+                                          description: |-
+                                            Matchers for which one or more alerts have to exist for the inhibition
+                                            to take effect. The operator enforces that the alert matches the
+                                            resource's namespace.
                                           items:
                                             description: Matcher defines how to match
                                               on alert's labels.
                                             properties:
                                               matchType:
-                                                description: Match operation available
-                                                  with AlertManager >= v0.22.0 and
-                                                  takes precedence over Regex (deprecated)
-                                                  if non-empty.
+                                                description: |-
+                                                  Match operation available with AlertManager >= v0.22.0 and
+                                                  takes precedence over Regex (deprecated) if non-empty.
                                                 enum:
                                                 - '!='
                                                 - "="
@@ -318,11 +326,9 @@ spec:
                                                 minLength: 1
                                                 type: string
                                               regex:
-                                                description: Whether to match on equality
-                                                  (false) or regular-expression (true).
-                                                  Deprecated as of AlertManager >=
-                                                  v0.22.0 where a user should use
-                                                  MatchType instead.
+                                                description: |-
+                                                  Whether to match on equality (false) or regular-expression (true).
+                                                  Deprecated as of AlertManager >= v0.22.0 where a user should use MatchType instead.
                                                 type: boolean
                                               value:
                                                 description: Label value to match.
@@ -332,19 +338,17 @@ spec:
                                             type: object
                                           type: array
                                         targetMatch:
-                                          description: Matchers that have to be fulfilled
-                                            in the alerts to be muted. The operator
-                                            enforces that the alert matches the resource's
-                                            namespace.
+                                          description: |-
+                                            Matchers that have to be fulfilled in the alerts to be muted. The
+                                            operator enforces that the alert matches the resource's namespace.
                                           items:
                                             description: Matcher defines how to match
                                               on alert's labels.
                                             properties:
                                               matchType:
-                                                description: Match operation available
-                                                  with AlertManager >= v0.22.0 and
-                                                  takes precedence over Regex (deprecated)
-                                                  if non-empty.
+                                                description: |-
+                                                  Match operation available with AlertManager >= v0.22.0 and
+                                                  takes precedence over Regex (deprecated) if non-empty.
                                                 enum:
                                                 - '!='
                                                 - "="
@@ -356,11 +360,9 @@ spec:
                                                 minLength: 1
                                                 type: string
                                               regex:
-                                                description: Whether to match on equality
-                                                  (false) or regular-expression (true).
-                                                  Deprecated as of AlertManager >=
-                                                  v0.22.0 where a user should use
-                                                  MatchType instead.
+                                                description: |-
+                                                  Whether to match on equality (false) or regular-expression (true).
+                                                  Deprecated as of AlertManager >= v0.22.0 where a user should use MatchType instead.
                                                 type: boolean
                                               value:
                                                 description: Label value to match.
@@ -414,13 +416,9 @@ spec:
                                               months:
                                                 description: Months is a list of MonthRange
                                                 items:
-                                                  description: MonthRange is an inclusive
-                                                    range of months of the year beginning
-                                                    in January Months can be specified
-                                                    by name (e.g 'January') by numerical
-                                                    month (e.g '1') or as an inclusive
-                                                    range (e.g 'January:March', '1:3',
-                                                    '1:March')
+                                                  description: |-
+                                                    MonthRange is an inclusive range of months of the year beginning in January
+                                                    Months can be specified by name (e.g 'January') by numerical month (e.g '1') or as an inclusive range (e.g 'January:March', '1:3', '1:March')
                                                   pattern: ^((?i)january|february|march|april|may|june|july|august|september|october|november|december|[1-12])(?:((:((?i)january|february|march|april|may|june|july|august|september|october|november|december|[1-12]))$)|$)
                                                   type: string
                                                 type: array
@@ -446,12 +444,9 @@ spec:
                                                 description: Weekdays is a list of
                                                   WeekdayRange
                                                 items:
-                                                  description: WeekdayRange is an
-                                                    inclusive range of days of the
-                                                    week beginning on Sunday Days
-                                                    can be specified by name (e.g
-                                                    'Sunday') or as an inclusive range
-                                                    (e.g 'Monday:Friday')
+                                                  description: |-
+                                                    WeekdayRange is an inclusive range of days of the week beginning on Sunday
+                                                    Days can be specified by name (e.g 'Sunday') or as an inclusive range (e.g 'Monday:Friday')
                                                   pattern: ^((?i)sun|mon|tues|wednes|thurs|fri|satur)day(?:((:(sun|mon|tues|wednes|thurs|fri|satur)day)$)|$)
                                                   type: string
                                                 type: array
@@ -484,12 +479,10 @@ spec:
                                                   authentication.
                                                 type: string
                                               authPassword:
-                                                description: The secret's key that
-                                                  contains the password to use for
-                                                  authentication. The secret needs
-                                                  to be in the same namespace as the
-                                                  AlertmanagerConfig object and accessible
-                                                  by the Prometheus Operator.
+                                                description: |-
+                                                  The secret's key that contains the password to use for authentication.
+                                                  The secret needs to be in the same namespace as the AlertmanagerConfig
+                                                  object and accessible by the Prometheus Operator.
                                                 properties:
                                                   key:
                                                     description: The key of the secret
@@ -497,10 +490,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -511,12 +504,10 @@ spec:
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               authSecret:
-                                                description: The secret's key that
-                                                  contains the CRAM-MD5 secret. The
-                                                  secret needs to be in the same namespace
-                                                  as the AlertmanagerConfig object
-                                                  and accessible by the Prometheus
-                                                  Operator.
+                                                description: |-
+                                                  The secret's key that contains the CRAM-MD5 secret.
+                                                  The secret needs to be in the same namespace as the AlertmanagerConfig
+                                                  object and accessible by the Prometheus Operator.
                                                 properties:
                                                   key:
                                                     description: The key of the secret
@@ -524,10 +515,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -545,10 +536,9 @@ spec:
                                                 description: The sender address.
                                                 type: string
                                               headers:
-                                                description: Further headers email
-                                                  header key/value pairs. Overrides
-                                                  any headers previously set by the
-                                                  notification implementation.
+                                                description: |-
+                                                  Further headers email header key/value pairs. Overrides any headers
+                                                  previously set by the notification implementation.
                                                 items:
                                                   description: KeyValue defines a
                                                     (key, value) tuple.
@@ -574,9 +564,9 @@ spec:
                                                   email notification.
                                                 type: string
                                               requireTLS:
-                                                description: The SMTP TLS requirement.
-                                                  Note that Go does not support unencrypted
-                                                  connections to remote SMTP endpoints.
+                                                description: |-
+                                                  The SMTP TLS requirement.
+                                                  Note that Go does not support unencrypted connections to remote SMTP endpoints.
                                                 type: boolean
                                               sendResolved:
                                                 description: Whether or not to notify
@@ -607,12 +597,10 @@ spec:
                                                               select.
                                                             type: string
                                                           name:
-                                                            description: 'Name of
-                                                              the referent. More info:
-                                                              https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                              TODO: Add other useful
-                                                              fields. apiVersion,
-                                                              kind, uid?'
+                                                            description: |-
+                                                              Name of the referent.
+                                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                                             type: string
                                                           optional:
                                                             description: Specify whether
@@ -634,12 +622,10 @@ spec:
                                                               secret key.
                                                             type: string
                                                           name:
-                                                            description: 'Name of
-                                                              the referent. More info:
-                                                              https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                              TODO: Add other useful
-                                                              fields. apiVersion,
-                                                              kind, uid?'
+                                                            description: |-
+                                                              Name of the referent.
+                                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                                             type: string
                                                           optional:
                                                             description: Specify whether
@@ -664,12 +650,10 @@ spec:
                                                               select.
                                                             type: string
                                                           name:
-                                                            description: 'Name of
-                                                              the referent. More info:
-                                                              https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                              TODO: Add other useful
-                                                              fields. apiVersion,
-                                                              kind, uid?'
+                                                            description: |-
+                                                              Name of the referent.
+                                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                                             type: string
                                                           optional:
                                                             description: Specify whether
@@ -691,12 +675,10 @@ spec:
                                                               secret key.
                                                             type: string
                                                           name:
-                                                            description: 'Name of
-                                                              the referent. More info:
-                                                              https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                              TODO: Add other useful
-                                                              fields. apiVersion,
-                                                              kind, uid?'
+                                                            description: |-
+                                                              Name of the referent.
+                                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                                             type: string
                                                           optional:
                                                             description: Specify whether
@@ -723,10 +705,10 @@ spec:
                                                           be a valid secret key.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -756,8 +738,9 @@ spec:
                                         opsgenieConfigs:
                                           description: List of OpsGenie configurations.
                                           items:
-                                            description: OpsGenieConfig configures
-                                              notifications via OpsGenie. See https://prometheus.io/docs/alerting/latest/configuration/#opsgenie_config
+                                            description: |-
+                                              OpsGenieConfig configures notifications via OpsGenie.
+                                              See https://prometheus.io/docs/alerting/latest/configuration/#opsgenie_config
                                             properties:
                                               actions:
                                                 description: Comma separated list
@@ -765,12 +748,10 @@ spec:
                                                   for the alert.
                                                 type: string
                                               apiKey:
-                                                description: The secret's key that
-                                                  contains the OpsGenie API key. The
-                                                  secret needs to be in the same namespace
-                                                  as the AlertmanagerConfig object
-                                                  and accessible by the Prometheus
-                                                  Operator.
+                                                description: |-
+                                                  The secret's key that contains the OpsGenie API key.
+                                                  The secret needs to be in the same namespace as the AlertmanagerConfig
+                                                  object and accessible by the Prometheus Operator.
                                                 properties:
                                                   key:
                                                     description: The key of the secret
@@ -778,10 +759,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -827,11 +808,9 @@ spec:
                                                 description: HTTP client configuration.
                                                 properties:
                                                   authorization:
-                                                    description: Authorization header
-                                                      configuration for the client.
-                                                      This is mutually exclusive with
-                                                      BasicAuth and is only available
-                                                      starting from Alertmanager v0.22+.
+                                                    description: |-
+                                                      Authorization header configuration for the client.
+                                                      This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
                                                     properties:
                                                       credentials:
                                                         description: The secret's
@@ -845,12 +824,10 @@ spec:
                                                               secret key.
                                                             type: string
                                                           name:
-                                                            description: 'Name of
-                                                              the referent. More info:
-                                                              https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                              TODO: Add other useful
-                                                              fields. apiVersion,
-                                                              kind, uid?'
+                                                            description: |-
+                                                              Name of the referent.
+                                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                                             type: string
                                                           optional:
                                                             description: Specify whether
@@ -862,22 +839,19 @@ spec:
                                                         type: object
                                                         x-kubernetes-map-type: atomic
                                                       type:
-                                                        description: Set the authentication
-                                                          type. Defaults to Bearer,
-                                                          Basic will cause an error
+                                                        description: |-
+                                                          Set the authentication type. Defaults to Bearer, Basic will cause an
+                                                          error
                                                         type: string
                                                     type: object
                                                   basicAuth:
-                                                    description: BasicAuth for the
-                                                      client. This is mutually exclusive
-                                                      with Authorization. If both
-                                                      are defined, BasicAuth takes
-                                                      precedence.
+                                                    description: |-
+                                                      BasicAuth for the client.
+                                                      This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
                                                     properties:
                                                       password:
-                                                        description: The secret in
-                                                          the service monitor namespace
-                                                          that contains the password
+                                                        description: |-
+                                                          The secret in the service monitor namespace that contains the password
                                                           for authentication.
                                                         properties:
                                                           key:
@@ -887,12 +861,10 @@ spec:
                                                               secret key.
                                                             type: string
                                                           name:
-                                                            description: 'Name of
-                                                              the referent. More info:
-                                                              https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                              TODO: Add other useful
-                                                              fields. apiVersion,
-                                                              kind, uid?'
+                                                            description: |-
+                                                              Name of the referent.
+                                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                                             type: string
                                                           optional:
                                                             description: Specify whether
@@ -904,9 +876,8 @@ spec:
                                                         type: object
                                                         x-kubernetes-map-type: atomic
                                                       username:
-                                                        description: The secret in
-                                                          the service monitor namespace
-                                                          that contains the username
+                                                        description: |-
+                                                          The secret in the service monitor namespace that contains the username
                                                           for authentication.
                                                         properties:
                                                           key:
@@ -916,12 +887,10 @@ spec:
                                                               secret key.
                                                             type: string
                                                           name:
-                                                            description: 'Name of
-                                                              the referent. More info:
-                                                              https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                              TODO: Add other useful
-                                                              fields. apiVersion,
-                                                              kind, uid?'
+                                                            description: |-
+                                                              Name of the referent.
+                                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                                             type: string
                                                           optional:
                                                             description: Specify whether
@@ -934,14 +903,11 @@ spec:
                                                         x-kubernetes-map-type: atomic
                                                     type: object
                                                   bearerTokenSecret:
-                                                    description: The secret's key
-                                                      that contains the bearer token
-                                                      to be used by the client for
-                                                      authentication. The secret needs
-                                                      to be in the same namespace
-                                                      as the AlertmanagerConfig object
-                                                      and accessible by the Prometheus
-                                                      Operator.
+                                                    description: |-
+                                                      The secret's key that contains the bearer token to be used by the client
+                                                      for authentication.
+                                                      The secret needs to be in the same namespace as the AlertmanagerConfig
+                                                      object and accessible by the Prometheus Operator.
                                                     properties:
                                                       key:
                                                         description: The key of the
@@ -949,10 +915,10 @@ spec:
                                                           be a valid secret key.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -988,12 +954,10 @@ spec:
                                                                   to select.
                                                                 type: string
                                                               name:
-                                                                description: 'Name
-                                                                  of the referent.
+                                                                description: |-
+                                                                  Name of the referent.
                                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                                  TODO: Add other
-                                                                  useful fields. apiVersion,
-                                                                  kind, uid?'
+                                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                                 type: string
                                                               optional:
                                                                 description: Specify
@@ -1018,12 +982,10 @@ spec:
                                                                   key.
                                                                 type: string
                                                               name:
-                                                                description: 'Name
-                                                                  of the referent.
+                                                                description: |-
+                                                                  Name of the referent.
                                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                                  TODO: Add other
-                                                                  useful fields. apiVersion,
-                                                                  kind, uid?'
+                                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                                 type: string
                                                               optional:
                                                                 description: Specify
@@ -1047,12 +1009,10 @@ spec:
                                                               secret key.
                                                             type: string
                                                           name:
-                                                            description: 'Name of
-                                                              the referent. More info:
-                                                              https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                              TODO: Add other useful
-                                                              fields. apiVersion,
-                                                              kind, uid?'
+                                                            description: |-
+                                                              Name of the referent.
+                                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                                             type: string
                                                           optional:
                                                             description: Specify whether
@@ -1107,12 +1067,10 @@ spec:
                                                                   to select.
                                                                 type: string
                                                               name:
-                                                                description: 'Name
-                                                                  of the referent.
+                                                                description: |-
+                                                                  Name of the referent.
                                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                                  TODO: Add other
-                                                                  useful fields. apiVersion,
-                                                                  kind, uid?'
+                                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                                 type: string
                                                               optional:
                                                                 description: Specify
@@ -1137,12 +1095,10 @@ spec:
                                                                   key.
                                                                 type: string
                                                               name:
-                                                                description: 'Name
-                                                                  of the referent.
+                                                                description: |-
+                                                                  Name of the referent.
                                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                                  TODO: Add other
-                                                                  useful fields. apiVersion,
-                                                                  kind, uid?'
+                                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                                 type: string
                                                               optional:
                                                                 description: Specify
@@ -1169,12 +1125,10 @@ spec:
                                                                   to select.
                                                                 type: string
                                                               name:
-                                                                description: 'Name
-                                                                  of the referent.
+                                                                description: |-
+                                                                  Name of the referent.
                                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                                  TODO: Add other
-                                                                  useful fields. apiVersion,
-                                                                  kind, uid?'
+                                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                                 type: string
                                                               optional:
                                                                 description: Specify
@@ -1199,12 +1153,10 @@ spec:
                                                                   key.
                                                                 type: string
                                                               name:
-                                                                description: 'Name
-                                                                  of the referent.
+                                                                description: |-
+                                                                  Name of the referent.
                                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                                  TODO: Add other
-                                                                  useful fields. apiVersion,
-                                                                  kind, uid?'
+                                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                                 type: string
                                                               optional:
                                                                 description: Specify
@@ -1233,12 +1185,10 @@ spec:
                                                               secret key.
                                                             type: string
                                                           name:
-                                                            description: 'Name of
-                                                              the referent. More info:
-                                                              https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                              TODO: Add other useful
-                                                              fields. apiVersion,
-                                                              kind, uid?'
+                                                            description: |-
+                                                              Name of the referent.
+                                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                                             type: string
                                                           optional:
                                                             description: Specify whether
@@ -1271,10 +1221,9 @@ spec:
                                                 description: List of responders responsible
                                                   for notifications.
                                                 items:
-                                                  description: OpsGenieConfigResponder
-                                                    defines a responder to an incident.
-                                                    One of `id`, `name` or `username`
-                                                    has to be defined.
+                                                  description: |-
+                                                    OpsGenieConfigResponder defines a responder to an incident.
+                                                    One of `id`, `name` or `username` has to be defined.
                                                   properties:
                                                     id:
                                                       description: ID of the responder.
@@ -1313,20 +1262,18 @@ spec:
                                                   of tags attached to the notifications.
                                                 type: string
                                               updateAlerts:
-                                                description: Whether to update message
-                                                  and description of the alert in
-                                                  OpsGenie if it already exists By
-                                                  default, the alert is never updated
-                                                  in OpsGenie, the new message only
-                                                  appears in activity log.
+                                                description: |-
+                                                  Whether to update message and description of the alert in OpsGenie if it already exists
+                                                  By default, the alert is never updated in OpsGenie, the new message only appears in activity log.
                                                 type: boolean
                                             type: object
                                           type: array
                                         pagerdutyConfigs:
                                           description: List of PagerDuty configurations.
                                           items:
-                                            description: PagerDutyConfig configures
-                                              notifications via PagerDuty. See https://prometheus.io/docs/alerting/latest/configuration/#pagerduty_config
+                                            description: |-
+                                              PagerDutyConfig configures notifications via PagerDuty.
+                                              See https://prometheus.io/docs/alerting/latest/configuration/#pagerduty_config
                                             properties:
                                               class:
                                                 description: The class/type of the
@@ -1374,11 +1321,9 @@ spec:
                                                 description: HTTP client configuration.
                                                 properties:
                                                   authorization:
-                                                    description: Authorization header
-                                                      configuration for the client.
-                                                      This is mutually exclusive with
-                                                      BasicAuth and is only available
-                                                      starting from Alertmanager v0.22+.
+                                                    description: |-
+                                                      Authorization header configuration for the client.
+                                                      This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
                                                     properties:
                                                       credentials:
                                                         description: The secret's
@@ -1392,12 +1337,10 @@ spec:
                                                               secret key.
                                                             type: string
                                                           name:
-                                                            description: 'Name of
-                                                              the referent. More info:
-                                                              https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                              TODO: Add other useful
-                                                              fields. apiVersion,
-                                                              kind, uid?'
+                                                            description: |-
+                                                              Name of the referent.
+                                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                                             type: string
                                                           optional:
                                                             description: Specify whether
@@ -1409,22 +1352,19 @@ spec:
                                                         type: object
                                                         x-kubernetes-map-type: atomic
                                                       type:
-                                                        description: Set the authentication
-                                                          type. Defaults to Bearer,
-                                                          Basic will cause an error
+                                                        description: |-
+                                                          Set the authentication type. Defaults to Bearer, Basic will cause an
+                                                          error
                                                         type: string
                                                     type: object
                                                   basicAuth:
-                                                    description: BasicAuth for the
-                                                      client. This is mutually exclusive
-                                                      with Authorization. If both
-                                                      are defined, BasicAuth takes
-                                                      precedence.
+                                                    description: |-
+                                                      BasicAuth for the client.
+                                                      This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
                                                     properties:
                                                       password:
-                                                        description: The secret in
-                                                          the service monitor namespace
-                                                          that contains the password
+                                                        description: |-
+                                                          The secret in the service monitor namespace that contains the password
                                                           for authentication.
                                                         properties:
                                                           key:
@@ -1434,12 +1374,10 @@ spec:
                                                               secret key.
                                                             type: string
                                                           name:
-                                                            description: 'Name of
-                                                              the referent. More info:
-                                                              https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                              TODO: Add other useful
-                                                              fields. apiVersion,
-                                                              kind, uid?'
+                                                            description: |-
+                                                              Name of the referent.
+                                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                                             type: string
                                                           optional:
                                                             description: Specify whether
@@ -1451,9 +1389,8 @@ spec:
                                                         type: object
                                                         x-kubernetes-map-type: atomic
                                                       username:
-                                                        description: The secret in
-                                                          the service monitor namespace
-                                                          that contains the username
+                                                        description: |-
+                                                          The secret in the service monitor namespace that contains the username
                                                           for authentication.
                                                         properties:
                                                           key:
@@ -1463,12 +1400,10 @@ spec:
                                                               secret key.
                                                             type: string
                                                           name:
-                                                            description: 'Name of
-                                                              the referent. More info:
-                                                              https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                              TODO: Add other useful
-                                                              fields. apiVersion,
-                                                              kind, uid?'
+                                                            description: |-
+                                                              Name of the referent.
+                                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                                             type: string
                                                           optional:
                                                             description: Specify whether
@@ -1481,14 +1416,11 @@ spec:
                                                         x-kubernetes-map-type: atomic
                                                     type: object
                                                   bearerTokenSecret:
-                                                    description: The secret's key
-                                                      that contains the bearer token
-                                                      to be used by the client for
-                                                      authentication. The secret needs
-                                                      to be in the same namespace
-                                                      as the AlertmanagerConfig object
-                                                      and accessible by the Prometheus
-                                                      Operator.
+                                                    description: |-
+                                                      The secret's key that contains the bearer token to be used by the client
+                                                      for authentication.
+                                                      The secret needs to be in the same namespace as the AlertmanagerConfig
+                                                      object and accessible by the Prometheus Operator.
                                                     properties:
                                                       key:
                                                         description: The key of the
@@ -1496,10 +1428,10 @@ spec:
                                                           be a valid secret key.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -1535,12 +1467,10 @@ spec:
                                                                   to select.
                                                                 type: string
                                                               name:
-                                                                description: 'Name
-                                                                  of the referent.
+                                                                description: |-
+                                                                  Name of the referent.
                                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                                  TODO: Add other
-                                                                  useful fields. apiVersion,
-                                                                  kind, uid?'
+                                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                                 type: string
                                                               optional:
                                                                 description: Specify
@@ -1565,12 +1495,10 @@ spec:
                                                                   key.
                                                                 type: string
                                                               name:
-                                                                description: 'Name
-                                                                  of the referent.
+                                                                description: |-
+                                                                  Name of the referent.
                                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                                  TODO: Add other
-                                                                  useful fields. apiVersion,
-                                                                  kind, uid?'
+                                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                                 type: string
                                                               optional:
                                                                 description: Specify
@@ -1594,12 +1522,10 @@ spec:
                                                               secret key.
                                                             type: string
                                                           name:
-                                                            description: 'Name of
-                                                              the referent. More info:
-                                                              https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                              TODO: Add other useful
-                                                              fields. apiVersion,
-                                                              kind, uid?'
+                                                            description: |-
+                                                              Name of the referent.
+                                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                                             type: string
                                                           optional:
                                                             description: Specify whether
@@ -1654,12 +1580,10 @@ spec:
                                                                   to select.
                                                                 type: string
                                                               name:
-                                                                description: 'Name
-                                                                  of the referent.
+                                                                description: |-
+                                                                  Name of the referent.
                                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                                  TODO: Add other
-                                                                  useful fields. apiVersion,
-                                                                  kind, uid?'
+                                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                                 type: string
                                                               optional:
                                                                 description: Specify
@@ -1684,12 +1608,10 @@ spec:
                                                                   key.
                                                                 type: string
                                                               name:
-                                                                description: 'Name
-                                                                  of the referent.
+                                                                description: |-
+                                                                  Name of the referent.
                                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                                  TODO: Add other
-                                                                  useful fields. apiVersion,
-                                                                  kind, uid?'
+                                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                                 type: string
                                                               optional:
                                                                 description: Specify
@@ -1716,12 +1638,10 @@ spec:
                                                                   to select.
                                                                 type: string
                                                               name:
-                                                                description: 'Name
-                                                                  of the referent.
+                                                                description: |-
+                                                                  Name of the referent.
                                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                                  TODO: Add other
-                                                                  useful fields. apiVersion,
-                                                                  kind, uid?'
+                                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                                 type: string
                                                               optional:
                                                                 description: Specify
@@ -1746,12 +1666,10 @@ spec:
                                                                   key.
                                                                 type: string
                                                               name:
-                                                                description: 'Name
-                                                                  of the referent.
+                                                                description: |-
+                                                                  Name of the referent.
                                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                                  TODO: Add other
-                                                                  useful fields. apiVersion,
-                                                                  kind, uid?'
+                                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                                 type: string
                                                               optional:
                                                                 description: Specify
@@ -1780,12 +1698,10 @@ spec:
                                                               secret key.
                                                             type: string
                                                           name:
-                                                            description: 'Name of
-                                                              the referent. More info:
-                                                              https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                              TODO: Add other useful
-                                                              fields. apiVersion,
-                                                              kind, uid?'
+                                                            description: |-
+                                                              Name of the referent.
+                                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                                             type: string
                                                           optional:
                                                             description: Specify whether
@@ -1845,15 +1761,11 @@ spec:
                                                   type: object
                                                 type: array
                                               routingKey:
-                                                description: The secret's key that
-                                                  contains the PagerDuty integration
-                                                  key (when using Events API v2).
-                                                  Either this field or `serviceKey`
-                                                  needs to be defined. The secret
-                                                  needs to be in the same namespace
-                                                  as the AlertmanagerConfig object
-                                                  and accessible by the Prometheus
-                                                  Operator.
+                                                description: |-
+                                                  The secret's key that contains the PagerDuty integration key (when using
+                                                  Events API v2). Either this field or `serviceKey` needs to be defined.
+                                                  The secret needs to be in the same namespace as the AlertmanagerConfig
+                                                  object and accessible by the Prometheus Operator.
                                                 properties:
                                                   key:
                                                     description: The key of the secret
@@ -1861,10 +1773,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -1879,15 +1791,12 @@ spec:
                                                   about resolved alerts.
                                                 type: boolean
                                               serviceKey:
-                                                description: The secret's key that
-                                                  contains the PagerDuty service key
-                                                  (when using integration type "Prometheus").
-                                                  Either this field or `routingKey`
-                                                  needs to be defined. The secret
-                                                  needs to be in the same namespace
-                                                  as the AlertmanagerConfig object
-                                                  and accessible by the Prometheus
-                                                  Operator.
+                                                description: |-
+                                                  The secret's key that contains the PagerDuty service key (when using
+                                                  integration type "Prometheus"). Either this field or `routingKey` needs to
+                                                  be defined.
+                                                  The secret needs to be in the same namespace as the AlertmanagerConfig
+                                                  object and accessible by the Prometheus Operator.
                                                 properties:
                                                   key:
                                                     description: The key of the secret
@@ -1895,10 +1804,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -1920,14 +1829,14 @@ spec:
                                         pushoverConfigs:
                                           description: List of Pushover configurations.
                                           items:
-                                            description: PushoverConfig configures
-                                              notifications via Pushover. See https://prometheus.io/docs/alerting/latest/configuration/#pushover_config
+                                            description: |-
+                                              PushoverConfig configures notifications via Pushover.
+                                              See https://prometheus.io/docs/alerting/latest/configuration/#pushover_config
                                             properties:
                                               expire:
-                                                description: How long your notification
-                                                  will continue to be retried for,
-                                                  unless the user acknowledges the
-                                                  notification.
+                                                description: |-
+                                                  How long your notification will continue to be retried for, unless the user
+                                                  acknowledges the notification.
                                                 pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
                                                 type: string
                                               html:
@@ -1938,11 +1847,9 @@ spec:
                                                 description: HTTP client configuration.
                                                 properties:
                                                   authorization:
-                                                    description: Authorization header
-                                                      configuration for the client.
-                                                      This is mutually exclusive with
-                                                      BasicAuth and is only available
-                                                      starting from Alertmanager v0.22+.
+                                                    description: |-
+                                                      Authorization header configuration for the client.
+                                                      This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
                                                     properties:
                                                       credentials:
                                                         description: The secret's
@@ -1956,12 +1863,10 @@ spec:
                                                               secret key.
                                                             type: string
                                                           name:
-                                                            description: 'Name of
-                                                              the referent. More info:
-                                                              https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                              TODO: Add other useful
-                                                              fields. apiVersion,
-                                                              kind, uid?'
+                                                            description: |-
+                                                              Name of the referent.
+                                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                                             type: string
                                                           optional:
                                                             description: Specify whether
@@ -1973,22 +1878,19 @@ spec:
                                                         type: object
                                                         x-kubernetes-map-type: atomic
                                                       type:
-                                                        description: Set the authentication
-                                                          type. Defaults to Bearer,
-                                                          Basic will cause an error
+                                                        description: |-
+                                                          Set the authentication type. Defaults to Bearer, Basic will cause an
+                                                          error
                                                         type: string
                                                     type: object
                                                   basicAuth:
-                                                    description: BasicAuth for the
-                                                      client. This is mutually exclusive
-                                                      with Authorization. If both
-                                                      are defined, BasicAuth takes
-                                                      precedence.
+                                                    description: |-
+                                                      BasicAuth for the client.
+                                                      This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
                                                     properties:
                                                       password:
-                                                        description: The secret in
-                                                          the service monitor namespace
-                                                          that contains the password
+                                                        description: |-
+                                                          The secret in the service monitor namespace that contains the password
                                                           for authentication.
                                                         properties:
                                                           key:
@@ -1998,12 +1900,10 @@ spec:
                                                               secret key.
                                                             type: string
                                                           name:
-                                                            description: 'Name of
-                                                              the referent. More info:
-                                                              https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                              TODO: Add other useful
-                                                              fields. apiVersion,
-                                                              kind, uid?'
+                                                            description: |-
+                                                              Name of the referent.
+                                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                                             type: string
                                                           optional:
                                                             description: Specify whether
@@ -2015,9 +1915,8 @@ spec:
                                                         type: object
                                                         x-kubernetes-map-type: atomic
                                                       username:
-                                                        description: The secret in
-                                                          the service monitor namespace
-                                                          that contains the username
+                                                        description: |-
+                                                          The secret in the service monitor namespace that contains the username
                                                           for authentication.
                                                         properties:
                                                           key:
@@ -2027,12 +1926,10 @@ spec:
                                                               secret key.
                                                             type: string
                                                           name:
-                                                            description: 'Name of
-                                                              the referent. More info:
-                                                              https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                              TODO: Add other useful
-                                                              fields. apiVersion,
-                                                              kind, uid?'
+                                                            description: |-
+                                                              Name of the referent.
+                                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                                             type: string
                                                           optional:
                                                             description: Specify whether
@@ -2045,14 +1942,11 @@ spec:
                                                         x-kubernetes-map-type: atomic
                                                     type: object
                                                   bearerTokenSecret:
-                                                    description: The secret's key
-                                                      that contains the bearer token
-                                                      to be used by the client for
-                                                      authentication. The secret needs
-                                                      to be in the same namespace
-                                                      as the AlertmanagerConfig object
-                                                      and accessible by the Prometheus
-                                                      Operator.
+                                                    description: |-
+                                                      The secret's key that contains the bearer token to be used by the client
+                                                      for authentication.
+                                                      The secret needs to be in the same namespace as the AlertmanagerConfig
+                                                      object and accessible by the Prometheus Operator.
                                                     properties:
                                                       key:
                                                         description: The key of the
@@ -2060,10 +1954,10 @@ spec:
                                                           be a valid secret key.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -2099,12 +1993,10 @@ spec:
                                                                   to select.
                                                                 type: string
                                                               name:
-                                                                description: 'Name
-                                                                  of the referent.
+                                                                description: |-
+                                                                  Name of the referent.
                                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                                  TODO: Add other
-                                                                  useful fields. apiVersion,
-                                                                  kind, uid?'
+                                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                                 type: string
                                                               optional:
                                                                 description: Specify
@@ -2129,12 +2021,10 @@ spec:
                                                                   key.
                                                                 type: string
                                                               name:
-                                                                description: 'Name
-                                                                  of the referent.
+                                                                description: |-
+                                                                  Name of the referent.
                                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                                  TODO: Add other
-                                                                  useful fields. apiVersion,
-                                                                  kind, uid?'
+                                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                                 type: string
                                                               optional:
                                                                 description: Specify
@@ -2158,12 +2048,10 @@ spec:
                                                               secret key.
                                                             type: string
                                                           name:
-                                                            description: 'Name of
-                                                              the referent. More info:
-                                                              https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                              TODO: Add other useful
-                                                              fields. apiVersion,
-                                                              kind, uid?'
+                                                            description: |-
+                                                              Name of the referent.
+                                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                                             type: string
                                                           optional:
                                                             description: Specify whether
@@ -2218,12 +2106,10 @@ spec:
                                                                   to select.
                                                                 type: string
                                                               name:
-                                                                description: 'Name
-                                                                  of the referent.
+                                                                description: |-
+                                                                  Name of the referent.
                                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                                  TODO: Add other
-                                                                  useful fields. apiVersion,
-                                                                  kind, uid?'
+                                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                                 type: string
                                                               optional:
                                                                 description: Specify
@@ -2248,12 +2134,10 @@ spec:
                                                                   key.
                                                                 type: string
                                                               name:
-                                                                description: 'Name
-                                                                  of the referent.
+                                                                description: |-
+                                                                  Name of the referent.
                                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                                  TODO: Add other
-                                                                  useful fields. apiVersion,
-                                                                  kind, uid?'
+                                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                                 type: string
                                                               optional:
                                                                 description: Specify
@@ -2280,12 +2164,10 @@ spec:
                                                                   to select.
                                                                 type: string
                                                               name:
-                                                                description: 'Name
-                                                                  of the referent.
+                                                                description: |-
+                                                                  Name of the referent.
                                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                                  TODO: Add other
-                                                                  useful fields. apiVersion,
-                                                                  kind, uid?'
+                                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                                 type: string
                                                               optional:
                                                                 description: Specify
@@ -2310,12 +2192,10 @@ spec:
                                                                   key.
                                                                 type: string
                                                               name:
-                                                                description: 'Name
-                                                                  of the referent.
+                                                                description: |-
+                                                                  Name of the referent.
                                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                                  TODO: Add other
-                                                                  useful fields. apiVersion,
-                                                                  kind, uid?'
+                                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                                 type: string
                                                               optional:
                                                                 description: Specify
@@ -2344,12 +2224,10 @@ spec:
                                                               secret key.
                                                             type: string
                                                           name:
-                                                            description: 'Name of
-                                                              the referent. More info:
-                                                              https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                              TODO: Add other useful
-                                                              fields. apiVersion,
-                                                              kind, uid?'
+                                                            description: |-
+                                                              Name of the referent.
+                                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                                             type: string
                                                           optional:
                                                             description: Specify whether
@@ -2373,10 +2251,9 @@ spec:
                                                 description: Priority, see https://pushover.net/api#priority
                                                 type: string
                                               retry:
-                                                description: How often the Pushover
-                                                  servers will send the same notification
-                                                  to the user. Must be at least 30
-                                                  seconds.
+                                                description: |-
+                                                  How often the Pushover servers will send the same notification to the user.
+                                                  Must be at least 30 seconds.
                                                 pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
                                                 type: string
                                               sendResolved:
@@ -2393,13 +2270,10 @@ spec:
                                                 description: Notification title.
                                                 type: string
                                               token:
-                                                description: The secret's key that
-                                                  contains the registered application's
-                                                  API token, see https://pushover.net/apps.
-                                                  The secret needs to be in the same
-                                                  namespace as the AlertmanagerConfig
-                                                  object and accessible by the Prometheus
-                                                  Operator.
+                                                description: |-
+                                                  The secret's key that contains the registered application's API token, see https://pushover.net/apps.
+                                                  The secret needs to be in the same namespace as the AlertmanagerConfig
+                                                  object and accessible by the Prometheus Operator.
                                                 properties:
                                                   key:
                                                     description: The key of the secret
@@ -2407,10 +2281,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -2429,12 +2303,10 @@ spec:
                                                   URL, otherwise just the URL is shown
                                                 type: string
                                               userKey:
-                                                description: The secret's key that
-                                                  contains the recipient user's user
-                                                  key. The secret needs to be in the
-                                                  same namespace as the AlertmanagerConfig
-                                                  object and accessible by the Prometheus
-                                                  Operator.
+                                                description: |-
+                                                  The secret's key that contains the recipient user's user key.
+                                                  The secret needs to be in the same namespace as the AlertmanagerConfig
+                                                  object and accessible by the Prometheus Operator.
                                                 properties:
                                                   key:
                                                     description: The key of the secret
@@ -2442,10 +2314,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -2460,27 +2332,26 @@ spec:
                                         slackConfigs:
                                           description: List of Slack configurations.
                                           items:
-                                            description: SlackConfig configures notifications
-                                              via Slack. See https://prometheus.io/docs/alerting/latest/configuration/#slack_config
+                                            description: |-
+                                              SlackConfig configures notifications via Slack.
+                                              See https://prometheus.io/docs/alerting/latest/configuration/#slack_config
                                             properties:
                                               actions:
                                                 description: A list of Slack actions
                                                   that are sent with each notification.
                                                 items:
-                                                  description: SlackAction configures
-                                                    a single Slack action that is
-                                                    sent with each notification. See
-                                                    https://api.slack.com/docs/message-attachments#action_fields
-                                                    and https://api.slack.com/docs/message-buttons
-                                                    for more information.
+                                                  description: |-
+                                                    SlackAction configures a single Slack action that is sent with each
+                                                    notification.
+                                                    See https://api.slack.com/docs/message-attachments#action_fields and
+                                                    https://api.slack.com/docs/message-buttons for more information.
                                                   properties:
                                                     confirm:
-                                                      description: SlackConfirmationField
-                                                        protect users from destructive
-                                                        actions or particularly distinguished
-                                                        decisions by asking them to
-                                                        confirm their button click
-                                                        one more time. See https://api.slack.com/docs/interactive-message-field-guide#confirmation_fields
+                                                      description: |-
+                                                        SlackConfirmationField protect users from destructive actions or
+                                                        particularly distinguished decisions by asking them to confirm their button
+                                                        click one more time.
+                                                        See https://api.slack.com/docs/interactive-message-field-guide#confirmation_fields
                                                         for more information.
                                                       properties:
                                                         dismissText:
@@ -2515,12 +2386,10 @@ spec:
                                                   type: object
                                                 type: array
                                               apiURL:
-                                                description: The secret's key that
-                                                  contains the Slack webhook URL.
-                                                  The secret needs to be in the same
-                                                  namespace as the AlertmanagerConfig
-                                                  object and accessible by the Prometheus
-                                                  Operator.
+                                                description: |-
+                                                  The secret's key that contains the Slack webhook URL.
+                                                  The secret needs to be in the same namespace as the AlertmanagerConfig
+                                                  object and accessible by the Prometheus Operator.
                                                 properties:
                                                   key:
                                                     description: The key of the secret
@@ -2528,10 +2397,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -2555,16 +2424,11 @@ spec:
                                                 description: A list of Slack fields
                                                   that are sent with each notification.
                                                 items:
-                                                  description: SlackField configures
-                                                    a single Slack field that is sent
-                                                    with each notification. Each field
-                                                    must contain a title, value, and
-                                                    optionally, a boolean value to
-                                                    indicate if the field is short
-                                                    enough to be displayed next to
-                                                    other fields designated as short.
-                                                    See https://api.slack.com/docs/message-attachments#fields
-                                                    for more information.
+                                                  description: |-
+                                                    SlackField configures a single Slack field that is sent with each notification.
+                                                    Each field must contain a title, value, and optionally, a boolean value to indicate if the field
+                                                    is short enough to be displayed next to other fields designated as short.
+                                                    See https://api.slack.com/docs/message-attachments#fields for more information.
                                                   properties:
                                                     short:
                                                       type: boolean
@@ -2585,11 +2449,9 @@ spec:
                                                 description: HTTP client configuration.
                                                 properties:
                                                   authorization:
-                                                    description: Authorization header
-                                                      configuration for the client.
-                                                      This is mutually exclusive with
-                                                      BasicAuth and is only available
-                                                      starting from Alertmanager v0.22+.
+                                                    description: |-
+                                                      Authorization header configuration for the client.
+                                                      This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
                                                     properties:
                                                       credentials:
                                                         description: The secret's
@@ -2603,12 +2465,10 @@ spec:
                                                               secret key.
                                                             type: string
                                                           name:
-                                                            description: 'Name of
-                                                              the referent. More info:
-                                                              https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                              TODO: Add other useful
-                                                              fields. apiVersion,
-                                                              kind, uid?'
+                                                            description: |-
+                                                              Name of the referent.
+                                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                                             type: string
                                                           optional:
                                                             description: Specify whether
@@ -2620,22 +2480,19 @@ spec:
                                                         type: object
                                                         x-kubernetes-map-type: atomic
                                                       type:
-                                                        description: Set the authentication
-                                                          type. Defaults to Bearer,
-                                                          Basic will cause an error
+                                                        description: |-
+                                                          Set the authentication type. Defaults to Bearer, Basic will cause an
+                                                          error
                                                         type: string
                                                     type: object
                                                   basicAuth:
-                                                    description: BasicAuth for the
-                                                      client. This is mutually exclusive
-                                                      with Authorization. If both
-                                                      are defined, BasicAuth takes
-                                                      precedence.
+                                                    description: |-
+                                                      BasicAuth for the client.
+                                                      This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
                                                     properties:
                                                       password:
-                                                        description: The secret in
-                                                          the service monitor namespace
-                                                          that contains the password
+                                                        description: |-
+                                                          The secret in the service monitor namespace that contains the password
                                                           for authentication.
                                                         properties:
                                                           key:
@@ -2645,12 +2502,10 @@ spec:
                                                               secret key.
                                                             type: string
                                                           name:
-                                                            description: 'Name of
-                                                              the referent. More info:
-                                                              https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                              TODO: Add other useful
-                                                              fields. apiVersion,
-                                                              kind, uid?'
+                                                            description: |-
+                                                              Name of the referent.
+                                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                                             type: string
                                                           optional:
                                                             description: Specify whether
@@ -2662,9 +2517,8 @@ spec:
                                                         type: object
                                                         x-kubernetes-map-type: atomic
                                                       username:
-                                                        description: The secret in
-                                                          the service monitor namespace
-                                                          that contains the username
+                                                        description: |-
+                                                          The secret in the service monitor namespace that contains the username
                                                           for authentication.
                                                         properties:
                                                           key:
@@ -2674,12 +2528,10 @@ spec:
                                                               secret key.
                                                             type: string
                                                           name:
-                                                            description: 'Name of
-                                                              the referent. More info:
-                                                              https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                              TODO: Add other useful
-                                                              fields. apiVersion,
-                                                              kind, uid?'
+                                                            description: |-
+                                                              Name of the referent.
+                                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                                             type: string
                                                           optional:
                                                             description: Specify whether
@@ -2692,14 +2544,11 @@ spec:
                                                         x-kubernetes-map-type: atomic
                                                     type: object
                                                   bearerTokenSecret:
-                                                    description: The secret's key
-                                                      that contains the bearer token
-                                                      to be used by the client for
-                                                      authentication. The secret needs
-                                                      to be in the same namespace
-                                                      as the AlertmanagerConfig object
-                                                      and accessible by the Prometheus
-                                                      Operator.
+                                                    description: |-
+                                                      The secret's key that contains the bearer token to be used by the client
+                                                      for authentication.
+                                                      The secret needs to be in the same namespace as the AlertmanagerConfig
+                                                      object and accessible by the Prometheus Operator.
                                                     properties:
                                                       key:
                                                         description: The key of the
@@ -2707,10 +2556,10 @@ spec:
                                                           be a valid secret key.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -2746,12 +2595,10 @@ spec:
                                                                   to select.
                                                                 type: string
                                                               name:
-                                                                description: 'Name
-                                                                  of the referent.
+                                                                description: |-
+                                                                  Name of the referent.
                                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                                  TODO: Add other
-                                                                  useful fields. apiVersion,
-                                                                  kind, uid?'
+                                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                                 type: string
                                                               optional:
                                                                 description: Specify
@@ -2776,12 +2623,10 @@ spec:
                                                                   key.
                                                                 type: string
                                                               name:
-                                                                description: 'Name
-                                                                  of the referent.
+                                                                description: |-
+                                                                  Name of the referent.
                                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                                  TODO: Add other
-                                                                  useful fields. apiVersion,
-                                                                  kind, uid?'
+                                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                                 type: string
                                                               optional:
                                                                 description: Specify
@@ -2805,12 +2650,10 @@ spec:
                                                               secret key.
                                                             type: string
                                                           name:
-                                                            description: 'Name of
-                                                              the referent. More info:
-                                                              https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                              TODO: Add other useful
-                                                              fields. apiVersion,
-                                                              kind, uid?'
+                                                            description: |-
+                                                              Name of the referent.
+                                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                                             type: string
                                                           optional:
                                                             description: Specify whether
@@ -2865,12 +2708,10 @@ spec:
                                                                   to select.
                                                                 type: string
                                                               name:
-                                                                description: 'Name
-                                                                  of the referent.
+                                                                description: |-
+                                                                  Name of the referent.
                                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                                  TODO: Add other
-                                                                  useful fields. apiVersion,
-                                                                  kind, uid?'
+                                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                                 type: string
                                                               optional:
                                                                 description: Specify
@@ -2895,12 +2736,10 @@ spec:
                                                                   key.
                                                                 type: string
                                                               name:
-                                                                description: 'Name
-                                                                  of the referent.
+                                                                description: |-
+                                                                  Name of the referent.
                                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                                  TODO: Add other
-                                                                  useful fields. apiVersion,
-                                                                  kind, uid?'
+                                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                                 type: string
                                                               optional:
                                                                 description: Specify
@@ -2927,12 +2766,10 @@ spec:
                                                                   to select.
                                                                 type: string
                                                               name:
-                                                                description: 'Name
-                                                                  of the referent.
+                                                                description: |-
+                                                                  Name of the referent.
                                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                                  TODO: Add other
-                                                                  useful fields. apiVersion,
-                                                                  kind, uid?'
+                                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                                 type: string
                                                               optional:
                                                                 description: Specify
@@ -2957,12 +2794,10 @@ spec:
                                                                   key.
                                                                 type: string
                                                               name:
-                                                                description: 'Name
-                                                                  of the referent.
+                                                                description: |-
+                                                                  Name of the referent.
                                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                                  TODO: Add other
-                                                                  useful fields. apiVersion,
-                                                                  kind, uid?'
+                                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                                 type: string
                                                               optional:
                                                                 description: Specify
@@ -2991,12 +2826,10 @@ spec:
                                                               secret key.
                                                             type: string
                                                           name:
-                                                            description: 'Name of
-                                                              the referent. More info:
-                                                              https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                              TODO: Add other useful
-                                                              fields. apiVersion,
-                                                              kind, uid?'
+                                                            description: |-
+                                                              Name of the referent.
+                                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                                             type: string
                                                           optional:
                                                             description: Specify whether
@@ -3048,14 +2881,14 @@ spec:
                                         snsConfigs:
                                           description: List of SNS configurations
                                           items:
-                                            description: SNSConfig configures notifications
-                                              via AWS SNS. See https://prometheus.io/docs/alerting/latest/configuration/#sns_configs
+                                            description: |-
+                                              SNSConfig configures notifications via AWS SNS.
+                                              See https://prometheus.io/docs/alerting/latest/configuration/#sns_configs
                                             properties:
                                               apiURL:
-                                                description: The SNS API URL i.e.
-                                                  https://sns.us-east-2.amazonaws.com.
-                                                  If not specified, the SNS API URL
-                                                  from the SNS SDK will be used.
+                                                description: |-
+                                                  The SNS API URL i.e. https://sns.us-east-2.amazonaws.com.
+                                                  If not specified, the SNS API URL from the SNS SDK will be used.
                                                 type: string
                                               attributes:
                                                 additionalProperties:
@@ -3066,11 +2899,9 @@ spec:
                                                 description: HTTP client configuration.
                                                 properties:
                                                   authorization:
-                                                    description: Authorization header
-                                                      configuration for the client.
-                                                      This is mutually exclusive with
-                                                      BasicAuth and is only available
-                                                      starting from Alertmanager v0.22+.
+                                                    description: |-
+                                                      Authorization header configuration for the client.
+                                                      This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
                                                     properties:
                                                       credentials:
                                                         description: The secret's
@@ -3084,12 +2915,10 @@ spec:
                                                               secret key.
                                                             type: string
                                                           name:
-                                                            description: 'Name of
-                                                              the referent. More info:
-                                                              https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                              TODO: Add other useful
-                                                              fields. apiVersion,
-                                                              kind, uid?'
+                                                            description: |-
+                                                              Name of the referent.
+                                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                                             type: string
                                                           optional:
                                                             description: Specify whether
@@ -3101,22 +2930,19 @@ spec:
                                                         type: object
                                                         x-kubernetes-map-type: atomic
                                                       type:
-                                                        description: Set the authentication
-                                                          type. Defaults to Bearer,
-                                                          Basic will cause an error
+                                                        description: |-
+                                                          Set the authentication type. Defaults to Bearer, Basic will cause an
+                                                          error
                                                         type: string
                                                     type: object
                                                   basicAuth:
-                                                    description: BasicAuth for the
-                                                      client. This is mutually exclusive
-                                                      with Authorization. If both
-                                                      are defined, BasicAuth takes
-                                                      precedence.
+                                                    description: |-
+                                                      BasicAuth for the client.
+                                                      This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
                                                     properties:
                                                       password:
-                                                        description: The secret in
-                                                          the service monitor namespace
-                                                          that contains the password
+                                                        description: |-
+                                                          The secret in the service monitor namespace that contains the password
                                                           for authentication.
                                                         properties:
                                                           key:
@@ -3126,12 +2952,10 @@ spec:
                                                               secret key.
                                                             type: string
                                                           name:
-                                                            description: 'Name of
-                                                              the referent. More info:
-                                                              https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                              TODO: Add other useful
-                                                              fields. apiVersion,
-                                                              kind, uid?'
+                                                            description: |-
+                                                              Name of the referent.
+                                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                                             type: string
                                                           optional:
                                                             description: Specify whether
@@ -3143,9 +2967,8 @@ spec:
                                                         type: object
                                                         x-kubernetes-map-type: atomic
                                                       username:
-                                                        description: The secret in
-                                                          the service monitor namespace
-                                                          that contains the username
+                                                        description: |-
+                                                          The secret in the service monitor namespace that contains the username
                                                           for authentication.
                                                         properties:
                                                           key:
@@ -3155,12 +2978,10 @@ spec:
                                                               secret key.
                                                             type: string
                                                           name:
-                                                            description: 'Name of
-                                                              the referent. More info:
-                                                              https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                              TODO: Add other useful
-                                                              fields. apiVersion,
-                                                              kind, uid?'
+                                                            description: |-
+                                                              Name of the referent.
+                                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                                             type: string
                                                           optional:
                                                             description: Specify whether
@@ -3173,14 +2994,11 @@ spec:
                                                         x-kubernetes-map-type: atomic
                                                     type: object
                                                   bearerTokenSecret:
-                                                    description: The secret's key
-                                                      that contains the bearer token
-                                                      to be used by the client for
-                                                      authentication. The secret needs
-                                                      to be in the same namespace
-                                                      as the AlertmanagerConfig object
-                                                      and accessible by the Prometheus
-                                                      Operator.
+                                                    description: |-
+                                                      The secret's key that contains the bearer token to be used by the client
+                                                      for authentication.
+                                                      The secret needs to be in the same namespace as the AlertmanagerConfig
+                                                      object and accessible by the Prometheus Operator.
                                                     properties:
                                                       key:
                                                         description: The key of the
@@ -3188,10 +3006,10 @@ spec:
                                                           be a valid secret key.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -3227,12 +3045,10 @@ spec:
                                                                   to select.
                                                                 type: string
                                                               name:
-                                                                description: 'Name
-                                                                  of the referent.
+                                                                description: |-
+                                                                  Name of the referent.
                                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                                  TODO: Add other
-                                                                  useful fields. apiVersion,
-                                                                  kind, uid?'
+                                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                                 type: string
                                                               optional:
                                                                 description: Specify
@@ -3257,12 +3073,10 @@ spec:
                                                                   key.
                                                                 type: string
                                                               name:
-                                                                description: 'Name
-                                                                  of the referent.
+                                                                description: |-
+                                                                  Name of the referent.
                                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                                  TODO: Add other
-                                                                  useful fields. apiVersion,
-                                                                  kind, uid?'
+                                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                                 type: string
                                                               optional:
                                                                 description: Specify
@@ -3286,12 +3100,10 @@ spec:
                                                               secret key.
                                                             type: string
                                                           name:
-                                                            description: 'Name of
-                                                              the referent. More info:
-                                                              https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                              TODO: Add other useful
-                                                              fields. apiVersion,
-                                                              kind, uid?'
+                                                            description: |-
+                                                              Name of the referent.
+                                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                                             type: string
                                                           optional:
                                                             description: Specify whether
@@ -3346,12 +3158,10 @@ spec:
                                                                   to select.
                                                                 type: string
                                                               name:
-                                                                description: 'Name
-                                                                  of the referent.
+                                                                description: |-
+                                                                  Name of the referent.
                                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                                  TODO: Add other
-                                                                  useful fields. apiVersion,
-                                                                  kind, uid?'
+                                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                                 type: string
                                                               optional:
                                                                 description: Specify
@@ -3376,12 +3186,10 @@ spec:
                                                                   key.
                                                                 type: string
                                                               name:
-                                                                description: 'Name
-                                                                  of the referent.
+                                                                description: |-
+                                                                  Name of the referent.
                                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                                  TODO: Add other
-                                                                  useful fields. apiVersion,
-                                                                  kind, uid?'
+                                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                                 type: string
                                                               optional:
                                                                 description: Specify
@@ -3408,12 +3216,10 @@ spec:
                                                                   to select.
                                                                 type: string
                                                               name:
-                                                                description: 'Name
-                                                                  of the referent.
+                                                                description: |-
+                                                                  Name of the referent.
                                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                                  TODO: Add other
-                                                                  useful fields. apiVersion,
-                                                                  kind, uid?'
+                                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                                 type: string
                                                               optional:
                                                                 description: Specify
@@ -3438,12 +3244,10 @@ spec:
                                                                   key.
                                                                 type: string
                                                               name:
-                                                                description: 'Name
-                                                                  of the referent.
+                                                                description: |-
+                                                                  Name of the referent.
                                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                                  TODO: Add other
-                                                                  useful fields. apiVersion,
-                                                                  kind, uid?'
+                                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                                 type: string
                                                               optional:
                                                                 description: Specify
@@ -3472,12 +3276,10 @@ spec:
                                                               secret key.
                                                             type: string
                                                           name:
-                                                            description: 'Name of
-                                                              the referent. More info:
-                                                              https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                              TODO: Add other useful
-                                                              fields. apiVersion,
-                                                              kind, uid?'
+                                                            description: |-
+                                                              Name of the referent.
+                                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                                             type: string
                                                           optional:
                                                             description: Specify whether
@@ -3499,11 +3301,9 @@ spec:
                                                   the SNS notification.
                                                 type: string
                                               phoneNumber:
-                                                description: Phone number if message
-                                                  is delivered via SMS in E.164 format.
-                                                  If you don't specify this value,
-                                                  you must specify a value for the
-                                                  TopicARN or TargetARN.
+                                                description: |-
+                                                  Phone number if message is delivered via SMS in E.164 format.
+                                                  If you don't specify this value, you must specify a value for the TopicARN or TargetARN.
                                                 type: string
                                               sendResolved:
                                                 description: Whether or not to notify
@@ -3526,10 +3326,10 @@ spec:
                                                           be a valid secret key.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -3566,10 +3366,10 @@ spec:
                                                           be a valid secret key.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -3586,39 +3386,34 @@ spec:
                                                   message is delivered to email endpoints.
                                                 type: string
                                               targetARN:
-                                                description: The  mobile platform
-                                                  endpoint ARN if message is delivered
-                                                  via mobile notifications. If you
-                                                  don't specify this value, you must
-                                                  specify a value for the topic_arn
-                                                  or PhoneNumber.
+                                                description: |-
+                                                  The  mobile platform endpoint ARN if message is delivered via mobile notifications.
+                                                  If you don't specify this value, you must specify a value for the topic_arn or PhoneNumber.
                                                 type: string
                                               topicARN:
-                                                description: SNS topic ARN, i.e. arn:aws:sns:us-east-2:698519295917:My-Topic
-                                                  If you don't specify this value,
-                                                  you must specify a value for the
-                                                  PhoneNumber or TargetARN.
+                                                description: |-
+                                                  SNS topic ARN, i.e. arn:aws:sns:us-east-2:698519295917:My-Topic
+                                                  If you don't specify this value, you must specify a value for the PhoneNumber or TargetARN.
                                                 type: string
                                             type: object
                                           type: array
                                         telegramConfigs:
                                           description: List of Telegram configurations.
                                           items:
-                                            description: TelegramConfig configures
-                                              notifications via Telegram. See https://prometheus.io/docs/alerting/latest/configuration/#telegram_config
+                                            description: |-
+                                              TelegramConfig configures notifications via Telegram.
+                                              See https://prometheus.io/docs/alerting/latest/configuration/#telegram_config
                                             properties:
                                               apiURL:
-                                                description: The Telegram API URL
-                                                  i.e. https://api.telegram.org. If
-                                                  not specified, default API URL will
-                                                  be used.
+                                                description: |-
+                                                  The Telegram API URL i.e. https://api.telegram.org.
+                                                  If not specified, default API URL will be used.
                                                 type: string
                                               botToken:
-                                                description: Telegram bot token The
-                                                  secret needs to be in the same namespace
-                                                  as the AlertmanagerConfig object
-                                                  and accessible by the Prometheus
-                                                  Operator.
+                                                description: |-
+                                                  Telegram bot token
+                                                  The secret needs to be in the same namespace as the AlertmanagerConfig
+                                                  object and accessible by the Prometheus Operator.
                                                 properties:
                                                   key:
                                                     description: The key of the secret
@@ -3626,10 +3421,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -3650,11 +3445,9 @@ spec:
                                                 description: HTTP client configuration.
                                                 properties:
                                                   authorization:
-                                                    description: Authorization header
-                                                      configuration for the client.
-                                                      This is mutually exclusive with
-                                                      BasicAuth and is only available
-                                                      starting from Alertmanager v0.22+.
+                                                    description: |-
+                                                      Authorization header configuration for the client.
+                                                      This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
                                                     properties:
                                                       credentials:
                                                         description: The secret's
@@ -3668,12 +3461,10 @@ spec:
                                                               secret key.
                                                             type: string
                                                           name:
-                                                            description: 'Name of
-                                                              the referent. More info:
-                                                              https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                              TODO: Add other useful
-                                                              fields. apiVersion,
-                                                              kind, uid?'
+                                                            description: |-
+                                                              Name of the referent.
+                                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                                             type: string
                                                           optional:
                                                             description: Specify whether
@@ -3685,22 +3476,19 @@ spec:
                                                         type: object
                                                         x-kubernetes-map-type: atomic
                                                       type:
-                                                        description: Set the authentication
-                                                          type. Defaults to Bearer,
-                                                          Basic will cause an error
+                                                        description: |-
+                                                          Set the authentication type. Defaults to Bearer, Basic will cause an
+                                                          error
                                                         type: string
                                                     type: object
                                                   basicAuth:
-                                                    description: BasicAuth for the
-                                                      client. This is mutually exclusive
-                                                      with Authorization. If both
-                                                      are defined, BasicAuth takes
-                                                      precedence.
+                                                    description: |-
+                                                      BasicAuth for the client.
+                                                      This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
                                                     properties:
                                                       password:
-                                                        description: The secret in
-                                                          the service monitor namespace
-                                                          that contains the password
+                                                        description: |-
+                                                          The secret in the service monitor namespace that contains the password
                                                           for authentication.
                                                         properties:
                                                           key:
@@ -3710,12 +3498,10 @@ spec:
                                                               secret key.
                                                             type: string
                                                           name:
-                                                            description: 'Name of
-                                                              the referent. More info:
-                                                              https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                              TODO: Add other useful
-                                                              fields. apiVersion,
-                                                              kind, uid?'
+                                                            description: |-
+                                                              Name of the referent.
+                                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                                             type: string
                                                           optional:
                                                             description: Specify whether
@@ -3727,9 +3513,8 @@ spec:
                                                         type: object
                                                         x-kubernetes-map-type: atomic
                                                       username:
-                                                        description: The secret in
-                                                          the service monitor namespace
-                                                          that contains the username
+                                                        description: |-
+                                                          The secret in the service monitor namespace that contains the username
                                                           for authentication.
                                                         properties:
                                                           key:
@@ -3739,12 +3524,10 @@ spec:
                                                               secret key.
                                                             type: string
                                                           name:
-                                                            description: 'Name of
-                                                              the referent. More info:
-                                                              https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                              TODO: Add other useful
-                                                              fields. apiVersion,
-                                                              kind, uid?'
+                                                            description: |-
+                                                              Name of the referent.
+                                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                                             type: string
                                                           optional:
                                                             description: Specify whether
@@ -3757,14 +3540,11 @@ spec:
                                                         x-kubernetes-map-type: atomic
                                                     type: object
                                                   bearerTokenSecret:
-                                                    description: The secret's key
-                                                      that contains the bearer token
-                                                      to be used by the client for
-                                                      authentication. The secret needs
-                                                      to be in the same namespace
-                                                      as the AlertmanagerConfig object
-                                                      and accessible by the Prometheus
-                                                      Operator.
+                                                    description: |-
+                                                      The secret's key that contains the bearer token to be used by the client
+                                                      for authentication.
+                                                      The secret needs to be in the same namespace as the AlertmanagerConfig
+                                                      object and accessible by the Prometheus Operator.
                                                     properties:
                                                       key:
                                                         description: The key of the
@@ -3772,10 +3552,10 @@ spec:
                                                           be a valid secret key.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -3811,12 +3591,10 @@ spec:
                                                                   to select.
                                                                 type: string
                                                               name:
-                                                                description: 'Name
-                                                                  of the referent.
+                                                                description: |-
+                                                                  Name of the referent.
                                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                                  TODO: Add other
-                                                                  useful fields. apiVersion,
-                                                                  kind, uid?'
+                                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                                 type: string
                                                               optional:
                                                                 description: Specify
@@ -3841,12 +3619,10 @@ spec:
                                                                   key.
                                                                 type: string
                                                               name:
-                                                                description: 'Name
-                                                                  of the referent.
+                                                                description: |-
+                                                                  Name of the referent.
                                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                                  TODO: Add other
-                                                                  useful fields. apiVersion,
-                                                                  kind, uid?'
+                                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                                 type: string
                                                               optional:
                                                                 description: Specify
@@ -3870,12 +3646,10 @@ spec:
                                                               secret key.
                                                             type: string
                                                           name:
-                                                            description: 'Name of
-                                                              the referent. More info:
-                                                              https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                              TODO: Add other useful
-                                                              fields. apiVersion,
-                                                              kind, uid?'
+                                                            description: |-
+                                                              Name of the referent.
+                                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                                             type: string
                                                           optional:
                                                             description: Specify whether
@@ -3930,12 +3704,10 @@ spec:
                                                                   to select.
                                                                 type: string
                                                               name:
-                                                                description: 'Name
-                                                                  of the referent.
+                                                                description: |-
+                                                                  Name of the referent.
                                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                                  TODO: Add other
-                                                                  useful fields. apiVersion,
-                                                                  kind, uid?'
+                                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                                 type: string
                                                               optional:
                                                                 description: Specify
@@ -3960,12 +3732,10 @@ spec:
                                                                   key.
                                                                 type: string
                                                               name:
-                                                                description: 'Name
-                                                                  of the referent.
+                                                                description: |-
+                                                                  Name of the referent.
                                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                                  TODO: Add other
-                                                                  useful fields. apiVersion,
-                                                                  kind, uid?'
+                                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                                 type: string
                                                               optional:
                                                                 description: Specify
@@ -3992,12 +3762,10 @@ spec:
                                                                   to select.
                                                                 type: string
                                                               name:
-                                                                description: 'Name
-                                                                  of the referent.
+                                                                description: |-
+                                                                  Name of the referent.
                                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                                  TODO: Add other
-                                                                  useful fields. apiVersion,
-                                                                  kind, uid?'
+                                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                                 type: string
                                                               optional:
                                                                 description: Specify
@@ -4022,12 +3790,10 @@ spec:
                                                                   key.
                                                                 type: string
                                                               name:
-                                                                description: 'Name
-                                                                  of the referent.
+                                                                description: |-
+                                                                  Name of the referent.
                                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                                  TODO: Add other
-                                                                  useful fields. apiVersion,
-                                                                  kind, uid?'
+                                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                                 type: string
                                                               optional:
                                                                 description: Specify
@@ -4056,12 +3822,10 @@ spec:
                                                               secret key.
                                                             type: string
                                                           name:
-                                                            description: 'Name of
-                                                              the referent. More info:
-                                                              https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                              TODO: Add other useful
-                                                              fields. apiVersion,
-                                                              kind, uid?'
+                                                            description: |-
+                                                              Name of the referent.
+                                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                                             type: string
                                                           optional:
                                                             description: Specify whether
@@ -4098,17 +3862,15 @@ spec:
                                         victoropsConfigs:
                                           description: List of VictorOps configurations.
                                           items:
-                                            description: VictorOpsConfig configures
-                                              notifications via VictorOps. See https://prometheus.io/docs/alerting/latest/configuration/#victorops_config
+                                            description: |-
+                                              VictorOpsConfig configures notifications via VictorOps.
+                                              See https://prometheus.io/docs/alerting/latest/configuration/#victorops_config
                                             properties:
                                               apiKey:
-                                                description: The secret's key that
-                                                  contains the API key to use when
-                                                  talking to the VictorOps API. The
-                                                  secret needs to be in the same namespace
-                                                  as the AlertmanagerConfig object
-                                                  and accessible by the Prometheus
-                                                  Operator.
+                                                description: |-
+                                                  The secret's key that contains the API key to use when talking to the VictorOps API.
+                                                  The secret needs to be in the same namespace as the AlertmanagerConfig
+                                                  object and accessible by the Prometheus Operator.
                                                 properties:
                                                   key:
                                                     description: The key of the secret
@@ -4116,10 +3878,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -4159,11 +3921,9 @@ spec:
                                                 description: The HTTP client's configuration.
                                                 properties:
                                                   authorization:
-                                                    description: Authorization header
-                                                      configuration for the client.
-                                                      This is mutually exclusive with
-                                                      BasicAuth and is only available
-                                                      starting from Alertmanager v0.22+.
+                                                    description: |-
+                                                      Authorization header configuration for the client.
+                                                      This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
                                                     properties:
                                                       credentials:
                                                         description: The secret's
@@ -4177,12 +3937,10 @@ spec:
                                                               secret key.
                                                             type: string
                                                           name:
-                                                            description: 'Name of
-                                                              the referent. More info:
-                                                              https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                              TODO: Add other useful
-                                                              fields. apiVersion,
-                                                              kind, uid?'
+                                                            description: |-
+                                                              Name of the referent.
+                                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                                             type: string
                                                           optional:
                                                             description: Specify whether
@@ -4194,22 +3952,19 @@ spec:
                                                         type: object
                                                         x-kubernetes-map-type: atomic
                                                       type:
-                                                        description: Set the authentication
-                                                          type. Defaults to Bearer,
-                                                          Basic will cause an error
+                                                        description: |-
+                                                          Set the authentication type. Defaults to Bearer, Basic will cause an
+                                                          error
                                                         type: string
                                                     type: object
                                                   basicAuth:
-                                                    description: BasicAuth for the
-                                                      client. This is mutually exclusive
-                                                      with Authorization. If both
-                                                      are defined, BasicAuth takes
-                                                      precedence.
+                                                    description: |-
+                                                      BasicAuth for the client.
+                                                      This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
                                                     properties:
                                                       password:
-                                                        description: The secret in
-                                                          the service monitor namespace
-                                                          that contains the password
+                                                        description: |-
+                                                          The secret in the service monitor namespace that contains the password
                                                           for authentication.
                                                         properties:
                                                           key:
@@ -4219,12 +3974,10 @@ spec:
                                                               secret key.
                                                             type: string
                                                           name:
-                                                            description: 'Name of
-                                                              the referent. More info:
-                                                              https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                              TODO: Add other useful
-                                                              fields. apiVersion,
-                                                              kind, uid?'
+                                                            description: |-
+                                                              Name of the referent.
+                                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                                             type: string
                                                           optional:
                                                             description: Specify whether
@@ -4236,9 +3989,8 @@ spec:
                                                         type: object
                                                         x-kubernetes-map-type: atomic
                                                       username:
-                                                        description: The secret in
-                                                          the service monitor namespace
-                                                          that contains the username
+                                                        description: |-
+                                                          The secret in the service monitor namespace that contains the username
                                                           for authentication.
                                                         properties:
                                                           key:
@@ -4248,12 +4000,10 @@ spec:
                                                               secret key.
                                                             type: string
                                                           name:
-                                                            description: 'Name of
-                                                              the referent. More info:
-                                                              https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                              TODO: Add other useful
-                                                              fields. apiVersion,
-                                                              kind, uid?'
+                                                            description: |-
+                                                              Name of the referent.
+                                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                                             type: string
                                                           optional:
                                                             description: Specify whether
@@ -4266,14 +4016,11 @@ spec:
                                                         x-kubernetes-map-type: atomic
                                                     type: object
                                                   bearerTokenSecret:
-                                                    description: The secret's key
-                                                      that contains the bearer token
-                                                      to be used by the client for
-                                                      authentication. The secret needs
-                                                      to be in the same namespace
-                                                      as the AlertmanagerConfig object
-                                                      and accessible by the Prometheus
-                                                      Operator.
+                                                    description: |-
+                                                      The secret's key that contains the bearer token to be used by the client
+                                                      for authentication.
+                                                      The secret needs to be in the same namespace as the AlertmanagerConfig
+                                                      object and accessible by the Prometheus Operator.
                                                     properties:
                                                       key:
                                                         description: The key of the
@@ -4281,10 +4028,10 @@ spec:
                                                           be a valid secret key.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -4320,12 +4067,10 @@ spec:
                                                                   to select.
                                                                 type: string
                                                               name:
-                                                                description: 'Name
-                                                                  of the referent.
+                                                                description: |-
+                                                                  Name of the referent.
                                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                                  TODO: Add other
-                                                                  useful fields. apiVersion,
-                                                                  kind, uid?'
+                                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                                 type: string
                                                               optional:
                                                                 description: Specify
@@ -4350,12 +4095,10 @@ spec:
                                                                   key.
                                                                 type: string
                                                               name:
-                                                                description: 'Name
-                                                                  of the referent.
+                                                                description: |-
+                                                                  Name of the referent.
                                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                                  TODO: Add other
-                                                                  useful fields. apiVersion,
-                                                                  kind, uid?'
+                                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                                 type: string
                                                               optional:
                                                                 description: Specify
@@ -4379,12 +4122,10 @@ spec:
                                                               secret key.
                                                             type: string
                                                           name:
-                                                            description: 'Name of
-                                                              the referent. More info:
-                                                              https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                              TODO: Add other useful
-                                                              fields. apiVersion,
-                                                              kind, uid?'
+                                                            description: |-
+                                                              Name of the referent.
+                                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                                             type: string
                                                           optional:
                                                             description: Specify whether
@@ -4439,12 +4180,10 @@ spec:
                                                                   to select.
                                                                 type: string
                                                               name:
-                                                                description: 'Name
-                                                                  of the referent.
+                                                                description: |-
+                                                                  Name of the referent.
                                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                                  TODO: Add other
-                                                                  useful fields. apiVersion,
-                                                                  kind, uid?'
+                                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                                 type: string
                                                               optional:
                                                                 description: Specify
@@ -4469,12 +4208,10 @@ spec:
                                                                   key.
                                                                 type: string
                                                               name:
-                                                                description: 'Name
-                                                                  of the referent.
+                                                                description: |-
+                                                                  Name of the referent.
                                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                                  TODO: Add other
-                                                                  useful fields. apiVersion,
-                                                                  kind, uid?'
+                                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                                 type: string
                                                               optional:
                                                                 description: Specify
@@ -4501,12 +4238,10 @@ spec:
                                                                   to select.
                                                                 type: string
                                                               name:
-                                                                description: 'Name
-                                                                  of the referent.
+                                                                description: |-
+                                                                  Name of the referent.
                                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                                  TODO: Add other
-                                                                  useful fields. apiVersion,
-                                                                  kind, uid?'
+                                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                                 type: string
                                                               optional:
                                                                 description: Specify
@@ -4531,12 +4266,10 @@ spec:
                                                                   key.
                                                                 type: string
                                                               name:
-                                                                description: 'Name
-                                                                  of the referent.
+                                                                description: |-
+                                                                  Name of the referent.
                                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                                  TODO: Add other
-                                                                  useful fields. apiVersion,
-                                                                  kind, uid?'
+                                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                                 type: string
                                                               optional:
                                                                 description: Specify
@@ -4565,12 +4298,10 @@ spec:
                                                               secret key.
                                                             type: string
                                                           name:
-                                                            description: 'Name of
-                                                              the referent. More info:
-                                                              https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                              TODO: Add other useful
-                                                              fields. apiVersion,
-                                                              kind, uid?'
+                                                            description: |-
+                                                              Name of the referent.
+                                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                                             type: string
                                                           optional:
                                                             description: Specify whether
@@ -4613,20 +4344,17 @@ spec:
                                         webhookConfigs:
                                           description: List of webhook configurations.
                                           items:
-                                            description: WebhookConfig configures
-                                              notifications via a generic receiver
-                                              supporting the webhook payload. See
-                                              https://prometheus.io/docs/alerting/latest/configuration/#webhook_config
+                                            description: |-
+                                              WebhookConfig configures notifications via a generic receiver supporting the webhook payload.
+                                              See https://prometheus.io/docs/alerting/latest/configuration/#webhook_config
                                             properties:
                                               httpConfig:
                                                 description: HTTP client configuration.
                                                 properties:
                                                   authorization:
-                                                    description: Authorization header
-                                                      configuration for the client.
-                                                      This is mutually exclusive with
-                                                      BasicAuth and is only available
-                                                      starting from Alertmanager v0.22+.
+                                                    description: |-
+                                                      Authorization header configuration for the client.
+                                                      This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
                                                     properties:
                                                       credentials:
                                                         description: The secret's
@@ -4640,12 +4368,10 @@ spec:
                                                               secret key.
                                                             type: string
                                                           name:
-                                                            description: 'Name of
-                                                              the referent. More info:
-                                                              https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                              TODO: Add other useful
-                                                              fields. apiVersion,
-                                                              kind, uid?'
+                                                            description: |-
+                                                              Name of the referent.
+                                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                                             type: string
                                                           optional:
                                                             description: Specify whether
@@ -4657,22 +4383,19 @@ spec:
                                                         type: object
                                                         x-kubernetes-map-type: atomic
                                                       type:
-                                                        description: Set the authentication
-                                                          type. Defaults to Bearer,
-                                                          Basic will cause an error
+                                                        description: |-
+                                                          Set the authentication type. Defaults to Bearer, Basic will cause an
+                                                          error
                                                         type: string
                                                     type: object
                                                   basicAuth:
-                                                    description: BasicAuth for the
-                                                      client. This is mutually exclusive
-                                                      with Authorization. If both
-                                                      are defined, BasicAuth takes
-                                                      precedence.
+                                                    description: |-
+                                                      BasicAuth for the client.
+                                                      This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
                                                     properties:
                                                       password:
-                                                        description: The secret in
-                                                          the service monitor namespace
-                                                          that contains the password
+                                                        description: |-
+                                                          The secret in the service monitor namespace that contains the password
                                                           for authentication.
                                                         properties:
                                                           key:
@@ -4682,12 +4405,10 @@ spec:
                                                               secret key.
                                                             type: string
                                                           name:
-                                                            description: 'Name of
-                                                              the referent. More info:
-                                                              https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                              TODO: Add other useful
-                                                              fields. apiVersion,
-                                                              kind, uid?'
+                                                            description: |-
+                                                              Name of the referent.
+                                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                                             type: string
                                                           optional:
                                                             description: Specify whether
@@ -4699,9 +4420,8 @@ spec:
                                                         type: object
                                                         x-kubernetes-map-type: atomic
                                                       username:
-                                                        description: The secret in
-                                                          the service monitor namespace
-                                                          that contains the username
+                                                        description: |-
+                                                          The secret in the service monitor namespace that contains the username
                                                           for authentication.
                                                         properties:
                                                           key:
@@ -4711,12 +4431,10 @@ spec:
                                                               secret key.
                                                             type: string
                                                           name:
-                                                            description: 'Name of
-                                                              the referent. More info:
-                                                              https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                              TODO: Add other useful
-                                                              fields. apiVersion,
-                                                              kind, uid?'
+                                                            description: |-
+                                                              Name of the referent.
+                                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                                             type: string
                                                           optional:
                                                             description: Specify whether
@@ -4729,14 +4447,11 @@ spec:
                                                         x-kubernetes-map-type: atomic
                                                     type: object
                                                   bearerTokenSecret:
-                                                    description: The secret's key
-                                                      that contains the bearer token
-                                                      to be used by the client for
-                                                      authentication. The secret needs
-                                                      to be in the same namespace
-                                                      as the AlertmanagerConfig object
-                                                      and accessible by the Prometheus
-                                                      Operator.
+                                                    description: |-
+                                                      The secret's key that contains the bearer token to be used by the client
+                                                      for authentication.
+                                                      The secret needs to be in the same namespace as the AlertmanagerConfig
+                                                      object and accessible by the Prometheus Operator.
                                                     properties:
                                                       key:
                                                         description: The key of the
@@ -4744,10 +4459,10 @@ spec:
                                                           be a valid secret key.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -4783,12 +4498,10 @@ spec:
                                                                   to select.
                                                                 type: string
                                                               name:
-                                                                description: 'Name
-                                                                  of the referent.
+                                                                description: |-
+                                                                  Name of the referent.
                                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                                  TODO: Add other
-                                                                  useful fields. apiVersion,
-                                                                  kind, uid?'
+                                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                                 type: string
                                                               optional:
                                                                 description: Specify
@@ -4813,12 +4526,10 @@ spec:
                                                                   key.
                                                                 type: string
                                                               name:
-                                                                description: 'Name
-                                                                  of the referent.
+                                                                description: |-
+                                                                  Name of the referent.
                                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                                  TODO: Add other
-                                                                  useful fields. apiVersion,
-                                                                  kind, uid?'
+                                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                                 type: string
                                                               optional:
                                                                 description: Specify
@@ -4842,12 +4553,10 @@ spec:
                                                               secret key.
                                                             type: string
                                                           name:
-                                                            description: 'Name of
-                                                              the referent. More info:
-                                                              https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                              TODO: Add other useful
-                                                              fields. apiVersion,
-                                                              kind, uid?'
+                                                            description: |-
+                                                              Name of the referent.
+                                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                                             type: string
                                                           optional:
                                                             description: Specify whether
@@ -4902,12 +4611,10 @@ spec:
                                                                   to select.
                                                                 type: string
                                                               name:
-                                                                description: 'Name
-                                                                  of the referent.
+                                                                description: |-
+                                                                  Name of the referent.
                                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                                  TODO: Add other
-                                                                  useful fields. apiVersion,
-                                                                  kind, uid?'
+                                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                                 type: string
                                                               optional:
                                                                 description: Specify
@@ -4932,12 +4639,10 @@ spec:
                                                                   key.
                                                                 type: string
                                                               name:
-                                                                description: 'Name
-                                                                  of the referent.
+                                                                description: |-
+                                                                  Name of the referent.
                                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                                  TODO: Add other
-                                                                  useful fields. apiVersion,
-                                                                  kind, uid?'
+                                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                                 type: string
                                                               optional:
                                                                 description: Specify
@@ -4964,12 +4669,10 @@ spec:
                                                                   to select.
                                                                 type: string
                                                               name:
-                                                                description: 'Name
-                                                                  of the referent.
+                                                                description: |-
+                                                                  Name of the referent.
                                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                                  TODO: Add other
-                                                                  useful fields. apiVersion,
-                                                                  kind, uid?'
+                                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                                 type: string
                                                               optional:
                                                                 description: Specify
@@ -4994,12 +4697,10 @@ spec:
                                                                   key.
                                                                 type: string
                                                               name:
-                                                                description: 'Name
-                                                                  of the referent.
+                                                                description: |-
+                                                                  Name of the referent.
                                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                                  TODO: Add other
-                                                                  useful fields. apiVersion,
-                                                                  kind, uid?'
+                                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                                 type: string
                                                               optional:
                                                                 description: Specify
@@ -5028,12 +4729,10 @@ spec:
                                                               secret key.
                                                             type: string
                                                           name:
-                                                            description: 'Name of
-                                                              the referent. More info:
-                                                              https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                              TODO: Add other useful
-                                                              fields. apiVersion,
-                                                              kind, uid?'
+                                                            description: |-
+                                                              Name of the referent.
+                                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                                             type: string
                                                           optional:
                                                             description: Specify whether
@@ -5062,21 +4761,17 @@ spec:
                                                   about resolved alerts.
                                                 type: boolean
                                               url:
-                                                description: The URL to send HTTP
-                                                  POST requests to. `urlSecret` takes
-                                                  precedence over `url`. One of `urlSecret`
-                                                  and `url` should be defined.
+                                                description: |-
+                                                  The URL to send HTTP POST requests to. `urlSecret` takes precedence over
+                                                  `url`. One of `urlSecret` and `url` should be defined.
                                                 type: string
                                               urlSecret:
-                                                description: The secret's key that
-                                                  contains the webhook URL to send
-                                                  HTTP requests to. `urlSecret` takes
-                                                  precedence over `url`. One of `urlSecret`
-                                                  and `url` should be defined. The
-                                                  secret needs to be in the same namespace
-                                                  as the AlertmanagerConfig object
-                                                  and accessible by the Prometheus
-                                                  Operator.
+                                                description: |-
+                                                  The secret's key that contains the webhook URL to send HTTP requests to.
+                                                  `urlSecret` takes precedence over `url`. One of `urlSecret` and `url`
+                                                  should be defined.
+                                                  The secret needs to be in the same namespace as the AlertmanagerConfig
+                                                  object and accessible by the Prometheus Operator.
                                                 properties:
                                                   key:
                                                     description: The key of the secret
@@ -5084,10 +4779,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -5102,18 +4797,17 @@ spec:
                                         wechatConfigs:
                                           description: List of WeChat configurations.
                                           items:
-                                            description: WeChatConfig configures notifications
-                                              via WeChat. See https://prometheus.io/docs/alerting/latest/configuration/#wechat_config
+                                            description: |-
+                                              WeChatConfig configures notifications via WeChat.
+                                              See https://prometheus.io/docs/alerting/latest/configuration/#wechat_config
                                             properties:
                                               agentID:
                                                 type: string
                                               apiSecret:
-                                                description: The secret's key that
-                                                  contains the WeChat API key. The
-                                                  secret needs to be in the same namespace
-                                                  as the AlertmanagerConfig object
-                                                  and accessible by the Prometheus
-                                                  Operator.
+                                                description: |-
+                                                  The secret's key that contains the WeChat API key.
+                                                  The secret needs to be in the same namespace as the AlertmanagerConfig
+                                                  object and accessible by the Prometheus Operator.
                                                 properties:
                                                   key:
                                                     description: The key of the secret
@@ -5121,10 +4815,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -5144,11 +4838,9 @@ spec:
                                                 description: HTTP client configuration.
                                                 properties:
                                                   authorization:
-                                                    description: Authorization header
-                                                      configuration for the client.
-                                                      This is mutually exclusive with
-                                                      BasicAuth and is only available
-                                                      starting from Alertmanager v0.22+.
+                                                    description: |-
+                                                      Authorization header configuration for the client.
+                                                      This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
                                                     properties:
                                                       credentials:
                                                         description: The secret's
@@ -5162,12 +4854,10 @@ spec:
                                                               secret key.
                                                             type: string
                                                           name:
-                                                            description: 'Name of
-                                                              the referent. More info:
-                                                              https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                              TODO: Add other useful
-                                                              fields. apiVersion,
-                                                              kind, uid?'
+                                                            description: |-
+                                                              Name of the referent.
+                                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                                             type: string
                                                           optional:
                                                             description: Specify whether
@@ -5179,22 +4869,19 @@ spec:
                                                         type: object
                                                         x-kubernetes-map-type: atomic
                                                       type:
-                                                        description: Set the authentication
-                                                          type. Defaults to Bearer,
-                                                          Basic will cause an error
+                                                        description: |-
+                                                          Set the authentication type. Defaults to Bearer, Basic will cause an
+                                                          error
                                                         type: string
                                                     type: object
                                                   basicAuth:
-                                                    description: BasicAuth for the
-                                                      client. This is mutually exclusive
-                                                      with Authorization. If both
-                                                      are defined, BasicAuth takes
-                                                      precedence.
+                                                    description: |-
+                                                      BasicAuth for the client.
+                                                      This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
                                                     properties:
                                                       password:
-                                                        description: The secret in
-                                                          the service monitor namespace
-                                                          that contains the password
+                                                        description: |-
+                                                          The secret in the service monitor namespace that contains the password
                                                           for authentication.
                                                         properties:
                                                           key:
@@ -5204,12 +4891,10 @@ spec:
                                                               secret key.
                                                             type: string
                                                           name:
-                                                            description: 'Name of
-                                                              the referent. More info:
-                                                              https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                              TODO: Add other useful
-                                                              fields. apiVersion,
-                                                              kind, uid?'
+                                                            description: |-
+                                                              Name of the referent.
+                                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                                             type: string
                                                           optional:
                                                             description: Specify whether
@@ -5221,9 +4906,8 @@ spec:
                                                         type: object
                                                         x-kubernetes-map-type: atomic
                                                       username:
-                                                        description: The secret in
-                                                          the service monitor namespace
-                                                          that contains the username
+                                                        description: |-
+                                                          The secret in the service monitor namespace that contains the username
                                                           for authentication.
                                                         properties:
                                                           key:
@@ -5233,12 +4917,10 @@ spec:
                                                               secret key.
                                                             type: string
                                                           name:
-                                                            description: 'Name of
-                                                              the referent. More info:
-                                                              https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                              TODO: Add other useful
-                                                              fields. apiVersion,
-                                                              kind, uid?'
+                                                            description: |-
+                                                              Name of the referent.
+                                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                                             type: string
                                                           optional:
                                                             description: Specify whether
@@ -5251,14 +4933,11 @@ spec:
                                                         x-kubernetes-map-type: atomic
                                                     type: object
                                                   bearerTokenSecret:
-                                                    description: The secret's key
-                                                      that contains the bearer token
-                                                      to be used by the client for
-                                                      authentication. The secret needs
-                                                      to be in the same namespace
-                                                      as the AlertmanagerConfig object
-                                                      and accessible by the Prometheus
-                                                      Operator.
+                                                    description: |-
+                                                      The secret's key that contains the bearer token to be used by the client
+                                                      for authentication.
+                                                      The secret needs to be in the same namespace as the AlertmanagerConfig
+                                                      object and accessible by the Prometheus Operator.
                                                     properties:
                                                       key:
                                                         description: The key of the
@@ -5266,10 +4945,10 @@ spec:
                                                           be a valid secret key.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -5305,12 +4984,10 @@ spec:
                                                                   to select.
                                                                 type: string
                                                               name:
-                                                                description: 'Name
-                                                                  of the referent.
+                                                                description: |-
+                                                                  Name of the referent.
                                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                                  TODO: Add other
-                                                                  useful fields. apiVersion,
-                                                                  kind, uid?'
+                                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                                 type: string
                                                               optional:
                                                                 description: Specify
@@ -5335,12 +5012,10 @@ spec:
                                                                   key.
                                                                 type: string
                                                               name:
-                                                                description: 'Name
-                                                                  of the referent.
+                                                                description: |-
+                                                                  Name of the referent.
                                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                                  TODO: Add other
-                                                                  useful fields. apiVersion,
-                                                                  kind, uid?'
+                                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                                 type: string
                                                               optional:
                                                                 description: Specify
@@ -5364,12 +5039,10 @@ spec:
                                                               secret key.
                                                             type: string
                                                           name:
-                                                            description: 'Name of
-                                                              the referent. More info:
-                                                              https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                              TODO: Add other useful
-                                                              fields. apiVersion,
-                                                              kind, uid?'
+                                                            description: |-
+                                                              Name of the referent.
+                                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                                             type: string
                                                           optional:
                                                             description: Specify whether
@@ -5424,12 +5097,10 @@ spec:
                                                                   to select.
                                                                 type: string
                                                               name:
-                                                                description: 'Name
-                                                                  of the referent.
+                                                                description: |-
+                                                                  Name of the referent.
                                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                                  TODO: Add other
-                                                                  useful fields. apiVersion,
-                                                                  kind, uid?'
+                                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                                 type: string
                                                               optional:
                                                                 description: Specify
@@ -5454,12 +5125,10 @@ spec:
                                                                   key.
                                                                 type: string
                                                               name:
-                                                                description: 'Name
-                                                                  of the referent.
+                                                                description: |-
+                                                                  Name of the referent.
                                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                                  TODO: Add other
-                                                                  useful fields. apiVersion,
-                                                                  kind, uid?'
+                                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                                 type: string
                                                               optional:
                                                                 description: Specify
@@ -5486,12 +5155,10 @@ spec:
                                                                   to select.
                                                                 type: string
                                                               name:
-                                                                description: 'Name
-                                                                  of the referent.
+                                                                description: |-
+                                                                  Name of the referent.
                                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                                  TODO: Add other
-                                                                  useful fields. apiVersion,
-                                                                  kind, uid?'
+                                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                                 type: string
                                                               optional:
                                                                 description: Specify
@@ -5516,12 +5183,10 @@ spec:
                                                                   key.
                                                                 type: string
                                                               name:
-                                                                description: 'Name
-                                                                  of the referent.
+                                                                description: |-
+                                                                  Name of the referent.
                                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                                  TODO: Add other
-                                                                  useful fields. apiVersion,
-                                                                  kind, uid?'
+                                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                                 type: string
                                                               optional:
                                                                 description: Specify
@@ -5550,12 +5215,10 @@ spec:
                                                               secret key.
                                                             type: string
                                                           name:
-                                                            description: 'Name of
-                                                              the referent. More info:
-                                                              https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                              TODO: Add other useful
-                                                              fields. apiVersion,
-                                                              kind, uid?'
+                                                            description: |-
+                                                              Name of the referent.
+                                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                                             type: string
                                                           optional:
                                                             description: Specify whether
@@ -5595,11 +5258,10 @@ spec:
                                       type: object
                                     type: array
                                   route:
-                                    description: The Alertmanager route definition
-                                      for alerts matching the resource's namespace.
-                                      If present, it will be added to the generated
-                                      Alertmanager configuration as a first-level
-                                      route.
+                                    description: |-
+                                      The Alertmanager route definition for alerts matching the resource's
+                                      namespace. If present, it will be added to the generated Alertmanager
+                                      configuration as a first-level route.
                                     properties:
                                       activeTimeIntervals:
                                         description: ActiveTimeIntervals is a list
@@ -5609,49 +5271,45 @@ spec:
                                           type: string
                                         type: array
                                       continue:
-                                        description: Boolean indicating whether an
-                                          alert should continue matching subsequent
-                                          sibling nodes. It will always be overridden
-                                          to true for the first-level route by the
-                                          Prometheus operator.
+                                        description: |-
+                                          Boolean indicating whether an alert should continue matching subsequent
+                                          sibling nodes. It will always be overridden to true for the first-level
+                                          route by the Prometheus operator.
                                         type: boolean
                                       groupBy:
-                                        description: List of labels to group by. Labels
-                                          must not be repeated (unique list). Special
-                                          label "..." (aggregate by all possible labels),
-                                          if provided, must be the only element in
-                                          the list.
+                                        description: |-
+                                          List of labels to group by.
+                                          Labels must not be repeated (unique list).
+                                          Special label "..." (aggregate by all possible labels), if provided, must be the only element in the list.
                                         items:
                                           type: string
                                         type: array
                                       groupInterval:
-                                        description: 'How long to wait before sending
-                                          an updated notification. Must match the
-                                          regular expression`^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$`
-                                          Example: "5m"'
+                                        description: |-
+                                          How long to wait before sending an updated notification.
+                                          Must match the regular expression`^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$`
+                                          Example: "5m"
                                         type: string
                                       groupWait:
-                                        description: 'How long to wait before sending
-                                          the initial notification. Must match the
-                                          regular expression`^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$`
-                                          Example: "30s"'
+                                        description: |-
+                                          How long to wait before sending the initial notification.
+                                          Must match the regular expression`^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$`
+                                          Example: "30s"
                                         type: string
                                       matchers:
-                                        description: 'List of matchers that the alert''s
-                                          labels should match. For the first level
-                                          route, the operator removes any existing
-                                          equality and regexp matcher on the `namespace`
-                                          label and adds a `namespace: <object namespace>`
-                                          matcher.'
+                                        description: |-
+                                          List of matchers that the alert's labels should match. For the first
+                                          level route, the operator removes any existing equality and regexp
+                                          matcher on the `namespace` label and adds a `namespace: <object
+                                          namespace>` matcher.
                                         items:
                                           description: Matcher defines how to match
                                             on alert's labels.
                                           properties:
                                             matchType:
-                                              description: Match operation available
-                                                with AlertManager >= v0.22.0 and takes
-                                                precedence over Regex (deprecated)
-                                                if non-empty.
+                                              description: |-
+                                                Match operation available with AlertManager >= v0.22.0 and
+                                                takes precedence over Regex (deprecated) if non-empty.
                                               enum:
                                               - '!='
                                               - "="
@@ -5663,11 +5321,9 @@ spec:
                                               minLength: 1
                                               type: string
                                             regex:
-                                              description: Whether to match on equality
-                                                (false) or regular-expression (true).
-                                                Deprecated as of AlertManager >= v0.22.0
-                                                where a user should use MatchType
-                                                instead.
+                                              description: |-
+                                                Whether to match on equality (false) or regular-expression (true).
+                                                Deprecated as of AlertManager >= v0.22.0 where a user should use MatchType instead.
                                               type: boolean
                                             value:
                                               description: Label value to match.
@@ -5677,30 +5333,28 @@ spec:
                                           type: object
                                         type: array
                                       muteTimeIntervals:
-                                        description: 'Note: this comment applies to
-                                          the field definition above but appears below
-                                          otherwise it gets included in the generated
-                                          manifest. CRD schema doesn''t support self-referential
-                                          types for now (see https://github.com/kubernetes/kubernetes/issues/62872).
-                                          We have to use an alternative type to circumvent
-                                          the limitation. The downside is that the
-                                          Kube API can''t validate the data beyond
-                                          the fact that it is a valid JSON representation.
-                                          MuteTimeIntervals is a list of MuteTimeInterval
-                                          names that will mute this route when matched,'
+                                        description: |-
+                                          Note: this comment applies to the field definition above but appears
+                                          below otherwise it gets included in the generated manifest.
+                                          CRD schema doesn't support self-referential types for now (see
+                                          https://github.com/kubernetes/kubernetes/issues/62872). We have to use
+                                          an alternative type to circumvent the limitation. The downside is that
+                                          the Kube API can't validate the data beyond the fact that it is a valid
+                                          JSON representation.
+                                          MuteTimeIntervals is a list of MuteTimeInterval names that will mute this route when matched,
                                         items:
                                           type: string
                                         type: array
                                       receiver:
-                                        description: Name of the receiver for this
-                                          route. If not empty, it should be listed
-                                          in the `receivers` field.
+                                        description: |-
+                                          Name of the receiver for this route. If not empty, it should be listed in
+                                          the `receivers` field.
                                         type: string
                                       repeatInterval:
-                                        description: 'How long to wait before repeating
-                                          the last notification. Must match the regular
-                                          expression`^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$`
-                                          Example: "4h"'
+                                        description: |-
+                                          How long to wait before repeating the last notification.
+                                          Must match the regular expression`^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$`
+                                          Example: "4h"
                                         type: string
                                       routes:
                                         description: Child routes.
@@ -5719,60 +5373,52 @@ spec:
                               ipFilter:
                                 default:
                                 - 0.0.0.0/0
-                                description: IPFilter is a list of allowed IPv4 CIDR
-                                  ranges that can access the service. If no IP Filter
-                                  is set, you may not be able to reach the service.
-                                  A value of `0.0.0.0/0` will open the service to
-                                  all addresses on the public internet.
+                                description: |-
+                                  IPFilter is a list of allowed IPv4 CIDR ranges that can access the service.
+                                  If no IP Filter is set, you may not be able to reach the service.
+                                  A value of `0.0.0.0/0` will open the service to all addresses on the public internet.
                                 items:
                                   type: string
                                 type: array
                               serviceType:
                                 default: ClusterIP
-                                description: 'ServiceType defines the type of the
-                                  service. Possible enum values: - `"ClusterIP"` indicates
-                                  that the service is only reachable from within the
-                                  cluster. - `"LoadBalancer"` indicates that the service
-                                  is reachable from the public internet via dedicated
-                                  Ipv4 address.'
+                                description: |-
+                                  ServiceType defines the type of the service.
+                                  Possible enum values:
+                                    - `"ClusterIP"` indicates that the service is only reachable from within the cluster.
+                                    - `"LoadBalancer"` indicates that the service is reachable from the public internet via dedicated Ipv4 address.
                                 enum:
                                 - ClusterIP
                                 - LoadBalancer
                                 type: string
                             type: object
                           replication:
-                            description: "This section allows to configure Postgres
-                              replication mode and HA roles groups. \n The main replication
-                              group is implicit and contains the total number of instances
-                              less the sum of all instances in other replication groups."
+                            description: |-
+                              This section allows to configure Postgres replication mode and HA roles groups.
+
+
+                              The main replication group is implicit and contains the total number of instances less the sum of all instances in other replication groups.
                             properties:
                               mode:
-                                description: "Mode defines the replication mode applied
-                                  to the whole cluster. Possible values are: \"async\"(default),
-                                  \"sync\", and \"strict-sync\" \n \"async\": When
-                                  in asynchronous mode the cluster is allowed to lose
-                                  some committed transactions. When the primary server
-                                  fails or becomes unavailable for any other reason
-                                  a sufficiently healthy standby will automatically
-                                  be promoted to primary. Any transactions that have
-                                  not been replicated to that standby remain in a
-                                  “forked timeline” on the primary, and are effectively
-                                  unrecoverable \n \"sync\": When in synchronous mode
-                                  a standby will not be promoted unless it is certain
-                                  that the standby contains all transactions that
-                                  may have returned a successful commit status to
-                                  client. This means that the system may be unavailable
-                                  for writes even though some servers are available.
-                                  \n \"strict-sync\": When it is absolutely necessary
-                                  to guarantee that each write is stored durably on
-                                  at least two nodes, use the strict synchronous mode.
-                                  This mode prevents synchronous replication to be
-                                  switched off on the primary when no synchronous
-                                  standby candidates are available. As a downside,
-                                  the primary will not be available for writes, blocking
-                                  all client write requests until at least one synchronous
-                                  replica comes up. \n NOTE: We recommend to always
-                                  use three intances when setting the mode to \"strict-sync\"."
+                                description: |-
+                                  Mode defines the replication mode applied to the whole cluster. Possible values are: "async"(default), "sync", and "strict-sync"
+
+
+                                  "async": When in asynchronous mode the cluster is allowed to lose some committed transactions.
+                                  When the primary server fails or becomes unavailable for any other reason a sufficiently healthy standby will automatically be promoted to primary.
+                                  Any transactions that have not been replicated to that standby remain in a “forked timeline” on the primary, and are effectively unrecoverable
+
+
+                                  "sync": When in synchronous mode a standby will not be promoted unless it is certain that the standby contains all transactions that may have returned a successful commit status to client.
+                                   This means that the system may be unavailable for writes even though some servers are available.
+
+
+                                  "strict-sync": When it is absolutely necessary to guarantee that each write is stored durably on at least two nodes, use the strict synchronous mode.
+                                  This mode prevents synchronous replication to be switched off on the primary when no synchronous standby candidates are available.
+                                  As a downside, the primary will not be available for writes, blocking all client write requests until at least one synchronous replica comes up.
+
+
+                                  NOTE: We recommend to always use three intances when setting the mode to "strict-sync".
                                 enum:
                                 - async
                                 - sync
@@ -5788,16 +5434,14 @@ spec:
                                   backup you want to restore.
                                 type: string
                               claimName:
-                                description: ClaimName specifies the name of the instance
-                                  you want to restore from. The claim has to be in
-                                  the same namespace as this new instance.
+                                description: |-
+                                  ClaimName specifies the name of the instance you want to restore from.
+                                  The claim has to be in the same namespace as this new instance.
                                 type: string
                               recoveryTimeStamp:
-                                description: RecoveryTimeStamp an ISO 8601 date, that
-                                  holds UTC date indicating at which point-in-time
-                                  the database has to be restored. This is optional
-                                  and if no PIT recovery is required, it can be left
-                                  empty.
+                                description: |-
+                                  RecoveryTimeStamp an ISO 8601 date, that holds UTC date indicating at which point-in-time the database has to be restored.
+                                  This is optional and if no PIT recovery is required, it can be left empty.
                                 pattern: ^(?:[1-9]\d{3}-(?:(?:0[1-9]|1[0-2])-(?:0[1-9]|1\d|2[0-8])|(?:0[13-9]|1[0-2])-(?:29|30)|(?:0[13578]|1[02])-31)|(?:[1-9]\d(?:0[48]|[2468][048]|[13579][26])|(?:[2468][048]|[13579][26])00)-02-29)T(?:[01]\d|2[0-3]):[0-5]\d:[0-5]\d(?:Z|[+-][01]\d:[0-5]\d)$
                                 type: string
                             type: object
@@ -5825,17 +5469,17 @@ spec:
                                     the name of a single extension.
                                   properties:
                                     name:
-                                      description: Name is the name of the extension
-                                        to enable. For an extensive list, please consult
-                                        https://stackgres.io/doc/latest/intro/extensions/
+                                      description: |-
+                                        Name is the name of the extension to enable.
+                                        For an extensive list, please consult https://stackgres.io/doc/latest/intro/extensions/
                                       type: string
                                   type: object
                                 type: array
                               majorVersion:
                                 default: "15"
-                                description: MajorVersion contains supported version
-                                  of PostgreSQL. Multiple versions are supported.
-                                  The latest version "15" is the default version.
+                                description: |-
+                                  MajorVersion contains supported version of PostgreSQL.
+                                  Multiple versions are supported. The latest version "15" is the default version.
                                 enum:
                                 - "12"
                                 - "13"
@@ -5847,30 +5491,27 @@ spec:
                                   to the pgBouncer instance.
                                 properties:
                                   databases:
-                                    description: "The `pgbouncer.ini` (Section [databases])
-                                      parameters the configuration contains, represented
-                                      as an object where the keys are valid names
-                                      for the `pgbouncer.ini` configuration file parameters.
-                                      \n Check [pgbouncer configuration](https://www.pgbouncer.org/config.html#section-databases)
-                                      for more information about supported parameters."
+                                    description: |-
+                                      The `pgbouncer.ini` (Section [databases]) parameters the configuration contains, represented as an object where the keys are valid names for the `pgbouncer.ini` configuration file parameters.
+
+
+                                      Check [pgbouncer configuration](https://www.pgbouncer.org/config.html#section-databases) for more information about supported parameters.
                                     type: object
                                     x-kubernetes-preserve-unknown-fields: true
                                   pgbouncer:
-                                    description: "The `pgbouncer.ini` (Section [pgbouncer])
-                                      parameters the configuration contains, represented
-                                      as an object where the keys are valid names
-                                      for the `pgbouncer.ini` configuration file parameters.
-                                      \n Check [pgbouncer configuration](https://www.pgbouncer.org/config.html#generic-settings)
-                                      for more information about supported parameters"
+                                    description: |-
+                                      The `pgbouncer.ini` (Section [pgbouncer]) parameters the configuration contains, represented as an object where the keys are valid names for the `pgbouncer.ini` configuration file parameters.
+
+
+                                      Check [pgbouncer configuration](https://www.pgbouncer.org/config.html#generic-settings) for more information about supported parameters
                                     type: object
                                     x-kubernetes-preserve-unknown-fields: true
                                   users:
-                                    description: "The `pgbouncer.ini` (Section [users])
-                                      parameters the configuration contains, represented
-                                      as an object where the keys are valid names
-                                      for the `pgbouncer.ini` configuration file parameters.
-                                      \n Check [pgbouncer configuration](https://www.pgbouncer.org/config.html#section-users)
-                                      for more information about supported parameters."
+                                    description: |-
+                                      The `pgbouncer.ini` (Section [users]) parameters the configuration contains, represented as an object where the keys are valid names for the `pgbouncer.ini` configuration file parameters.
+
+
+                                      Check [pgbouncer configuration](https://www.pgbouncer.org/config.html#section-users) for more information about supported parameters.
                                     type: object
                                     x-kubernetes-preserve-unknown-fields: true
                                 type: object
@@ -5929,14 +5570,11 @@ spec:
                             properties:
                               type:
                                 default: Immediate
-                                description: 'Type indicates the type of the UpdateStrategy.
-                                  Default is OnRestart. Possible enum values: - `"OnRestart"`
-                                  indicates that the changes to the spec will only
-                                  be applied once the instance is restarted by other
-                                  means, most likely during maintenance. - `"Immediate"`
-                                  indicates that update will be applied to the instance
-                                  as soon as the spec changes. Please be aware that
-                                  this might lead to short downtime.'
+                                description: |-
+                                  Type indicates the type of the UpdateStrategy. Default is OnRestart.
+                                  Possible enum values:
+                                    - `"OnRestart"` indicates that the changes to the spec will only be applied once the instance is restarted by other means, most likely during maintenance.
+                                    - `"Immediate"` indicates that update will be applied to the instance as soon as the spec changes. Please be aware that this might lead to short downtime.
                                 enum:
                                 - Immediate
                                 - OnRestart
@@ -5958,9 +5596,9 @@ spec:
                         type: string
                       version:
                         default: "23"
-                        description: Version contains supported version of keycloak.
-                          Multiple versions are supported. The latest version 23 is
-                          the default version.
+                        description: |-
+                          Version contains supported version of keycloak.
+                          Multiple versions are supported. The latest version 23 is the default version.
                         enum:
                         - "23"
                         type: string
@@ -6017,9 +5655,10 @@ spec:
               providerConfigRef:
                 default:
                   name: default
-                description: ProviderConfigReference specifies how the provider that
-                  will be used to create, observe, update, and delete this managed
-                  resource should be configured.
+                description: |-
+                  ProviderConfigReference specifies how the provider that will be used to
+                  create, observe, update, and delete this managed resource should be
+                  configured.
                 properties:
                   name:
                     description: Name of the referenced object.
@@ -6029,21 +5668,21 @@ spec:
                     properties:
                       resolution:
                         default: Required
-                        description: Resolution specifies whether resolution of this
-                          reference is required. The default is 'Required', which
-                          means the reconcile will fail if the reference cannot be
-                          resolved. 'Optional' means this reference will be a no-op
-                          if it cannot be resolved.
+                        description: |-
+                          Resolution specifies whether resolution of this reference is required.
+                          The default is 'Required', which means the reconcile will fail if the
+                          reference cannot be resolved. 'Optional' means this reference will be
+                          a no-op if it cannot be resolved.
                         enum:
                         - Required
                         - Optional
                         type: string
                       resolve:
-                        description: Resolve specifies when this reference should
-                          be resolved. The default is 'IfNotPresent', which will attempt
-                          to resolve the reference only when the corresponding field
-                          is not present. Use 'Always' to resolve the reference on
-                          every reconcile.
+                        description: |-
+                          Resolve specifies when this reference should be resolved. The default
+                          is 'IfNotPresent', which will attempt to resolve the reference only when
+                          the corresponding field is not present. Use 'Always' to resolve the
+                          reference on every reconcile.
                         enum:
                         - Always
                         - IfNotPresent
@@ -6053,17 +5692,19 @@ spec:
                 - name
                 type: object
               publishConnectionDetailsTo:
-                description: PublishConnectionDetailsTo specifies the connection secret
-                  config which contains a name, metadata and a reference to secret
-                  store config to which any connection details for this managed resource
-                  should be written. Connection details frequently include the endpoint,
-                  username, and password required to connect to the managed resource.
+                description: |-
+                  PublishConnectionDetailsTo specifies the connection secret config which
+                  contains a name, metadata and a reference to secret store config to
+                  which any connection details for this managed resource should be written.
+                  Connection details frequently include the endpoint, username,
+                  and password required to connect to the managed resource.
                 properties:
                   configRef:
                     default:
                       name: default
-                    description: SecretStoreConfigRef specifies which secret store
-                      config should be used for this ConnectionSecret.
+                    description: |-
+                      SecretStoreConfigRef specifies which secret store config should be used
+                      for this ConnectionSecret.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -6073,21 +5714,21 @@ spec:
                         properties:
                           resolution:
                             default: Required
-                            description: Resolution specifies whether resolution of
-                              this reference is required. The default is 'Required',
-                              which means the reconcile will fail if the reference
-                              cannot be resolved. 'Optional' means this reference
-                              will be a no-op if it cannot be resolved.
+                            description: |-
+                              Resolution specifies whether resolution of this reference is required.
+                              The default is 'Required', which means the reconcile will fail if the
+                              reference cannot be resolved. 'Optional' means this reference will be
+                              a no-op if it cannot be resolved.
                             enum:
                             - Required
                             - Optional
                             type: string
                           resolve:
-                            description: Resolve specifies when this reference should
-                              be resolved. The default is 'IfNotPresent', which will
-                              attempt to resolve the reference only when the corresponding
-                              field is not present. Use 'Always' to resolve the reference
-                              on every reconcile.
+                            description: |-
+                              Resolve specifies when this reference should be resolved. The default
+                              is 'IfNotPresent', which will attempt to resolve the reference only when
+                              the corresponding field is not present. Use 'Always' to resolve the
+                              reference on every reconcile.
                             enum:
                             - Always
                             - IfNotPresent
@@ -6102,21 +5743,22 @@ spec:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Annotations are the annotations to be added to
-                          connection secret. - For Kubernetes secrets, this will be
-                          used as "metadata.annotations". - It is up to Secret Store
-                          implementation for others store types.
+                        description: |-
+                          Annotations are the annotations to be added to connection secret.
+                          - For Kubernetes secrets, this will be used as "metadata.annotations".
+                          - It is up to Secret Store implementation for others store types.
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Labels are the labels/tags to be added to connection
-                          secret. - For Kubernetes secrets, this will be used as "metadata.labels".
-                          - It is up to Secret Store implementation for others store
-                          types.
+                        description: |-
+                          Labels are the labels/tags to be added to connection secret.
+                          - For Kubernetes secrets, this will be used as "metadata.labels".
+                          - It is up to Secret Store implementation for others store types.
                         type: object
                       type:
-                        description: Type is the SecretType for the connection secret.
+                        description: |-
+                          Type is the SecretType for the connection secret.
                           - Only valid for Kubernetes Secret Stores.
                         type: string
                     type: object
@@ -6127,14 +5769,15 @@ spec:
                 - name
                 type: object
               writeConnectionSecretToRef:
-                description: WriteConnectionSecretToReference specifies the namespace
-                  and name of a Secret to which any connection details for this managed
-                  resource should be written. Connection details frequently include
-                  the endpoint, username, and password required to connect to the
-                  managed resource. This field is planned to be replaced in a future
-                  release in favor of PublishConnectionDetailsTo. Currently, both
-                  could be set independently and connection details would be published
-                  to both without affecting each other.
+                description: |-
+                  WriteConnectionSecretToReference specifies the namespace and name of a
+                  Secret to which any connection details for this managed resource should
+                  be written. Connection details frequently include the endpoint, username,
+                  and password required to connect to the managed resource.
+                  This field is planned to be replaced in a future release in favor of
+                  PublishConnectionDetailsTo. Currently, both could be set independently
+                  and connection details would be published to both without affecting
+                  each other.
                 properties:
                   name:
                     description: Name of the secret.
@@ -6163,11 +5806,9 @@ spec:
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: ObservedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
+                      description: |-
+                        ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
@@ -6205,11 +5846,9 @@ spec:
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: ObservedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
+                      description: |-
+                        ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
@@ -6239,13 +5878,15 @@ spec:
                   description: A Condition that may apply to a resource.
                   properties:
                     lastTransitionTime:
-                      description: LastTransitionTime is the last time this condition
-                        transitioned from one status to another.
+                      description: |-
+                        LastTransitionTime is the last time this condition transitioned from one
+                        status to another.
                       format: date-time
                       type: string
                     message:
-                      description: A Message containing details about this condition's
-                        last transition from one status to another, if any.
+                      description: |-
+                        A Message containing details about this condition's last transition from
+                        one status to another, if any.
                       type: string
                     reason:
                       description: A Reason for this condition's last transition from
@@ -6256,8 +5897,9 @@ spec:
                         False, or Unknown?
                       type: string
                     type:
-                      description: Type of this condition. At most one of each condition
-                        type may apply to a resource at any point in time.
+                      description: |-
+                        Type of this condition. At most one of each condition type may apply to
+                        a resource at any point in time.
                       type: string
                   required:
                   - lastTransitionTime
@@ -6287,11 +5929,9 @@ spec:
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: ObservedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
+                      description: |-
+                        ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
@@ -6329,11 +5969,9 @@ spec:
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: ObservedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
+                      description: |-
+                        ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
@@ -6358,8 +5996,9 @@ spec:
                   type: object
                 type: array
               schedules:
-                description: Schedules keeps track of random generated schedules,
-                  is overwriten by schedules set in the service's spec.
+                description: |-
+                  Schedules keeps track of random generated schedules, is overwriten by
+                  schedules set in the service's spec.
                 properties:
                   backup:
                     description: Backup keeps track of the backup schedule.
@@ -6368,9 +6007,9 @@ spec:
                     description: Maintenance keeps track of the maintenance schedule.
                     properties:
                       dayOfWeek:
-                        description: DayOfWeek specifies at which weekday the maintenance
-                          is held place. Allowed values are [monday, tuesday, wednesday,
-                          thursday, friday, saturday, sunday]
+                        description: |-
+                          DayOfWeek specifies at which weekday the maintenance is held place.
+                          Allowed values are [monday, tuesday, wednesday, thursday, friday, saturday, sunday]
                         enum:
                         - monday
                         - tuesday
@@ -6381,8 +6020,9 @@ spec:
                         - sunday
                         type: string
                       timeOfDay:
-                        description: 'TimeOfDay for installing updates in UTC. Format:
-                          "hh:mm:ss".'
+                        description: |-
+                          TimeOfDay for installing updates in UTC.
+                          Format: "hh:mm:ss".
                         pattern: ^([0-1]?[0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9])$
                         type: string
                     type: object
@@ -6401,11 +6041,9 @@ spec:
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: ObservedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
+                      description: |-
+                        ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
@@ -6443,11 +6081,9 @@ spec:
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: ObservedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
+                      description: |-
+                        ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer

--- a/crds/vshn.appcat.vshn.io_xvshnmariadbs.yaml
+++ b/crds/vshn.appcat.vshn.io_xvshnmariadbs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: xvshnmariadbs.vshn.appcat.vshn.io
 spec:
   group: vshn.appcat.vshn.io
@@ -20,14 +20,19 @@ spec:
         description: XVSHNMariaDB represents the internal composite of this claim
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -36,13 +41,14 @@ spec:
             properties:
               deletionPolicy:
                 default: Delete
-                description: 'DeletionPolicy specifies what will happen to the underlying
-                  external when this managed resource is deleted - either "Delete"
-                  or "Orphan" the external resource. This field is planned to be deprecated
-                  in favor of the ManagementPolicies field in a future release. Currently,
-                  both could be set independently and non-default values would be
-                  honored if the feature flag is enabled. See the design doc for more
-                  information: https://github.com/crossplane/crossplane/blob/499895a25d1a1a0ba1604944ef98ac7a1a71f197/design/design-doc-observe-only-resources.md?plain=1#L223'
+                description: |-
+                  DeletionPolicy specifies what will happen to the underlying external
+                  when this managed resource is deleted - either "Delete" or "Orphan" the
+                  external resource.
+                  This field is planned to be deprecated in favor of the ManagementPolicies
+                  field in a future release. Currently, both could be set independently and
+                  non-default values would be honored if the feature flag is enabled.
+                  See the design doc for more information: https://github.com/crossplane/crossplane/blob/499895a25d1a1a0ba1604944ef98ac7a1a71f197/design/design-doc-observe-only-resources.md?plain=1#L223
                 enum:
                 - Orphan
                 - Delete
@@ -50,19 +56,21 @@ spec:
               managementPolicies:
                 default:
                 - '*'
-                description: 'THIS IS A BETA FIELD. It is on by default but can be
-                  opted out through a Crossplane feature flag. ManagementPolicies
-                  specify the array of actions Crossplane is allowed to take on the
-                  managed and external resources. This field is planned to replace
-                  the DeletionPolicy field in a future release. Currently, both could
-                  be set independently and non-default values would be honored if
-                  the feature flag is enabled. If both are custom, the DeletionPolicy
-                  field will be ignored. See the design doc for more information:
-                  https://github.com/crossplane/crossplane/blob/499895a25d1a1a0ba1604944ef98ac7a1a71f197/design/design-doc-observe-only-resources.md?plain=1#L223
-                  and this one: https://github.com/crossplane/crossplane/blob/444267e84783136daa93568b364a5f01228cacbe/design/one-pager-ignore-changes.md'
+                description: |-
+                  THIS IS A BETA FIELD. It is on by default but can be opted out
+                  through a Crossplane feature flag.
+                  ManagementPolicies specify the array of actions Crossplane is allowed to
+                  take on the managed and external resources.
+                  This field is planned to replace the DeletionPolicy field in a future
+                  release. Currently, both could be set independently and non-default
+                  values would be honored if the feature flag is enabled. If both are
+                  custom, the DeletionPolicy field will be ignored.
+                  See the design doc for more information: https://github.com/crossplane/crossplane/blob/499895a25d1a1a0ba1604944ef98ac7a1a71f197/design/design-doc-observe-only-resources.md?plain=1#L223
+                  and this one: https://github.com/crossplane/crossplane/blob/444267e84783136daa93568b364a5f01228cacbe/design/one-pager-ignore-changes.md
                 items:
-                  description: A ManagementAction represents an action that the Crossplane
-                    controllers can take on an external resource.
+                  description: |-
+                    A ManagementAction represents an action that the Crossplane controllers
+                    can take on an external resource.
                   enum:
                   - Observe
                   - Create
@@ -108,9 +116,9 @@ spec:
                       of an instance.
                     properties:
                       dayOfWeek:
-                        description: DayOfWeek specifies at which weekday the maintenance
-                          is held place. Allowed values are [monday, tuesday, wednesday,
-                          thursday, friday, saturday, sunday]
+                        description: |-
+                          DayOfWeek specifies at which weekday the maintenance is held place.
+                          Allowed values are [monday, tuesday, wednesday, thursday, friday, saturday, sunday]
                         enum:
                         - monday
                         - tuesday
@@ -121,8 +129,9 @@ spec:
                         - sunday
                         type: string
                       timeOfDay:
-                        description: 'TimeOfDay for installing updates in UTC. Format:
-                          "hh:mm:ss".'
+                        description: |-
+                          TimeOfDay for installing updates in UTC.
+                          Format: "hh:mm:ss".
                         pattern: ^([0-1]?[0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9])$
                         type: string
                     type: object
@@ -135,9 +144,9 @@ spec:
                           you want to restore.
                         type: string
                       claimName:
-                        description: ClaimName specifies the name of the instance
-                          you want to restore from. The claim has to be in the same
-                          namespace as this new instance.
+                        description: |-
+                          ClaimName specifies the name of the instance you want to restore from.
+                          The claim has to be in the same namespace as this new instance.
                         type: string
                     type: object
                   scheduling:
@@ -168,9 +177,9 @@ spec:
                         type: string
                       version:
                         default: "11.2"
-                        description: Version contains supported version of MariaDB.
-                          Multiple versions are supported. The latest version "11.2"
-                          is the default version.
+                        description: |-
+                          Version contains supported version of MariaDB.
+                          Multiple versions are supported. The latest version "11.2" is the default version.
                         enum:
                         - "10.4"
                         - "10.5"
@@ -239,9 +248,10 @@ spec:
               providerConfigRef:
                 default:
                   name: default
-                description: ProviderConfigReference specifies how the provider that
-                  will be used to create, observe, update, and delete this managed
-                  resource should be configured.
+                description: |-
+                  ProviderConfigReference specifies how the provider that will be used to
+                  create, observe, update, and delete this managed resource should be
+                  configured.
                 properties:
                   name:
                     description: Name of the referenced object.
@@ -251,21 +261,21 @@ spec:
                     properties:
                       resolution:
                         default: Required
-                        description: Resolution specifies whether resolution of this
-                          reference is required. The default is 'Required', which
-                          means the reconcile will fail if the reference cannot be
-                          resolved. 'Optional' means this reference will be a no-op
-                          if it cannot be resolved.
+                        description: |-
+                          Resolution specifies whether resolution of this reference is required.
+                          The default is 'Required', which means the reconcile will fail if the
+                          reference cannot be resolved. 'Optional' means this reference will be
+                          a no-op if it cannot be resolved.
                         enum:
                         - Required
                         - Optional
                         type: string
                       resolve:
-                        description: Resolve specifies when this reference should
-                          be resolved. The default is 'IfNotPresent', which will attempt
-                          to resolve the reference only when the corresponding field
-                          is not present. Use 'Always' to resolve the reference on
-                          every reconcile.
+                        description: |-
+                          Resolve specifies when this reference should be resolved. The default
+                          is 'IfNotPresent', which will attempt to resolve the reference only when
+                          the corresponding field is not present. Use 'Always' to resolve the
+                          reference on every reconcile.
                         enum:
                         - Always
                         - IfNotPresent
@@ -275,17 +285,19 @@ spec:
                 - name
                 type: object
               publishConnectionDetailsTo:
-                description: PublishConnectionDetailsTo specifies the connection secret
-                  config which contains a name, metadata and a reference to secret
-                  store config to which any connection details for this managed resource
-                  should be written. Connection details frequently include the endpoint,
-                  username, and password required to connect to the managed resource.
+                description: |-
+                  PublishConnectionDetailsTo specifies the connection secret config which
+                  contains a name, metadata and a reference to secret store config to
+                  which any connection details for this managed resource should be written.
+                  Connection details frequently include the endpoint, username,
+                  and password required to connect to the managed resource.
                 properties:
                   configRef:
                     default:
                       name: default
-                    description: SecretStoreConfigRef specifies which secret store
-                      config should be used for this ConnectionSecret.
+                    description: |-
+                      SecretStoreConfigRef specifies which secret store config should be used
+                      for this ConnectionSecret.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -295,21 +307,21 @@ spec:
                         properties:
                           resolution:
                             default: Required
-                            description: Resolution specifies whether resolution of
-                              this reference is required. The default is 'Required',
-                              which means the reconcile will fail if the reference
-                              cannot be resolved. 'Optional' means this reference
-                              will be a no-op if it cannot be resolved.
+                            description: |-
+                              Resolution specifies whether resolution of this reference is required.
+                              The default is 'Required', which means the reconcile will fail if the
+                              reference cannot be resolved. 'Optional' means this reference will be
+                              a no-op if it cannot be resolved.
                             enum:
                             - Required
                             - Optional
                             type: string
                           resolve:
-                            description: Resolve specifies when this reference should
-                              be resolved. The default is 'IfNotPresent', which will
-                              attempt to resolve the reference only when the corresponding
-                              field is not present. Use 'Always' to resolve the reference
-                              on every reconcile.
+                            description: |-
+                              Resolve specifies when this reference should be resolved. The default
+                              is 'IfNotPresent', which will attempt to resolve the reference only when
+                              the corresponding field is not present. Use 'Always' to resolve the
+                              reference on every reconcile.
                             enum:
                             - Always
                             - IfNotPresent
@@ -324,21 +336,22 @@ spec:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Annotations are the annotations to be added to
-                          connection secret. - For Kubernetes secrets, this will be
-                          used as "metadata.annotations". - It is up to Secret Store
-                          implementation for others store types.
+                        description: |-
+                          Annotations are the annotations to be added to connection secret.
+                          - For Kubernetes secrets, this will be used as "metadata.annotations".
+                          - It is up to Secret Store implementation for others store types.
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Labels are the labels/tags to be added to connection
-                          secret. - For Kubernetes secrets, this will be used as "metadata.labels".
-                          - It is up to Secret Store implementation for others store
-                          types.
+                        description: |-
+                          Labels are the labels/tags to be added to connection secret.
+                          - For Kubernetes secrets, this will be used as "metadata.labels".
+                          - It is up to Secret Store implementation for others store types.
                         type: object
                       type:
-                        description: Type is the SecretType for the connection secret.
+                        description: |-
+                          Type is the SecretType for the connection secret.
                           - Only valid for Kubernetes Secret Stores.
                         type: string
                     type: object
@@ -349,14 +362,15 @@ spec:
                 - name
                 type: object
               writeConnectionSecretToRef:
-                description: WriteConnectionSecretToReference specifies the namespace
-                  and name of a Secret to which any connection details for this managed
-                  resource should be written. Connection details frequently include
-                  the endpoint, username, and password required to connect to the
-                  managed resource. This field is planned to be replaced in a future
-                  release in favor of PublishConnectionDetailsTo. Currently, both
-                  could be set independently and connection details would be published
-                  to both without affecting each other.
+                description: |-
+                  WriteConnectionSecretToReference specifies the namespace and name of a
+                  Secret to which any connection details for this managed resource should
+                  be written. Connection details frequently include the endpoint, username,
+                  and password required to connect to the managed resource.
+                  This field is planned to be replaced in a future release in favor of
+                  PublishConnectionDetailsTo. Currently, both could be set independently
+                  and connection details would be published to both without affecting
+                  each other.
                 properties:
                   name:
                     description: Name of the secret.
@@ -385,11 +399,9 @@ spec:
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: ObservedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
+                      description: |-
+                        ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
@@ -427,11 +439,9 @@ spec:
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: ObservedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
+                      description: |-
+                        ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
@@ -461,13 +471,15 @@ spec:
                   description: A Condition that may apply to a resource.
                   properties:
                     lastTransitionTime:
-                      description: LastTransitionTime is the last time this condition
-                        transitioned from one status to another.
+                      description: |-
+                        LastTransitionTime is the last time this condition transitioned from one
+                        status to another.
                       format: date-time
                       type: string
                     message:
-                      description: A Message containing details about this condition's
-                        last transition from one status to another, if any.
+                      description: |-
+                        A Message containing details about this condition's last transition from
+                        one status to another, if any.
                       type: string
                     reason:
                       description: A Reason for this condition's last transition from
@@ -478,8 +490,9 @@ spec:
                         False, or Unknown?
                       type: string
                     type:
-                      description: Type of this condition. At most one of each condition
-                        type may apply to a resource at any point in time.
+                      description: |-
+                        Type of this condition. At most one of each condition type may apply to
+                        a resource at any point in time.
                       type: string
                   required:
                   - lastTransitionTime
@@ -509,11 +522,9 @@ spec:
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: ObservedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
+                      description: |-
+                        ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
@@ -551,11 +562,9 @@ spec:
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: ObservedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
+                      description: |-
+                        ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
@@ -580,8 +589,9 @@ spec:
                   type: object
                 type: array
               schedules:
-                description: Schedules keeps track of random generated schedules,
-                  is overwriten by schedules set in the service's spec.
+                description: |-
+                  Schedules keeps track of random generated schedules, is overwriten by
+                  schedules set in the service's spec.
                 properties:
                   backup:
                     description: Backup keeps track of the backup schedule.
@@ -590,9 +600,9 @@ spec:
                     description: Maintenance keeps track of the maintenance schedule.
                     properties:
                       dayOfWeek:
-                        description: DayOfWeek specifies at which weekday the maintenance
-                          is held place. Allowed values are [monday, tuesday, wednesday,
-                          thursday, friday, saturday, sunday]
+                        description: |-
+                          DayOfWeek specifies at which weekday the maintenance is held place.
+                          Allowed values are [monday, tuesday, wednesday, thursday, friday, saturday, sunday]
                         enum:
                         - monday
                         - tuesday
@@ -603,8 +613,9 @@ spec:
                         - sunday
                         type: string
                       timeOfDay:
-                        description: 'TimeOfDay for installing updates in UTC. Format:
-                          "hh:mm:ss".'
+                        description: |-
+                          TimeOfDay for installing updates in UTC.
+                          Format: "hh:mm:ss".
                         pattern: ^([0-1]?[0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9])$
                         type: string
                     type: object
@@ -623,11 +634,9 @@ spec:
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: ObservedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
+                      description: |-
+                        ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
@@ -665,11 +674,9 @@ spec:
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: ObservedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
+                      description: |-
+                        ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer

--- a/crds/vshn.appcat.vshn.io_xvshnminios.yaml
+++ b/crds/vshn.appcat.vshn.io_xvshnminios.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: xvshnminios.vshn.appcat.vshn.io
 spec:
   group: vshn.appcat.vshn.io
@@ -20,20 +20,66 @@ spec:
         description: XVSHNMinios represents the internal composite of this claim
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
             description: XVSHNMinioSpec defines the desired state of a VSHNMinio.
             properties:
+              deletionPolicy:
+                default: Delete
+                description: |-
+                  DeletionPolicy specifies what will happen to the underlying external
+                  when this managed resource is deleted - either "Delete" or "Orphan" the
+                  external resource.
+                  This field is planned to be deprecated in favor of the ManagementPolicies
+                  field in a future release. Currently, both could be set independently and
+                  non-default values would be honored if the feature flag is enabled.
+                  See the design doc for more information: https://github.com/crossplane/crossplane/blob/499895a25d1a1a0ba1604944ef98ac7a1a71f197/design/design-doc-observe-only-resources.md?plain=1#L223
+                enum:
+                - Orphan
+                - Delete
+                type: string
+              managementPolicies:
+                default:
+                - '*'
+                description: |-
+                  THIS IS A BETA FIELD. It is on by default but can be opted out
+                  through a Crossplane feature flag.
+                  ManagementPolicies specify the array of actions Crossplane is allowed to
+                  take on the managed and external resources.
+                  This field is planned to replace the DeletionPolicy field in a future
+                  release. Currently, both could be set independently and non-default
+                  values would be honored if the feature flag is enabled. If both are
+                  custom, the DeletionPolicy field will be ignored.
+                  See the design doc for more information: https://github.com/crossplane/crossplane/blob/499895a25d1a1a0ba1604944ef98ac7a1a71f197/design/design-doc-observe-only-resources.md?plain=1#L223
+                  and this one: https://github.com/crossplane/crossplane/blob/444267e84783136daa93568b364a5f01228cacbe/design/one-pager-ignore-changes.md
+                items:
+                  description: |-
+                    A ManagementAction represents an action that the Crossplane controllers
+                    can take on an external resource.
+                  enum:
+                  - Observe
+                  - Create
+                  - Update
+                  - Delete
+                  - LateInitialize
+                  - '*'
+                  type: string
+                type: array
               parameters:
                 description: Parameters are the configurable fields of a VSHNMinio.
                 properties:
@@ -67,8 +113,9 @@ spec:
                     type: object
                   instances:
                     default: 4
-                    description: Instances configures the number of Minio instances
-                      for the cluster. Each instance contains one Minio server.
+                    description: |-
+                      Instances configures the number of Minio instances for the cluster.
+                      Each instance contains one Minio server.
                     minimum: 4
                     type: integer
                   maintenance:
@@ -76,9 +123,9 @@ spec:
                       of an instance.
                     properties:
                       dayOfWeek:
-                        description: DayOfWeek specifies at which weekday the maintenance
-                          is held place. Allowed values are [monday, tuesday, wednesday,
-                          thursday, friday, saturday, sunday]
+                        description: |-
+                          DayOfWeek specifies at which weekday the maintenance is held place.
+                          Allowed values are [monday, tuesday, wednesday, thursday, friday, saturday, sunday]
                         enum:
                         - monday
                         - tuesday
@@ -89,8 +136,9 @@ spec:
                         - sunday
                         type: string
                       timeOfDay:
-                        description: 'TimeOfDay for installing updates in UTC. Format:
-                          "hh:mm:ss".'
+                        description: |-
+                          TimeOfDay for installing updates in UTC.
+                          Format: "hh:mm:ss".
                         pattern: ^([0-1]?[0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9])$
                         type: string
                     type: object
@@ -103,9 +151,9 @@ spec:
                           you want to restore.
                         type: string
                       claimName:
-                        description: ClaimName specifies the name of the instance
-                          you want to restore from. The claim has to be in the same
-                          namespace as this new instance.
+                        description: |-
+                          ClaimName specifies the name of the instance you want to restore from.
+                          The claim has to be in the same namespace as this new instance.
                         type: string
                     type: object
                   service:
@@ -113,8 +161,9 @@ spec:
                     properties:
                       mode:
                         default: distributed
-                        description: Mode configures the mode of MinIO. Valid values
-                          are "distributed" and "standalone".
+                        description: |-
+                          Mode configures the mode of MinIO.
+                          Valid values are "distributed" and "standalone".
                         enum:
                         - distributed
                         - standalone
@@ -159,54 +208,59 @@ spec:
                       the PVC used by MinIO.
                     type: string
                 type: object
-              spec:
-                description: A ResourceSpec defines the desired state of a managed
-                  resource.
+              providerConfigRef:
+                default:
+                  name: default
+                description: |-
+                  ProviderConfigReference specifies how the provider that will be used to
+                  create, observe, update, and delete this managed resource should be
+                  configured.
                 properties:
-                  deletionPolicy:
-                    default: Delete
-                    description: 'DeletionPolicy specifies what will happen to the
-                      underlying external when this managed resource is deleted -
-                      either "Delete" or "Orphan" the external resource. This field
-                      is planned to be deprecated in favor of the ManagementPolicies
-                      field in a future release. Currently, both could be set independently
-                      and non-default values would be honored if the feature flag
-                      is enabled. See the design doc for more information: https://github.com/crossplane/crossplane/blob/499895a25d1a1a0ba1604944ef98ac7a1a71f197/design/design-doc-observe-only-resources.md?plain=1#L223'
-                    enum:
-                    - Orphan
-                    - Delete
+                  name:
+                    description: Name of the referenced object.
                     type: string
-                  managementPolicies:
-                    default:
-                    - '*'
-                    description: 'THIS IS A BETA FIELD. It is on by default but can
-                      be opted out through a Crossplane feature flag. ManagementPolicies
-                      specify the array of actions Crossplane is allowed to take on
-                      the managed and external resources. This field is planned to
-                      replace the DeletionPolicy field in a future release. Currently,
-                      both could be set independently and non-default values would
-                      be honored if the feature flag is enabled. If both are custom,
-                      the DeletionPolicy field will be ignored. See the design doc
-                      for more information: https://github.com/crossplane/crossplane/blob/499895a25d1a1a0ba1604944ef98ac7a1a71f197/design/design-doc-observe-only-resources.md?plain=1#L223
-                      and this one: https://github.com/crossplane/crossplane/blob/444267e84783136daa93568b364a5f01228cacbe/design/one-pager-ignore-changes.md'
-                    items:
-                      description: A ManagementAction represents an action that the
-                        Crossplane controllers can take on an external resource.
-                      enum:
-                      - Observe
-                      - Create
-                      - Update
-                      - Delete
-                      - LateInitialize
-                      - '*'
-                      type: string
-                    type: array
-                  providerConfigRef:
+                  policy:
+                    description: Policies for referencing.
+                    properties:
+                      resolution:
+                        default: Required
+                        description: |-
+                          Resolution specifies whether resolution of this reference is required.
+                          The default is 'Required', which means the reconcile will fail if the
+                          reference cannot be resolved. 'Optional' means this reference will be
+                          a no-op if it cannot be resolved.
+                        enum:
+                        - Required
+                        - Optional
+                        type: string
+                      resolve:
+                        description: |-
+                          Resolve specifies when this reference should be resolved. The default
+                          is 'IfNotPresent', which will attempt to resolve the reference only when
+                          the corresponding field is not present. Use 'Always' to resolve the
+                          reference on every reconcile.
+                        enum:
+                        - Always
+                        - IfNotPresent
+                        type: string
+                    type: object
+                required:
+                - name
+                type: object
+              publishConnectionDetailsTo:
+                description: |-
+                  PublishConnectionDetailsTo specifies the connection secret config which
+                  contains a name, metadata and a reference to secret store config to
+                  which any connection details for this managed resource should be written.
+                  Connection details frequently include the endpoint, username,
+                  and password required to connect to the managed resource.
+                properties:
+                  configRef:
                     default:
                       name: default
-                    description: ProviderConfigReference specifies how the provider
-                      that will be used to create, observe, update, and delete this
-                      managed resource should be configured.
+                    description: |-
+                      SecretStoreConfigRef specifies which secret store config should be used
+                      for this ConnectionSecret.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -216,21 +270,21 @@ spec:
                         properties:
                           resolution:
                             default: Required
-                            description: Resolution specifies whether resolution of
-                              this reference is required. The default is 'Required',
-                              which means the reconcile will fail if the reference
-                              cannot be resolved. 'Optional' means this reference
-                              will be a no-op if it cannot be resolved.
+                            description: |-
+                              Resolution specifies whether resolution of this reference is required.
+                              The default is 'Required', which means the reconcile will fail if the
+                              reference cannot be resolved. 'Optional' means this reference will be
+                              a no-op if it cannot be resolved.
                             enum:
                             - Required
                             - Optional
                             type: string
                           resolve:
-                            description: Resolve specifies when this reference should
-                              be resolved. The default is 'IfNotPresent', which will
-                              attempt to resolve the reference only when the corresponding
-                              field is not present. Use 'Always' to resolve the reference
-                              on every reconcile.
+                            description: |-
+                              Resolve specifies when this reference should be resolved. The default
+                              is 'IfNotPresent', which will attempt to resolve the reference only when
+                              the corresponding field is not present. Use 'Always' to resolve the
+                              reference on every reconcile.
                             enum:
                             - Always
                             - IfNotPresent
@@ -239,104 +293,58 @@ spec:
                     required:
                     - name
                     type: object
-                  publishConnectionDetailsTo:
-                    description: PublishConnectionDetailsTo specifies the connection
-                      secret config which contains a name, metadata and a reference
-                      to secret store config to which any connection details for this
-                      managed resource should be written. Connection details frequently
-                      include the endpoint, username, and password required to connect
-                      to the managed resource.
+                  metadata:
+                    description: Metadata is the metadata for connection secret.
                     properties:
-                      configRef:
-                        default:
-                          name: default
-                        description: SecretStoreConfigRef specifies which secret store
-                          config should be used for this ConnectionSecret.
-                        properties:
-                          name:
-                            description: Name of the referenced object.
-                            type: string
-                          policy:
-                            description: Policies for referencing.
-                            properties:
-                              resolution:
-                                default: Required
-                                description: Resolution specifies whether resolution
-                                  of this reference is required. The default is 'Required',
-                                  which means the reconcile will fail if the reference
-                                  cannot be resolved. 'Optional' means this reference
-                                  will be a no-op if it cannot be resolved.
-                                enum:
-                                - Required
-                                - Optional
-                                type: string
-                              resolve:
-                                description: Resolve specifies when this reference
-                                  should be resolved. The default is 'IfNotPresent',
-                                  which will attempt to resolve the reference only
-                                  when the corresponding field is not present. Use
-                                  'Always' to resolve the reference on every reconcile.
-                                enum:
-                                - Always
-                                - IfNotPresent
-                                type: string
-                            type: object
-                        required:
-                        - name
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Annotations are the annotations to be added to connection secret.
+                          - For Kubernetes secrets, this will be used as "metadata.annotations".
+                          - It is up to Secret Store implementation for others store types.
                         type: object
-                      metadata:
-                        description: Metadata is the metadata for connection secret.
-                        properties:
-                          annotations:
-                            additionalProperties:
-                              type: string
-                            description: Annotations are the annotations to be added
-                              to connection secret. - For Kubernetes secrets, this
-                              will be used as "metadata.annotations". - It is up to
-                              Secret Store implementation for others store types.
-                            type: object
-                          labels:
-                            additionalProperties:
-                              type: string
-                            description: Labels are the labels/tags to be added to
-                              connection secret. - For Kubernetes secrets, this will
-                              be used as "metadata.labels". - It is up to Secret Store
-                              implementation for others store types.
-                            type: object
-                          type:
-                            description: Type is the SecretType for the connection
-                              secret. - Only valid for Kubernetes Secret Stores.
-                            type: string
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Labels are the labels/tags to be added to connection secret.
+                          - For Kubernetes secrets, this will be used as "metadata.labels".
+                          - It is up to Secret Store implementation for others store types.
                         type: object
-                      name:
-                        description: Name is the name of the connection secret.
+                      type:
+                        description: |-
+                          Type is the SecretType for the connection secret.
+                          - Only valid for Kubernetes Secret Stores.
                         type: string
-                    required:
-                    - name
                     type: object
-                  writeConnectionSecretToRef:
-                    description: WriteConnectionSecretToReference specifies the namespace
-                      and name of a Secret to which any connection details for this
-                      managed resource should be written. Connection details frequently
-                      include the endpoint, username, and password required to connect
-                      to the managed resource. This field is planned to be replaced
-                      in a future release in favor of PublishConnectionDetailsTo.
-                      Currently, both could be set independently and connection details
-                      would be published to both without affecting each other.
-                    properties:
-                      name:
-                        description: Name of the secret.
-                        type: string
-                      namespace:
-                        description: Namespace of the secret.
-                        type: string
-                    required:
-                    - name
-                    - namespace
-                    type: object
+                  name:
+                    description: Name is the name of the connection secret.
+                    type: string
+                required:
+                - name
                 type: object
-            required:
-            - spec
+              writeConnectionSecretToRef:
+                description: |-
+                  WriteConnectionSecretToReference specifies the namespace and name of a
+                  Secret to which any connection details for this managed resource should
+                  be written. Connection details frequently include the endpoint, username,
+                  and password required to connect to the managed resource.
+                  This field is planned to be replaced in a future release in favor of
+                  PublishConnectionDetailsTo. Currently, both could be set independently
+                  and connection details would be published to both without affecting
+                  each other.
+                properties:
+                  name:
+                    description: Name of the secret.
+                    type: string
+                  namespace:
+                    description: Namespace of the secret.
+                    type: string
+                required:
+                - name
+                - namespace
+                type: object
             type: object
           status:
             properties:
@@ -346,13 +354,15 @@ spec:
                   description: A Condition that may apply to a resource.
                   properties:
                     lastTransitionTime:
-                      description: LastTransitionTime is the last time this condition
-                        transitioned from one status to another.
+                      description: |-
+                        LastTransitionTime is the last time this condition transitioned from one
+                        status to another.
                       format: date-time
                       type: string
                     message:
-                      description: A Message containing details about this condition's
-                        last transition from one status to another, if any.
+                      description: |-
+                        A Message containing details about this condition's last transition from
+                        one status to another, if any.
                       type: string
                     reason:
                       description: A Reason for this condition's last transition from
@@ -363,8 +373,9 @@ spec:
                         False, or Unknown?
                       type: string
                     type:
-                      description: Type of this condition. At most one of each condition
-                        type may apply to a resource at any point in time.
+                      description: |-
+                        Type of this condition. At most one of each condition type may apply to
+                        a resource at any point in time.
                       type: string
                   required:
                   - lastTransitionTime
@@ -396,11 +407,9 @@ spec:
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: ObservedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
+                      description: |-
+                        ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
@@ -425,8 +434,9 @@ spec:
                   type: object
                 type: array
               schedules:
-                description: Schedules keeps track of random generated schedules,
-                  is overwriten by schedules set in the service's spec.
+                description: |-
+                  Schedules keeps track of random generated schedules, is overwriten by
+                  schedules set in the service's spec.
                 properties:
                   backup:
                     description: Backup keeps track of the backup schedule.
@@ -435,9 +445,9 @@ spec:
                     description: Maintenance keeps track of the maintenance schedule.
                     properties:
                       dayOfWeek:
-                        description: DayOfWeek specifies at which weekday the maintenance
-                          is held place. Allowed values are [monday, tuesday, wednesday,
-                          thursday, friday, saturday, sunday]
+                        description: |-
+                          DayOfWeek specifies at which weekday the maintenance is held place.
+                          Allowed values are [monday, tuesday, wednesday, thursday, friday, saturday, sunday]
                         enum:
                         - monday
                         - tuesday
@@ -448,8 +458,9 @@ spec:
                         - sunday
                         type: string
                       timeOfDay:
-                        description: 'TimeOfDay for installing updates in UTC. Format:
-                          "hh:mm:ss".'
+                        description: |-
+                          TimeOfDay for installing updates in UTC.
+                          Format: "hh:mm:ss".
                         pattern: ^([0-1]?[0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9])$
                         type: string
                     type: object

--- a/crds/vshn.appcat.vshn.io_xvshnpostgresqls.yaml
+++ b/crds/vshn.appcat.vshn.io_xvshnpostgresqls.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: xvshnpostgresqls.vshn.appcat.vshn.io
 spec:
   group: vshn.appcat.vshn.io
@@ -20,14 +20,19 @@ spec:
         description: XVSHNPostgreSQL represents the internal composite of this claim
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -35,13 +40,14 @@ spec:
             properties:
               deletionPolicy:
                 default: Delete
-                description: 'DeletionPolicy specifies what will happen to the underlying
-                  external when this managed resource is deleted - either "Delete"
-                  or "Orphan" the external resource. This field is planned to be deprecated
-                  in favor of the ManagementPolicies field in a future release. Currently,
-                  both could be set independently and non-default values would be
-                  honored if the feature flag is enabled. See the design doc for more
-                  information: https://github.com/crossplane/crossplane/blob/499895a25d1a1a0ba1604944ef98ac7a1a71f197/design/design-doc-observe-only-resources.md?plain=1#L223'
+                description: |-
+                  DeletionPolicy specifies what will happen to the underlying external
+                  when this managed resource is deleted - either "Delete" or "Orphan" the
+                  external resource.
+                  This field is planned to be deprecated in favor of the ManagementPolicies
+                  field in a future release. Currently, both could be set independently and
+                  non-default values would be honored if the feature flag is enabled.
+                  See the design doc for more information: https://github.com/crossplane/crossplane/blob/499895a25d1a1a0ba1604944ef98ac7a1a71f197/design/design-doc-observe-only-resources.md?plain=1#L223
                 enum:
                 - Orphan
                 - Delete
@@ -49,19 +55,21 @@ spec:
               managementPolicies:
                 default:
                 - '*'
-                description: 'THIS IS A BETA FIELD. It is on by default but can be
-                  opted out through a Crossplane feature flag. ManagementPolicies
-                  specify the array of actions Crossplane is allowed to take on the
-                  managed and external resources. This field is planned to replace
-                  the DeletionPolicy field in a future release. Currently, both could
-                  be set independently and non-default values would be honored if
-                  the feature flag is enabled. If both are custom, the DeletionPolicy
-                  field will be ignored. See the design doc for more information:
-                  https://github.com/crossplane/crossplane/blob/499895a25d1a1a0ba1604944ef98ac7a1a71f197/design/design-doc-observe-only-resources.md?plain=1#L223
-                  and this one: https://github.com/crossplane/crossplane/blob/444267e84783136daa93568b364a5f01228cacbe/design/one-pager-ignore-changes.md'
+                description: |-
+                  THIS IS A BETA FIELD. It is on by default but can be opted out
+                  through a Crossplane feature flag.
+                  ManagementPolicies specify the array of actions Crossplane is allowed to
+                  take on the managed and external resources.
+                  This field is planned to replace the DeletionPolicy field in a future
+                  release. Currently, both could be set independently and non-default
+                  values would be honored if the feature flag is enabled. If both are
+                  custom, the DeletionPolicy field will be ignored.
+                  See the design doc for more information: https://github.com/crossplane/crossplane/blob/499895a25d1a1a0ba1604944ef98ac7a1a71f197/design/design-doc-observe-only-resources.md?plain=1#L223
+                  and this one: https://github.com/crossplane/crossplane/blob/444267e84783136daa93568b364a5f01228cacbe/design/one-pager-ignore-changes.md
                 items:
-                  description: A ManagementAction represents an action that the Crossplane
-                    controllers can take on an external resource.
+                  description: |-
+                    A ManagementAction represents an action that the Crossplane controllers
+                    can take on an external resource.
                   enum:
                   - Observe
                   - Create
@@ -80,15 +88,15 @@ spec:
                     properties:
                       deletionProtection:
                         default: true
-                        description: DeletionProtection will protect the instance
-                          from being deleted for the given retention time. This is
-                          enabled by default.
+                        description: |-
+                          DeletionProtection will protect the instance from being deleted for the given retention time.
+                          This is enabled by default.
                         type: boolean
                       deletionRetention:
                         default: 7
-                        description: DeletionRetention specifies in days how long
-                          the instance should be kept after deletion. The default
-                          is keeping it one week.
+                        description: |-
+                          DeletionRetention specifies in days how long the instance should be kept after deletion.
+                          The default is keeping it one week.
                         type: integer
                       retention:
                         default: 6
@@ -112,10 +120,10 @@ spec:
                     type: object
                   instances:
                     default: 1
-                    description: Instances configures the number of PostgreSQL instances
-                      for the cluster. Each instance contains one Postgres server.
-                      Out of all Postgres servers, one is elected as the primary,
-                      the rest remain as read-only replicas.
+                    description: |-
+                      Instances configures the number of PostgreSQL instances for the cluster.
+                      Each instance contains one Postgres server.
+                      Out of all Postgres servers, one is elected as the primary, the rest remain as read-only replicas.
                     maximum: 3
                     minimum: 1
                     type: integer
@@ -124,9 +132,9 @@ spec:
                       of an instance.
                     properties:
                       dayOfWeek:
-                        description: DayOfWeek specifies at which weekday the maintenance
-                          is held place. Allowed values are [monday, tuesday, wednesday,
-                          thursday, friday, saturday, sunday]
+                        description: |-
+                          DayOfWeek specifies at which weekday the maintenance is held place.
+                          Allowed values are [monday, tuesday, wednesday, thursday, friday, saturday, sunday]
                         enum:
                         - monday
                         - tuesday
@@ -137,8 +145,9 @@ spec:
                         - sunday
                         type: string
                       timeOfDay:
-                        description: 'TimeOfDay for installing updates in UTC. Format:
-                          "hh:mm:ss".'
+                        description: |-
+                          TimeOfDay for installing updates in UTC.
+                          Format: "hh:mm:ss".
                         pattern: ^([0-1]?[0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9])$
                         type: string
                     type: object
@@ -146,46 +155,50 @@ spec:
                     description: Monitoring contains settings to control monitoring.
                     properties:
                       alertmanagerConfigRef:
-                        description: AlertmanagerConfigRef contains the name of the
-                          AlertmanagerConfig that should be copied over to the namespace
-                          of the instance.
+                        description: |-
+                          AlertmanagerConfigRef contains the name of the AlertmanagerConfig that should be copied over to the
+                          namespace of the instance.
                         type: string
                       alertmanagerConfigSecretRef:
-                        description: AlertmanagerConfigSecretRef contains the name
-                          of the secret that is used in the referenced AlertmanagerConfig
+                        description: |-
+                          AlertmanagerConfigSecretRef contains the name of the secret that is used
+                          in the referenced AlertmanagerConfig
                         type: string
                       alertmanagerConfigTemplate:
-                        description: AlertmanagerConfigSpecTemplate takes an AlertmanagerConfigSpec
-                          object. This takes precedence over the AlertmanagerConfigRef.
+                        description: |-
+                          AlertmanagerConfigSpecTemplate takes an AlertmanagerConfigSpec object.
+                          This takes precedence over the AlertmanagerConfigRef.
                         properties:
                           inhibitRules:
-                            description: List of inhibition rules. The rules will
-                              only apply to alerts matching the resource's namespace.
+                            description: |-
+                              List of inhibition rules. The rules will only apply to alerts matching
+                              the resource's namespace.
                             items:
-                              description: InhibitRule defines an inhibition rule
-                                that allows to mute alerts when other alerts are already
-                                firing. See https://prometheus.io/docs/alerting/latest/configuration/#inhibit_rule
+                              description: |-
+                                InhibitRule defines an inhibition rule that allows to mute alerts when other
+                                alerts are already firing.
+                                See https://prometheus.io/docs/alerting/latest/configuration/#inhibit_rule
                               properties:
                                 equal:
-                                  description: Labels that must have an equal value
-                                    in the source and target alert for the inhibition
-                                    to take effect.
+                                  description: |-
+                                    Labels that must have an equal value in the source and target alert for
+                                    the inhibition to take effect.
                                   items:
                                     type: string
                                   type: array
                                 sourceMatch:
-                                  description: Matchers for which one or more alerts
-                                    have to exist for the inhibition to take effect.
-                                    The operator enforces that the alert matches the
+                                  description: |-
+                                    Matchers for which one or more alerts have to exist for the inhibition
+                                    to take effect. The operator enforces that the alert matches the
                                     resource's namespace.
                                   items:
                                     description: Matcher defines how to match on alert's
                                       labels.
                                     properties:
                                       matchType:
-                                        description: Match operation available with
-                                          AlertManager >= v0.22.0 and takes precedence
-                                          over Regex (deprecated) if non-empty.
+                                        description: |-
+                                          Match operation available with AlertManager >= v0.22.0 and
+                                          takes precedence over Regex (deprecated) if non-empty.
                                         enum:
                                         - '!='
                                         - "="
@@ -197,10 +210,9 @@ spec:
                                         minLength: 1
                                         type: string
                                       regex:
-                                        description: Whether to match on equality
-                                          (false) or regular-expression (true). Deprecated
-                                          as of AlertManager >= v0.22.0 where a user
-                                          should use MatchType instead.
+                                        description: |-
+                                          Whether to match on equality (false) or regular-expression (true).
+                                          Deprecated as of AlertManager >= v0.22.0 where a user should use MatchType instead.
                                         type: boolean
                                       value:
                                         description: Label value to match.
@@ -210,17 +222,17 @@ spec:
                                     type: object
                                   type: array
                                 targetMatch:
-                                  description: Matchers that have to be fulfilled
-                                    in the alerts to be muted. The operator enforces
-                                    that the alert matches the resource's namespace.
+                                  description: |-
+                                    Matchers that have to be fulfilled in the alerts to be muted. The
+                                    operator enforces that the alert matches the resource's namespace.
                                   items:
                                     description: Matcher defines how to match on alert's
                                       labels.
                                     properties:
                                       matchType:
-                                        description: Match operation available with
-                                          AlertManager >= v0.22.0 and takes precedence
-                                          over Regex (deprecated) if non-empty.
+                                        description: |-
+                                          Match operation available with AlertManager >= v0.22.0 and
+                                          takes precedence over Regex (deprecated) if non-empty.
                                         enum:
                                         - '!='
                                         - "="
@@ -232,10 +244,9 @@ spec:
                                         minLength: 1
                                         type: string
                                       regex:
-                                        description: Whether to match on equality
-                                          (false) or regular-expression (true). Deprecated
-                                          as of AlertManager >= v0.22.0 where a user
-                                          should use MatchType instead.
+                                        description: |-
+                                          Whether to match on equality (false) or regular-expression (true).
+                                          Deprecated as of AlertManager >= v0.22.0 where a user should use MatchType instead.
                                         type: boolean
                                       value:
                                         description: Label value to match.
@@ -285,12 +296,9 @@ spec:
                                       months:
                                         description: Months is a list of MonthRange
                                         items:
-                                          description: MonthRange is an inclusive
-                                            range of months of the year beginning
-                                            in January Months can be specified by
-                                            name (e.g 'January') by numerical month
-                                            (e.g '1') or as an inclusive range (e.g
-                                            'January:March', '1:3', '1:March')
+                                          description: |-
+                                            MonthRange is an inclusive range of months of the year beginning in January
+                                            Months can be specified by name (e.g 'January') by numerical month (e.g '1') or as an inclusive range (e.g 'January:March', '1:3', '1:March')
                                           pattern: ^((?i)january|february|march|april|may|june|july|august|september|october|november|december|[1-12])(?:((:((?i)january|february|march|april|may|june|july|august|september|october|november|december|[1-12]))$)|$)
                                           type: string
                                         type: array
@@ -315,11 +323,9 @@ spec:
                                       weekdays:
                                         description: Weekdays is a list of WeekdayRange
                                         items:
-                                          description: WeekdayRange is an inclusive
-                                            range of days of the week beginning on
-                                            Sunday Days can be specified by name (e.g
-                                            'Sunday') or as an inclusive range (e.g
-                                            'Monday:Friday')
+                                          description: |-
+                                            WeekdayRange is an inclusive range of days of the week beginning on Sunday
+                                            Days can be specified by name (e.g 'Sunday') or as an inclusive range (e.g 'Monday:Friday')
                                           pattern: ^((?i)sun|mon|tues|wednes|thurs|fri|satur)day(?:((:(sun|mon|tues|wednes|thurs|fri|satur)day)$)|$)
                                           type: string
                                         type: array
@@ -351,11 +357,10 @@ spec:
                                         description: The identity to use for authentication.
                                         type: string
                                       authPassword:
-                                        description: The secret's key that contains
-                                          the password to use for authentication.
-                                          The secret needs to be in the same namespace
-                                          as the AlertmanagerConfig object and accessible
-                                          by the Prometheus Operator.
+                                        description: |-
+                                          The secret's key that contains the password to use for authentication.
+                                          The secret needs to be in the same namespace as the AlertmanagerConfig
+                                          object and accessible by the Prometheus Operator.
                                         properties:
                                           key:
                                             description: The key of the secret to
@@ -363,10 +368,10 @@ spec:
                                               key.
                                             type: string
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
                                             description: Specify whether the Secret
@@ -377,11 +382,10 @@ spec:
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       authSecret:
-                                        description: The secret's key that contains
-                                          the CRAM-MD5 secret. The secret needs to
-                                          be in the same namespace as the AlertmanagerConfig
-                                          object and accessible by the Prometheus
-                                          Operator.
+                                        description: |-
+                                          The secret's key that contains the CRAM-MD5 secret.
+                                          The secret needs to be in the same namespace as the AlertmanagerConfig
+                                          object and accessible by the Prometheus Operator.
                                         properties:
                                           key:
                                             description: The key of the secret to
@@ -389,10 +393,10 @@ spec:
                                               key.
                                             type: string
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
                                             description: Specify whether the Secret
@@ -409,9 +413,9 @@ spec:
                                         description: The sender address.
                                         type: string
                                       headers:
-                                        description: Further headers email header
-                                          key/value pairs. Overrides any headers previously
-                                          set by the notification implementation.
+                                        description: |-
+                                          Further headers email header key/value pairs. Overrides any headers
+                                          previously set by the notification implementation.
                                         items:
                                           description: KeyValue defines a (key, value)
                                             tuple.
@@ -436,9 +440,9 @@ spec:
                                         description: The HTML body of the email notification.
                                         type: string
                                       requireTLS:
-                                        description: The SMTP TLS requirement. Note
-                                          that Go does not support unencrypted connections
-                                          to remote SMTP endpoints.
+                                        description: |-
+                                          The SMTP TLS requirement.
+                                          Note that Go does not support unencrypted connections to remote SMTP endpoints.
                                         type: boolean
                                       sendResolved:
                                         description: Whether or not to notify about
@@ -466,10 +470,10 @@ spec:
                                                     description: The key to select.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -490,10 +494,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -516,10 +520,10 @@ spec:
                                                     description: The key to select.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -540,10 +544,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -568,10 +572,10 @@ spec:
                                                   secret key.
                                                 type: string
                                               name:
-                                                description: 'Name of the referent.
+                                                description: |-
+                                                  Name of the referent.
                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
+                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                 type: string
                                               optional:
                                                 description: Specify whether the Secret
@@ -600,19 +604,19 @@ spec:
                                 opsgenieConfigs:
                                   description: List of OpsGenie configurations.
                                   items:
-                                    description: OpsGenieConfig configures notifications
-                                      via OpsGenie. See https://prometheus.io/docs/alerting/latest/configuration/#opsgenie_config
+                                    description: |-
+                                      OpsGenieConfig configures notifications via OpsGenie.
+                                      See https://prometheus.io/docs/alerting/latest/configuration/#opsgenie_config
                                     properties:
                                       actions:
                                         description: Comma separated list of actions
                                           that will be available for the alert.
                                         type: string
                                       apiKey:
-                                        description: The secret's key that contains
-                                          the OpsGenie API key. The secret needs to
-                                          be in the same namespace as the AlertmanagerConfig
-                                          object and accessible by the Prometheus
-                                          Operator.
+                                        description: |-
+                                          The secret's key that contains the OpsGenie API key.
+                                          The secret needs to be in the same namespace as the AlertmanagerConfig
+                                          object and accessible by the Prometheus Operator.
                                         properties:
                                           key:
                                             description: The key of the secret to
@@ -620,10 +624,10 @@ spec:
                                               key.
                                             type: string
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
                                             description: Specify whether the Secret
@@ -669,10 +673,9 @@ spec:
                                         description: HTTP client configuration.
                                         properties:
                                           authorization:
-                                            description: Authorization header configuration
-                                              for the client. This is mutually exclusive
-                                              with BasicAuth and is only available
-                                              starting from Alertmanager v0.22+.
+                                            description: |-
+                                              Authorization header configuration for the client.
+                                              This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
                                             properties:
                                               credentials:
                                                 description: The secret's key that
@@ -685,10 +688,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -699,21 +702,20 @@ spec:
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               type:
-                                                description: Set the authentication
-                                                  type. Defaults to Bearer, Basic
-                                                  will cause an error
+                                                description: |-
+                                                  Set the authentication type. Defaults to Bearer, Basic will cause an
+                                                  error
                                                 type: string
                                             type: object
                                           basicAuth:
-                                            description: BasicAuth for the client.
-                                              This is mutually exclusive with Authorization.
-                                              If both are defined, BasicAuth takes
-                                              precedence.
+                                            description: |-
+                                              BasicAuth for the client.
+                                              This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
                                             properties:
                                               password:
-                                                description: The secret in the service
-                                                  monitor namespace that contains
-                                                  the password for authentication.
+                                                description: |-
+                                                  The secret in the service monitor namespace that contains the password
+                                                  for authentication.
                                                 properties:
                                                   key:
                                                     description: The key of the secret
@@ -721,10 +723,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -735,9 +737,9 @@ spec:
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               username:
-                                                description: The secret in the service
-                                                  monitor namespace that contains
-                                                  the username for authentication.
+                                                description: |-
+                                                  The secret in the service monitor namespace that contains the username
+                                                  for authentication.
                                                 properties:
                                                   key:
                                                     description: The key of the secret
@@ -745,10 +747,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -760,12 +762,11 @@ spec:
                                                 x-kubernetes-map-type: atomic
                                             type: object
                                           bearerTokenSecret:
-                                            description: The secret's key that contains
-                                              the bearer token to be used by the client
-                                              for authentication. The secret needs
-                                              to be in the same namespace as the AlertmanagerConfig
-                                              object and accessible by the Prometheus
-                                              Operator.
+                                            description: |-
+                                              The secret's key that contains the bearer token to be used by the client
+                                              for authentication.
+                                              The secret needs to be in the same namespace as the AlertmanagerConfig
+                                              object and accessible by the Prometheus Operator.
                                             properties:
                                               key:
                                                 description: The key of the secret
@@ -773,10 +774,10 @@ spec:
                                                   secret key.
                                                 type: string
                                               name:
-                                                description: 'Name of the referent.
+                                                description: |-
+                                                  Name of the referent.
                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
+                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                 type: string
                                               optional:
                                                 description: Specify whether the Secret
@@ -807,10 +808,10 @@ spec:
                                                         description: The key to select.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -831,10 +832,10 @@ spec:
                                                           be a valid secret key.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -856,10 +857,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -910,10 +911,10 @@ spec:
                                                         description: The key to select.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -934,10 +935,10 @@ spec:
                                                           be a valid secret key.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -961,10 +962,10 @@ spec:
                                                         description: The key to select.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -985,10 +986,10 @@ spec:
                                                           be a valid secret key.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -1014,10 +1015,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -1047,9 +1048,9 @@ spec:
                                         description: List of responders responsible
                                           for notifications.
                                         items:
-                                          description: OpsGenieConfigResponder defines
-                                            a responder to an incident. One of `id`,
-                                            `name` or `username` has to be defined.
+                                          description: |-
+                                            OpsGenieConfigResponder defines a responder to an incident.
+                                            One of `id`, `name` or `username` has to be defined.
                                           properties:
                                             id:
                                               description: ID of the responder.
@@ -1087,19 +1088,18 @@ spec:
                                           attached to the notifications.
                                         type: string
                                       updateAlerts:
-                                        description: Whether to update message and
-                                          description of the alert in OpsGenie if
-                                          it already exists By default, the alert
-                                          is never updated in OpsGenie, the new message
-                                          only appears in activity log.
+                                        description: |-
+                                          Whether to update message and description of the alert in OpsGenie if it already exists
+                                          By default, the alert is never updated in OpsGenie, the new message only appears in activity log.
                                         type: boolean
                                     type: object
                                   type: array
                                 pagerdutyConfigs:
                                   description: List of PagerDuty configurations.
                                   items:
-                                    description: PagerDutyConfig configures notifications
-                                      via PagerDuty. See https://prometheus.io/docs/alerting/latest/configuration/#pagerduty_config
+                                    description: |-
+                                      PagerDutyConfig configures notifications via PagerDuty.
+                                      See https://prometheus.io/docs/alerting/latest/configuration/#pagerduty_config
                                     properties:
                                       class:
                                         description: The class/type of the event.
@@ -1143,10 +1143,9 @@ spec:
                                         description: HTTP client configuration.
                                         properties:
                                           authorization:
-                                            description: Authorization header configuration
-                                              for the client. This is mutually exclusive
-                                              with BasicAuth and is only available
-                                              starting from Alertmanager v0.22+.
+                                            description: |-
+                                              Authorization header configuration for the client.
+                                              This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
                                             properties:
                                               credentials:
                                                 description: The secret's key that
@@ -1159,10 +1158,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -1173,21 +1172,20 @@ spec:
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               type:
-                                                description: Set the authentication
-                                                  type. Defaults to Bearer, Basic
-                                                  will cause an error
+                                                description: |-
+                                                  Set the authentication type. Defaults to Bearer, Basic will cause an
+                                                  error
                                                 type: string
                                             type: object
                                           basicAuth:
-                                            description: BasicAuth for the client.
-                                              This is mutually exclusive with Authorization.
-                                              If both are defined, BasicAuth takes
-                                              precedence.
+                                            description: |-
+                                              BasicAuth for the client.
+                                              This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
                                             properties:
                                               password:
-                                                description: The secret in the service
-                                                  monitor namespace that contains
-                                                  the password for authentication.
+                                                description: |-
+                                                  The secret in the service monitor namespace that contains the password
+                                                  for authentication.
                                                 properties:
                                                   key:
                                                     description: The key of the secret
@@ -1195,10 +1193,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -1209,9 +1207,9 @@ spec:
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               username:
-                                                description: The secret in the service
-                                                  monitor namespace that contains
-                                                  the username for authentication.
+                                                description: |-
+                                                  The secret in the service monitor namespace that contains the username
+                                                  for authentication.
                                                 properties:
                                                   key:
                                                     description: The key of the secret
@@ -1219,10 +1217,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -1234,12 +1232,11 @@ spec:
                                                 x-kubernetes-map-type: atomic
                                             type: object
                                           bearerTokenSecret:
-                                            description: The secret's key that contains
-                                              the bearer token to be used by the client
-                                              for authentication. The secret needs
-                                              to be in the same namespace as the AlertmanagerConfig
-                                              object and accessible by the Prometheus
-                                              Operator.
+                                            description: |-
+                                              The secret's key that contains the bearer token to be used by the client
+                                              for authentication.
+                                              The secret needs to be in the same namespace as the AlertmanagerConfig
+                                              object and accessible by the Prometheus Operator.
                                             properties:
                                               key:
                                                 description: The key of the secret
@@ -1247,10 +1244,10 @@ spec:
                                                   secret key.
                                                 type: string
                                               name:
-                                                description: 'Name of the referent.
+                                                description: |-
+                                                  Name of the referent.
                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
+                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                 type: string
                                               optional:
                                                 description: Specify whether the Secret
@@ -1281,10 +1278,10 @@ spec:
                                                         description: The key to select.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -1305,10 +1302,10 @@ spec:
                                                           be a valid secret key.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -1330,10 +1327,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -1384,10 +1381,10 @@ spec:
                                                         description: The key to select.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -1408,10 +1405,10 @@ spec:
                                                           be a valid secret key.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -1435,10 +1432,10 @@ spec:
                                                         description: The key to select.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -1459,10 +1456,10 @@ spec:
                                                           be a valid secret key.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -1488,10 +1485,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -1547,13 +1544,11 @@ spec:
                                           type: object
                                         type: array
                                       routingKey:
-                                        description: The secret's key that contains
-                                          the PagerDuty integration key (when using
-                                          Events API v2). Either this field or `serviceKey`
-                                          needs to be defined. The secret needs to
-                                          be in the same namespace as the AlertmanagerConfig
-                                          object and accessible by the Prometheus
-                                          Operator.
+                                        description: |-
+                                          The secret's key that contains the PagerDuty integration key (when using
+                                          Events API v2). Either this field or `serviceKey` needs to be defined.
+                                          The secret needs to be in the same namespace as the AlertmanagerConfig
+                                          object and accessible by the Prometheus Operator.
                                         properties:
                                           key:
                                             description: The key of the secret to
@@ -1561,10 +1556,10 @@ spec:
                                               key.
                                             type: string
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
                                             description: Specify whether the Secret
@@ -1579,13 +1574,12 @@ spec:
                                           resolved alerts.
                                         type: boolean
                                       serviceKey:
-                                        description: The secret's key that contains
-                                          the PagerDuty service key (when using integration
-                                          type "Prometheus"). Either this field or
-                                          `routingKey` needs to be defined. The secret
-                                          needs to be in the same namespace as the
-                                          AlertmanagerConfig object and accessible
-                                          by the Prometheus Operator.
+                                        description: |-
+                                          The secret's key that contains the PagerDuty service key (when using
+                                          integration type "Prometheus"). Either this field or `routingKey` needs to
+                                          be defined.
+                                          The secret needs to be in the same namespace as the AlertmanagerConfig
+                                          object and accessible by the Prometheus Operator.
                                         properties:
                                           key:
                                             description: The key of the secret to
@@ -1593,10 +1587,10 @@ spec:
                                               key.
                                             type: string
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
                                             description: Specify whether the Secret
@@ -1617,12 +1611,13 @@ spec:
                                 pushoverConfigs:
                                   description: List of Pushover configurations.
                                   items:
-                                    description: PushoverConfig configures notifications
-                                      via Pushover. See https://prometheus.io/docs/alerting/latest/configuration/#pushover_config
+                                    description: |-
+                                      PushoverConfig configures notifications via Pushover.
+                                      See https://prometheus.io/docs/alerting/latest/configuration/#pushover_config
                                     properties:
                                       expire:
-                                        description: How long your notification will
-                                          continue to be retried for, unless the user
+                                        description: |-
+                                          How long your notification will continue to be retried for, unless the user
                                           acknowledges the notification.
                                         pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
                                         type: string
@@ -1634,10 +1629,9 @@ spec:
                                         description: HTTP client configuration.
                                         properties:
                                           authorization:
-                                            description: Authorization header configuration
-                                              for the client. This is mutually exclusive
-                                              with BasicAuth and is only available
-                                              starting from Alertmanager v0.22+.
+                                            description: |-
+                                              Authorization header configuration for the client.
+                                              This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
                                             properties:
                                               credentials:
                                                 description: The secret's key that
@@ -1650,10 +1644,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -1664,21 +1658,20 @@ spec:
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               type:
-                                                description: Set the authentication
-                                                  type. Defaults to Bearer, Basic
-                                                  will cause an error
+                                                description: |-
+                                                  Set the authentication type. Defaults to Bearer, Basic will cause an
+                                                  error
                                                 type: string
                                             type: object
                                           basicAuth:
-                                            description: BasicAuth for the client.
-                                              This is mutually exclusive with Authorization.
-                                              If both are defined, BasicAuth takes
-                                              precedence.
+                                            description: |-
+                                              BasicAuth for the client.
+                                              This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
                                             properties:
                                               password:
-                                                description: The secret in the service
-                                                  monitor namespace that contains
-                                                  the password for authentication.
+                                                description: |-
+                                                  The secret in the service monitor namespace that contains the password
+                                                  for authentication.
                                                 properties:
                                                   key:
                                                     description: The key of the secret
@@ -1686,10 +1679,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -1700,9 +1693,9 @@ spec:
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               username:
-                                                description: The secret in the service
-                                                  monitor namespace that contains
-                                                  the username for authentication.
+                                                description: |-
+                                                  The secret in the service monitor namespace that contains the username
+                                                  for authentication.
                                                 properties:
                                                   key:
                                                     description: The key of the secret
@@ -1710,10 +1703,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -1725,12 +1718,11 @@ spec:
                                                 x-kubernetes-map-type: atomic
                                             type: object
                                           bearerTokenSecret:
-                                            description: The secret's key that contains
-                                              the bearer token to be used by the client
-                                              for authentication. The secret needs
-                                              to be in the same namespace as the AlertmanagerConfig
-                                              object and accessible by the Prometheus
-                                              Operator.
+                                            description: |-
+                                              The secret's key that contains the bearer token to be used by the client
+                                              for authentication.
+                                              The secret needs to be in the same namespace as the AlertmanagerConfig
+                                              object and accessible by the Prometheus Operator.
                                             properties:
                                               key:
                                                 description: The key of the secret
@@ -1738,10 +1730,10 @@ spec:
                                                   secret key.
                                                 type: string
                                               name:
-                                                description: 'Name of the referent.
+                                                description: |-
+                                                  Name of the referent.
                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
+                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                 type: string
                                               optional:
                                                 description: Specify whether the Secret
@@ -1772,10 +1764,10 @@ spec:
                                                         description: The key to select.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -1796,10 +1788,10 @@ spec:
                                                           be a valid secret key.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -1821,10 +1813,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -1875,10 +1867,10 @@ spec:
                                                         description: The key to select.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -1899,10 +1891,10 @@ spec:
                                                           be a valid secret key.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -1926,10 +1918,10 @@ spec:
                                                         description: The key to select.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -1950,10 +1942,10 @@ spec:
                                                           be a valid secret key.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -1979,10 +1971,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -2005,8 +1997,8 @@ spec:
                                         description: Priority, see https://pushover.net/api#priority
                                         type: string
                                       retry:
-                                        description: How often the Pushover servers
-                                          will send the same notification to the user.
+                                        description: |-
+                                          How often the Pushover servers will send the same notification to the user.
                                           Must be at least 30 seconds.
                                         pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
                                         type: string
@@ -2023,12 +2015,10 @@ spec:
                                         description: Notification title.
                                         type: string
                                       token:
-                                        description: The secret's key that contains
-                                          the registered application's API token,
-                                          see https://pushover.net/apps. The secret
-                                          needs to be in the same namespace as the
-                                          AlertmanagerConfig object and accessible
-                                          by the Prometheus Operator.
+                                        description: |-
+                                          The secret's key that contains the registered application's API token, see https://pushover.net/apps.
+                                          The secret needs to be in the same namespace as the AlertmanagerConfig
+                                          object and accessible by the Prometheus Operator.
                                         properties:
                                           key:
                                             description: The key of the secret to
@@ -2036,10 +2026,10 @@ spec:
                                               key.
                                             type: string
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
                                             description: Specify whether the Secret
@@ -2058,11 +2048,10 @@ spec:
                                           otherwise just the URL is shown
                                         type: string
                                       userKey:
-                                        description: The secret's key that contains
-                                          the recipient user's user key. The secret
-                                          needs to be in the same namespace as the
-                                          AlertmanagerConfig object and accessible
-                                          by the Prometheus Operator.
+                                        description: |-
+                                          The secret's key that contains the recipient user's user key.
+                                          The secret needs to be in the same namespace as the AlertmanagerConfig
+                                          object and accessible by the Prometheus Operator.
                                         properties:
                                           key:
                                             description: The key of the secret to
@@ -2070,10 +2059,10 @@ spec:
                                               key.
                                             type: string
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
                                             description: Specify whether the Secret
@@ -2088,25 +2077,26 @@ spec:
                                 slackConfigs:
                                   description: List of Slack configurations.
                                   items:
-                                    description: SlackConfig configures notifications
-                                      via Slack. See https://prometheus.io/docs/alerting/latest/configuration/#slack_config
+                                    description: |-
+                                      SlackConfig configures notifications via Slack.
+                                      See https://prometheus.io/docs/alerting/latest/configuration/#slack_config
                                     properties:
                                       actions:
                                         description: A list of Slack actions that
                                           are sent with each notification.
                                         items:
-                                          description: SlackAction configures a single
-                                            Slack action that is sent with each notification.
-                                            See https://api.slack.com/docs/message-attachments#action_fields
-                                            and https://api.slack.com/docs/message-buttons
-                                            for more information.
+                                          description: |-
+                                            SlackAction configures a single Slack action that is sent with each
+                                            notification.
+                                            See https://api.slack.com/docs/message-attachments#action_fields and
+                                            https://api.slack.com/docs/message-buttons for more information.
                                           properties:
                                             confirm:
-                                              description: SlackConfirmationField
-                                                protect users from destructive actions
-                                                or particularly distinguished decisions
-                                                by asking them to confirm their button
-                                                click one more time. See https://api.slack.com/docs/interactive-message-field-guide#confirmation_fields
+                                              description: |-
+                                                SlackConfirmationField protect users from destructive actions or
+                                                particularly distinguished decisions by asking them to confirm their button
+                                                click one more time.
+                                                See https://api.slack.com/docs/interactive-message-field-guide#confirmation_fields
                                                 for more information.
                                               properties:
                                                 dismissText:
@@ -2141,11 +2131,10 @@ spec:
                                           type: object
                                         type: array
                                       apiURL:
-                                        description: The secret's key that contains
-                                          the Slack webhook URL. The secret needs
-                                          to be in the same namespace as the AlertmanagerConfig
-                                          object and accessible by the Prometheus
-                                          Operator.
+                                        description: |-
+                                          The secret's key that contains the Slack webhook URL.
+                                          The secret needs to be in the same namespace as the AlertmanagerConfig
+                                          object and accessible by the Prometheus Operator.
                                         properties:
                                           key:
                                             description: The key of the secret to
@@ -2153,10 +2142,10 @@ spec:
                                               key.
                                             type: string
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
                                             description: Specify whether the Secret
@@ -2180,14 +2169,11 @@ spec:
                                         description: A list of Slack fields that are
                                           sent with each notification.
                                         items:
-                                          description: SlackField configures a single
-                                            Slack field that is sent with each notification.
-                                            Each field must contain a title, value,
-                                            and optionally, a boolean value to indicate
-                                            if the field is short enough to be displayed
-                                            next to other fields designated as short.
-                                            See https://api.slack.com/docs/message-attachments#fields
-                                            for more information.
+                                          description: |-
+                                            SlackField configures a single Slack field that is sent with each notification.
+                                            Each field must contain a title, value, and optionally, a boolean value to indicate if the field
+                                            is short enough to be displayed next to other fields designated as short.
+                                            See https://api.slack.com/docs/message-attachments#fields for more information.
                                           properties:
                                             short:
                                               type: boolean
@@ -2208,10 +2194,9 @@ spec:
                                         description: HTTP client configuration.
                                         properties:
                                           authorization:
-                                            description: Authorization header configuration
-                                              for the client. This is mutually exclusive
-                                              with BasicAuth and is only available
-                                              starting from Alertmanager v0.22+.
+                                            description: |-
+                                              Authorization header configuration for the client.
+                                              This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
                                             properties:
                                               credentials:
                                                 description: The secret's key that
@@ -2224,10 +2209,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -2238,21 +2223,20 @@ spec:
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               type:
-                                                description: Set the authentication
-                                                  type. Defaults to Bearer, Basic
-                                                  will cause an error
+                                                description: |-
+                                                  Set the authentication type. Defaults to Bearer, Basic will cause an
+                                                  error
                                                 type: string
                                             type: object
                                           basicAuth:
-                                            description: BasicAuth for the client.
-                                              This is mutually exclusive with Authorization.
-                                              If both are defined, BasicAuth takes
-                                              precedence.
+                                            description: |-
+                                              BasicAuth for the client.
+                                              This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
                                             properties:
                                               password:
-                                                description: The secret in the service
-                                                  monitor namespace that contains
-                                                  the password for authentication.
+                                                description: |-
+                                                  The secret in the service monitor namespace that contains the password
+                                                  for authentication.
                                                 properties:
                                                   key:
                                                     description: The key of the secret
@@ -2260,10 +2244,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -2274,9 +2258,9 @@ spec:
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               username:
-                                                description: The secret in the service
-                                                  monitor namespace that contains
-                                                  the username for authentication.
+                                                description: |-
+                                                  The secret in the service monitor namespace that contains the username
+                                                  for authentication.
                                                 properties:
                                                   key:
                                                     description: The key of the secret
@@ -2284,10 +2268,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -2299,12 +2283,11 @@ spec:
                                                 x-kubernetes-map-type: atomic
                                             type: object
                                           bearerTokenSecret:
-                                            description: The secret's key that contains
-                                              the bearer token to be used by the client
-                                              for authentication. The secret needs
-                                              to be in the same namespace as the AlertmanagerConfig
-                                              object and accessible by the Prometheus
-                                              Operator.
+                                            description: |-
+                                              The secret's key that contains the bearer token to be used by the client
+                                              for authentication.
+                                              The secret needs to be in the same namespace as the AlertmanagerConfig
+                                              object and accessible by the Prometheus Operator.
                                             properties:
                                               key:
                                                 description: The key of the secret
@@ -2312,10 +2295,10 @@ spec:
                                                   secret key.
                                                 type: string
                                               name:
-                                                description: 'Name of the referent.
+                                                description: |-
+                                                  Name of the referent.
                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
+                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                 type: string
                                               optional:
                                                 description: Specify whether the Secret
@@ -2346,10 +2329,10 @@ spec:
                                                         description: The key to select.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -2370,10 +2353,10 @@ spec:
                                                           be a valid secret key.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -2395,10 +2378,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -2449,10 +2432,10 @@ spec:
                                                         description: The key to select.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -2473,10 +2456,10 @@ spec:
                                                           be a valid secret key.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -2500,10 +2483,10 @@ spec:
                                                         description: The key to select.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -2524,10 +2507,10 @@ spec:
                                                           be a valid secret key.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -2553,10 +2536,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -2607,13 +2590,14 @@ spec:
                                 snsConfigs:
                                   description: List of SNS configurations
                                   items:
-                                    description: SNSConfig configures notifications
-                                      via AWS SNS. See https://prometheus.io/docs/alerting/latest/configuration/#sns_configs
+                                    description: |-
+                                      SNSConfig configures notifications via AWS SNS.
+                                      See https://prometheus.io/docs/alerting/latest/configuration/#sns_configs
                                     properties:
                                       apiURL:
-                                        description: The SNS API URL i.e. https://sns.us-east-2.amazonaws.com.
-                                          If not specified, the SNS API URL from the
-                                          SNS SDK will be used.
+                                        description: |-
+                                          The SNS API URL i.e. https://sns.us-east-2.amazonaws.com.
+                                          If not specified, the SNS API URL from the SNS SDK will be used.
                                         type: string
                                       attributes:
                                         additionalProperties:
@@ -2624,10 +2608,9 @@ spec:
                                         description: HTTP client configuration.
                                         properties:
                                           authorization:
-                                            description: Authorization header configuration
-                                              for the client. This is mutually exclusive
-                                              with BasicAuth and is only available
-                                              starting from Alertmanager v0.22+.
+                                            description: |-
+                                              Authorization header configuration for the client.
+                                              This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
                                             properties:
                                               credentials:
                                                 description: The secret's key that
@@ -2640,10 +2623,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -2654,21 +2637,20 @@ spec:
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               type:
-                                                description: Set the authentication
-                                                  type. Defaults to Bearer, Basic
-                                                  will cause an error
+                                                description: |-
+                                                  Set the authentication type. Defaults to Bearer, Basic will cause an
+                                                  error
                                                 type: string
                                             type: object
                                           basicAuth:
-                                            description: BasicAuth for the client.
-                                              This is mutually exclusive with Authorization.
-                                              If both are defined, BasicAuth takes
-                                              precedence.
+                                            description: |-
+                                              BasicAuth for the client.
+                                              This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
                                             properties:
                                               password:
-                                                description: The secret in the service
-                                                  monitor namespace that contains
-                                                  the password for authentication.
+                                                description: |-
+                                                  The secret in the service monitor namespace that contains the password
+                                                  for authentication.
                                                 properties:
                                                   key:
                                                     description: The key of the secret
@@ -2676,10 +2658,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -2690,9 +2672,9 @@ spec:
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               username:
-                                                description: The secret in the service
-                                                  monitor namespace that contains
-                                                  the username for authentication.
+                                                description: |-
+                                                  The secret in the service monitor namespace that contains the username
+                                                  for authentication.
                                                 properties:
                                                   key:
                                                     description: The key of the secret
@@ -2700,10 +2682,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -2715,12 +2697,11 @@ spec:
                                                 x-kubernetes-map-type: atomic
                                             type: object
                                           bearerTokenSecret:
-                                            description: The secret's key that contains
-                                              the bearer token to be used by the client
-                                              for authentication. The secret needs
-                                              to be in the same namespace as the AlertmanagerConfig
-                                              object and accessible by the Prometheus
-                                              Operator.
+                                            description: |-
+                                              The secret's key that contains the bearer token to be used by the client
+                                              for authentication.
+                                              The secret needs to be in the same namespace as the AlertmanagerConfig
+                                              object and accessible by the Prometheus Operator.
                                             properties:
                                               key:
                                                 description: The key of the secret
@@ -2728,10 +2709,10 @@ spec:
                                                   secret key.
                                                 type: string
                                               name:
-                                                description: 'Name of the referent.
+                                                description: |-
+                                                  Name of the referent.
                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
+                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                 type: string
                                               optional:
                                                 description: Specify whether the Secret
@@ -2762,10 +2743,10 @@ spec:
                                                         description: The key to select.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -2786,10 +2767,10 @@ spec:
                                                           be a valid secret key.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -2811,10 +2792,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -2865,10 +2846,10 @@ spec:
                                                         description: The key to select.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -2889,10 +2870,10 @@ spec:
                                                           be a valid secret key.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -2916,10 +2897,10 @@ spec:
                                                         description: The key to select.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -2940,10 +2921,10 @@ spec:
                                                           be a valid secret key.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -2969,10 +2950,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -2993,10 +2974,9 @@ spec:
                                           notification.
                                         type: string
                                       phoneNumber:
-                                        description: Phone number if message is delivered
-                                          via SMS in E.164 format. If you don't specify
-                                          this value, you must specify a value for
-                                          the TopicARN or TargetARN.
+                                        description: |-
+                                          Phone number if message is delivered via SMS in E.164 format.
+                                          If you don't specify this value, you must specify a value for the TopicARN or TargetARN.
                                         type: string
                                       sendResolved:
                                         description: Whether or not to notify about
@@ -3017,10 +2997,10 @@ spec:
                                                   secret key.
                                                 type: string
                                               name:
-                                                description: 'Name of the referent.
+                                                description: |-
+                                                  Name of the referent.
                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
+                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                 type: string
                                               optional:
                                                 description: Specify whether the Secret
@@ -3054,10 +3034,10 @@ spec:
                                                   secret key.
                                                 type: string
                                               name:
-                                                description: 'Name of the referent.
+                                                description: |-
+                                                  Name of the referent.
                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
+                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                 type: string
                                               optional:
                                                 description: Specify whether the Secret
@@ -3073,34 +3053,34 @@ spec:
                                           is delivered to email endpoints.
                                         type: string
                                       targetARN:
-                                        description: The  mobile platform endpoint
-                                          ARN if message is delivered via mobile notifications.
-                                          If you don't specify this value, you must
-                                          specify a value for the topic_arn or PhoneNumber.
+                                        description: |-
+                                          The  mobile platform endpoint ARN if message is delivered via mobile notifications.
+                                          If you don't specify this value, you must specify a value for the topic_arn or PhoneNumber.
                                         type: string
                                       topicARN:
-                                        description: SNS topic ARN, i.e. arn:aws:sns:us-east-2:698519295917:My-Topic
-                                          If you don't specify this value, you must
-                                          specify a value for the PhoneNumber or TargetARN.
+                                        description: |-
+                                          SNS topic ARN, i.e. arn:aws:sns:us-east-2:698519295917:My-Topic
+                                          If you don't specify this value, you must specify a value for the PhoneNumber or TargetARN.
                                         type: string
                                     type: object
                                   type: array
                                 telegramConfigs:
                                   description: List of Telegram configurations.
                                   items:
-                                    description: TelegramConfig configures notifications
-                                      via Telegram. See https://prometheus.io/docs/alerting/latest/configuration/#telegram_config
+                                    description: |-
+                                      TelegramConfig configures notifications via Telegram.
+                                      See https://prometheus.io/docs/alerting/latest/configuration/#telegram_config
                                     properties:
                                       apiURL:
-                                        description: The Telegram API URL i.e. https://api.telegram.org.
-                                          If not specified, default API URL will be
-                                          used.
+                                        description: |-
+                                          The Telegram API URL i.e. https://api.telegram.org.
+                                          If not specified, default API URL will be used.
                                         type: string
                                       botToken:
-                                        description: Telegram bot token The secret
-                                          needs to be in the same namespace as the
-                                          AlertmanagerConfig object and accessible
-                                          by the Prometheus Operator.
+                                        description: |-
+                                          Telegram bot token
+                                          The secret needs to be in the same namespace as the AlertmanagerConfig
+                                          object and accessible by the Prometheus Operator.
                                         properties:
                                           key:
                                             description: The key of the secret to
@@ -3108,10 +3088,10 @@ spec:
                                               key.
                                             type: string
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
                                             description: Specify whether the Secret
@@ -3132,10 +3112,9 @@ spec:
                                         description: HTTP client configuration.
                                         properties:
                                           authorization:
-                                            description: Authorization header configuration
-                                              for the client. This is mutually exclusive
-                                              with BasicAuth and is only available
-                                              starting from Alertmanager v0.22+.
+                                            description: |-
+                                              Authorization header configuration for the client.
+                                              This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
                                             properties:
                                               credentials:
                                                 description: The secret's key that
@@ -3148,10 +3127,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -3162,21 +3141,20 @@ spec:
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               type:
-                                                description: Set the authentication
-                                                  type. Defaults to Bearer, Basic
-                                                  will cause an error
+                                                description: |-
+                                                  Set the authentication type. Defaults to Bearer, Basic will cause an
+                                                  error
                                                 type: string
                                             type: object
                                           basicAuth:
-                                            description: BasicAuth for the client.
-                                              This is mutually exclusive with Authorization.
-                                              If both are defined, BasicAuth takes
-                                              precedence.
+                                            description: |-
+                                              BasicAuth for the client.
+                                              This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
                                             properties:
                                               password:
-                                                description: The secret in the service
-                                                  monitor namespace that contains
-                                                  the password for authentication.
+                                                description: |-
+                                                  The secret in the service monitor namespace that contains the password
+                                                  for authentication.
                                                 properties:
                                                   key:
                                                     description: The key of the secret
@@ -3184,10 +3162,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -3198,9 +3176,9 @@ spec:
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               username:
-                                                description: The secret in the service
-                                                  monitor namespace that contains
-                                                  the username for authentication.
+                                                description: |-
+                                                  The secret in the service monitor namespace that contains the username
+                                                  for authentication.
                                                 properties:
                                                   key:
                                                     description: The key of the secret
@@ -3208,10 +3186,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -3223,12 +3201,11 @@ spec:
                                                 x-kubernetes-map-type: atomic
                                             type: object
                                           bearerTokenSecret:
-                                            description: The secret's key that contains
-                                              the bearer token to be used by the client
-                                              for authentication. The secret needs
-                                              to be in the same namespace as the AlertmanagerConfig
-                                              object and accessible by the Prometheus
-                                              Operator.
+                                            description: |-
+                                              The secret's key that contains the bearer token to be used by the client
+                                              for authentication.
+                                              The secret needs to be in the same namespace as the AlertmanagerConfig
+                                              object and accessible by the Prometheus Operator.
                                             properties:
                                               key:
                                                 description: The key of the secret
@@ -3236,10 +3213,10 @@ spec:
                                                   secret key.
                                                 type: string
                                               name:
-                                                description: 'Name of the referent.
+                                                description: |-
+                                                  Name of the referent.
                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
+                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                 type: string
                                               optional:
                                                 description: Specify whether the Secret
@@ -3270,10 +3247,10 @@ spec:
                                                         description: The key to select.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -3294,10 +3271,10 @@ spec:
                                                           be a valid secret key.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -3319,10 +3296,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -3373,10 +3350,10 @@ spec:
                                                         description: The key to select.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -3397,10 +3374,10 @@ spec:
                                                           be a valid secret key.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -3424,10 +3401,10 @@ spec:
                                                         description: The key to select.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -3448,10 +3425,10 @@ spec:
                                                           be a valid secret key.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -3477,10 +3454,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -3515,15 +3492,15 @@ spec:
                                 victoropsConfigs:
                                   description: List of VictorOps configurations.
                                   items:
-                                    description: VictorOpsConfig configures notifications
-                                      via VictorOps. See https://prometheus.io/docs/alerting/latest/configuration/#victorops_config
+                                    description: |-
+                                      VictorOpsConfig configures notifications via VictorOps.
+                                      See https://prometheus.io/docs/alerting/latest/configuration/#victorops_config
                                     properties:
                                       apiKey:
-                                        description: The secret's key that contains
-                                          the API key to use when talking to the VictorOps
-                                          API. The secret needs to be in the same
-                                          namespace as the AlertmanagerConfig object
-                                          and accessible by the Prometheus Operator.
+                                        description: |-
+                                          The secret's key that contains the API key to use when talking to the VictorOps API.
+                                          The secret needs to be in the same namespace as the AlertmanagerConfig
+                                          object and accessible by the Prometheus Operator.
                                         properties:
                                           key:
                                             description: The key of the secret to
@@ -3531,10 +3508,10 @@ spec:
                                               key.
                                             type: string
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
                                             description: Specify whether the Secret
@@ -3574,10 +3551,9 @@ spec:
                                         description: The HTTP client's configuration.
                                         properties:
                                           authorization:
-                                            description: Authorization header configuration
-                                              for the client. This is mutually exclusive
-                                              with BasicAuth and is only available
-                                              starting from Alertmanager v0.22+.
+                                            description: |-
+                                              Authorization header configuration for the client.
+                                              This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
                                             properties:
                                               credentials:
                                                 description: The secret's key that
@@ -3590,10 +3566,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -3604,21 +3580,20 @@ spec:
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               type:
-                                                description: Set the authentication
-                                                  type. Defaults to Bearer, Basic
-                                                  will cause an error
+                                                description: |-
+                                                  Set the authentication type. Defaults to Bearer, Basic will cause an
+                                                  error
                                                 type: string
                                             type: object
                                           basicAuth:
-                                            description: BasicAuth for the client.
-                                              This is mutually exclusive with Authorization.
-                                              If both are defined, BasicAuth takes
-                                              precedence.
+                                            description: |-
+                                              BasicAuth for the client.
+                                              This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
                                             properties:
                                               password:
-                                                description: The secret in the service
-                                                  monitor namespace that contains
-                                                  the password for authentication.
+                                                description: |-
+                                                  The secret in the service monitor namespace that contains the password
+                                                  for authentication.
                                                 properties:
                                                   key:
                                                     description: The key of the secret
@@ -3626,10 +3601,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -3640,9 +3615,9 @@ spec:
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               username:
-                                                description: The secret in the service
-                                                  monitor namespace that contains
-                                                  the username for authentication.
+                                                description: |-
+                                                  The secret in the service monitor namespace that contains the username
+                                                  for authentication.
                                                 properties:
                                                   key:
                                                     description: The key of the secret
@@ -3650,10 +3625,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -3665,12 +3640,11 @@ spec:
                                                 x-kubernetes-map-type: atomic
                                             type: object
                                           bearerTokenSecret:
-                                            description: The secret's key that contains
-                                              the bearer token to be used by the client
-                                              for authentication. The secret needs
-                                              to be in the same namespace as the AlertmanagerConfig
-                                              object and accessible by the Prometheus
-                                              Operator.
+                                            description: |-
+                                              The secret's key that contains the bearer token to be used by the client
+                                              for authentication.
+                                              The secret needs to be in the same namespace as the AlertmanagerConfig
+                                              object and accessible by the Prometheus Operator.
                                             properties:
                                               key:
                                                 description: The key of the secret
@@ -3678,10 +3652,10 @@ spec:
                                                   secret key.
                                                 type: string
                                               name:
-                                                description: 'Name of the referent.
+                                                description: |-
+                                                  Name of the referent.
                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
+                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                 type: string
                                               optional:
                                                 description: Specify whether the Secret
@@ -3712,10 +3686,10 @@ spec:
                                                         description: The key to select.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -3736,10 +3710,10 @@ spec:
                                                           be a valid secret key.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -3761,10 +3735,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -3815,10 +3789,10 @@ spec:
                                                         description: The key to select.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -3839,10 +3813,10 @@ spec:
                                                           be a valid secret key.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -3866,10 +3840,10 @@ spec:
                                                         description: The key to select.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -3890,10 +3864,10 @@ spec:
                                                           be a valid secret key.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -3919,10 +3893,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -3963,18 +3937,17 @@ spec:
                                 webhookConfigs:
                                   description: List of webhook configurations.
                                   items:
-                                    description: WebhookConfig configures notifications
-                                      via a generic receiver supporting the webhook
-                                      payload. See https://prometheus.io/docs/alerting/latest/configuration/#webhook_config
+                                    description: |-
+                                      WebhookConfig configures notifications via a generic receiver supporting the webhook payload.
+                                      See https://prometheus.io/docs/alerting/latest/configuration/#webhook_config
                                     properties:
                                       httpConfig:
                                         description: HTTP client configuration.
                                         properties:
                                           authorization:
-                                            description: Authorization header configuration
-                                              for the client. This is mutually exclusive
-                                              with BasicAuth and is only available
-                                              starting from Alertmanager v0.22+.
+                                            description: |-
+                                              Authorization header configuration for the client.
+                                              This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
                                             properties:
                                               credentials:
                                                 description: The secret's key that
@@ -3987,10 +3960,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -4001,21 +3974,20 @@ spec:
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               type:
-                                                description: Set the authentication
-                                                  type. Defaults to Bearer, Basic
-                                                  will cause an error
+                                                description: |-
+                                                  Set the authentication type. Defaults to Bearer, Basic will cause an
+                                                  error
                                                 type: string
                                             type: object
                                           basicAuth:
-                                            description: BasicAuth for the client.
-                                              This is mutually exclusive with Authorization.
-                                              If both are defined, BasicAuth takes
-                                              precedence.
+                                            description: |-
+                                              BasicAuth for the client.
+                                              This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
                                             properties:
                                               password:
-                                                description: The secret in the service
-                                                  monitor namespace that contains
-                                                  the password for authentication.
+                                                description: |-
+                                                  The secret in the service monitor namespace that contains the password
+                                                  for authentication.
                                                 properties:
                                                   key:
                                                     description: The key of the secret
@@ -4023,10 +3995,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -4037,9 +4009,9 @@ spec:
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               username:
-                                                description: The secret in the service
-                                                  monitor namespace that contains
-                                                  the username for authentication.
+                                                description: |-
+                                                  The secret in the service monitor namespace that contains the username
+                                                  for authentication.
                                                 properties:
                                                   key:
                                                     description: The key of the secret
@@ -4047,10 +4019,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -4062,12 +4034,11 @@ spec:
                                                 x-kubernetes-map-type: atomic
                                             type: object
                                           bearerTokenSecret:
-                                            description: The secret's key that contains
-                                              the bearer token to be used by the client
-                                              for authentication. The secret needs
-                                              to be in the same namespace as the AlertmanagerConfig
-                                              object and accessible by the Prometheus
-                                              Operator.
+                                            description: |-
+                                              The secret's key that contains the bearer token to be used by the client
+                                              for authentication.
+                                              The secret needs to be in the same namespace as the AlertmanagerConfig
+                                              object and accessible by the Prometheus Operator.
                                             properties:
                                               key:
                                                 description: The key of the secret
@@ -4075,10 +4046,10 @@ spec:
                                                   secret key.
                                                 type: string
                                               name:
-                                                description: 'Name of the referent.
+                                                description: |-
+                                                  Name of the referent.
                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
+                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                 type: string
                                               optional:
                                                 description: Specify whether the Secret
@@ -4109,10 +4080,10 @@ spec:
                                                         description: The key to select.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -4133,10 +4104,10 @@ spec:
                                                           be a valid secret key.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -4158,10 +4129,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -4212,10 +4183,10 @@ spec:
                                                         description: The key to select.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -4236,10 +4207,10 @@ spec:
                                                           be a valid secret key.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -4263,10 +4234,10 @@ spec:
                                                         description: The key to select.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -4287,10 +4258,10 @@ spec:
                                                           be a valid secret key.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -4316,10 +4287,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -4347,18 +4318,17 @@ spec:
                                           resolved alerts.
                                         type: boolean
                                       url:
-                                        description: The URL to send HTTP POST requests
-                                          to. `urlSecret` takes precedence over `url`.
-                                          One of `urlSecret` and `url` should be defined.
+                                        description: |-
+                                          The URL to send HTTP POST requests to. `urlSecret` takes precedence over
+                                          `url`. One of `urlSecret` and `url` should be defined.
                                         type: string
                                       urlSecret:
-                                        description: The secret's key that contains
-                                          the webhook URL to send HTTP requests to.
-                                          `urlSecret` takes precedence over `url`.
-                                          One of `urlSecret` and `url` should be defined.
-                                          The secret needs to be in the same namespace
-                                          as the AlertmanagerConfig object and accessible
-                                          by the Prometheus Operator.
+                                        description: |-
+                                          The secret's key that contains the webhook URL to send HTTP requests to.
+                                          `urlSecret` takes precedence over `url`. One of `urlSecret` and `url`
+                                          should be defined.
+                                          The secret needs to be in the same namespace as the AlertmanagerConfig
+                                          object and accessible by the Prometheus Operator.
                                         properties:
                                           key:
                                             description: The key of the secret to
@@ -4366,10 +4336,10 @@ spec:
                                               key.
                                             type: string
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
                                             description: Specify whether the Secret
@@ -4384,17 +4354,17 @@ spec:
                                 wechatConfigs:
                                   description: List of WeChat configurations.
                                   items:
-                                    description: WeChatConfig configures notifications
-                                      via WeChat. See https://prometheus.io/docs/alerting/latest/configuration/#wechat_config
+                                    description: |-
+                                      WeChatConfig configures notifications via WeChat.
+                                      See https://prometheus.io/docs/alerting/latest/configuration/#wechat_config
                                     properties:
                                       agentID:
                                         type: string
                                       apiSecret:
-                                        description: The secret's key that contains
-                                          the WeChat API key. The secret needs to
-                                          be in the same namespace as the AlertmanagerConfig
-                                          object and accessible by the Prometheus
-                                          Operator.
+                                        description: |-
+                                          The secret's key that contains the WeChat API key.
+                                          The secret needs to be in the same namespace as the AlertmanagerConfig
+                                          object and accessible by the Prometheus Operator.
                                         properties:
                                           key:
                                             description: The key of the secret to
@@ -4402,10 +4372,10 @@ spec:
                                               key.
                                             type: string
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
                                             description: Specify whether the Secret
@@ -4425,10 +4395,9 @@ spec:
                                         description: HTTP client configuration.
                                         properties:
                                           authorization:
-                                            description: Authorization header configuration
-                                              for the client. This is mutually exclusive
-                                              with BasicAuth and is only available
-                                              starting from Alertmanager v0.22+.
+                                            description: |-
+                                              Authorization header configuration for the client.
+                                              This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
                                             properties:
                                               credentials:
                                                 description: The secret's key that
@@ -4441,10 +4410,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -4455,21 +4424,20 @@ spec:
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               type:
-                                                description: Set the authentication
-                                                  type. Defaults to Bearer, Basic
-                                                  will cause an error
+                                                description: |-
+                                                  Set the authentication type. Defaults to Bearer, Basic will cause an
+                                                  error
                                                 type: string
                                             type: object
                                           basicAuth:
-                                            description: BasicAuth for the client.
-                                              This is mutually exclusive with Authorization.
-                                              If both are defined, BasicAuth takes
-                                              precedence.
+                                            description: |-
+                                              BasicAuth for the client.
+                                              This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
                                             properties:
                                               password:
-                                                description: The secret in the service
-                                                  monitor namespace that contains
-                                                  the password for authentication.
+                                                description: |-
+                                                  The secret in the service monitor namespace that contains the password
+                                                  for authentication.
                                                 properties:
                                                   key:
                                                     description: The key of the secret
@@ -4477,10 +4445,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -4491,9 +4459,9 @@ spec:
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               username:
-                                                description: The secret in the service
-                                                  monitor namespace that contains
-                                                  the username for authentication.
+                                                description: |-
+                                                  The secret in the service monitor namespace that contains the username
+                                                  for authentication.
                                                 properties:
                                                   key:
                                                     description: The key of the secret
@@ -4501,10 +4469,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -4516,12 +4484,11 @@ spec:
                                                 x-kubernetes-map-type: atomic
                                             type: object
                                           bearerTokenSecret:
-                                            description: The secret's key that contains
-                                              the bearer token to be used by the client
-                                              for authentication. The secret needs
-                                              to be in the same namespace as the AlertmanagerConfig
-                                              object and accessible by the Prometheus
-                                              Operator.
+                                            description: |-
+                                              The secret's key that contains the bearer token to be used by the client
+                                              for authentication.
+                                              The secret needs to be in the same namespace as the AlertmanagerConfig
+                                              object and accessible by the Prometheus Operator.
                                             properties:
                                               key:
                                                 description: The key of the secret
@@ -4529,10 +4496,10 @@ spec:
                                                   secret key.
                                                 type: string
                                               name:
-                                                description: 'Name of the referent.
+                                                description: |-
+                                                  Name of the referent.
                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
+                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                 type: string
                                               optional:
                                                 description: Specify whether the Secret
@@ -4563,10 +4530,10 @@ spec:
                                                         description: The key to select.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -4587,10 +4554,10 @@ spec:
                                                           be a valid secret key.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -4612,10 +4579,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -4666,10 +4633,10 @@ spec:
                                                         description: The key to select.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -4690,10 +4657,10 @@ spec:
                                                           be a valid secret key.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -4717,10 +4684,10 @@ spec:
                                                         description: The key to select.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -4741,10 +4708,10 @@ spec:
                                                           be a valid secret key.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -4770,10 +4737,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -4812,10 +4779,10 @@ spec:
                               type: object
                             type: array
                           route:
-                            description: The Alertmanager route definition for alerts
-                              matching the resource's namespace. If present, it will
-                              be added to the generated Alertmanager configuration
-                              as a first-level route.
+                            description: |-
+                              The Alertmanager route definition for alerts matching the resource's
+                              namespace. If present, it will be added to the generated Alertmanager
+                              configuration as a first-level route.
                             properties:
                               activeTimeIntervals:
                                 description: ActiveTimeIntervals is a list of MuteTimeInterval
@@ -4824,43 +4791,45 @@ spec:
                                   type: string
                                 type: array
                               continue:
-                                description: Boolean indicating whether an alert should
-                                  continue matching subsequent sibling nodes. It will
-                                  always be overridden to true for the first-level
+                                description: |-
+                                  Boolean indicating whether an alert should continue matching subsequent
+                                  sibling nodes. It will always be overridden to true for the first-level
                                   route by the Prometheus operator.
                                 type: boolean
                               groupBy:
-                                description: List of labels to group by. Labels must
-                                  not be repeated (unique list). Special label "..."
-                                  (aggregate by all possible labels), if provided,
-                                  must be the only element in the list.
+                                description: |-
+                                  List of labels to group by.
+                                  Labels must not be repeated (unique list).
+                                  Special label "..." (aggregate by all possible labels), if provided, must be the only element in the list.
                                 items:
                                   type: string
                                 type: array
                               groupInterval:
-                                description: 'How long to wait before sending an updated
-                                  notification. Must match the regular expression`^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$`
-                                  Example: "5m"'
+                                description: |-
+                                  How long to wait before sending an updated notification.
+                                  Must match the regular expression`^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$`
+                                  Example: "5m"
                                 type: string
                               groupWait:
-                                description: 'How long to wait before sending the
-                                  initial notification. Must match the regular expression`^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$`
-                                  Example: "30s"'
+                                description: |-
+                                  How long to wait before sending the initial notification.
+                                  Must match the regular expression`^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$`
+                                  Example: "30s"
                                 type: string
                               matchers:
-                                description: 'List of matchers that the alert''s labels
-                                  should match. For the first level route, the operator
-                                  removes any existing equality and regexp matcher
-                                  on the `namespace` label and adds a `namespace:
-                                  <object namespace>` matcher.'
+                                description: |-
+                                  List of matchers that the alert's labels should match. For the first
+                                  level route, the operator removes any existing equality and regexp
+                                  matcher on the `namespace` label and adds a `namespace: <object
+                                  namespace>` matcher.
                                 items:
                                   description: Matcher defines how to match on alert's
                                     labels.
                                   properties:
                                     matchType:
-                                      description: Match operation available with
-                                        AlertManager >= v0.22.0 and takes precedence
-                                        over Regex (deprecated) if non-empty.
+                                      description: |-
+                                        Match operation available with AlertManager >= v0.22.0 and
+                                        takes precedence over Regex (deprecated) if non-empty.
                                       enum:
                                       - '!='
                                       - "="
@@ -4872,10 +4841,9 @@ spec:
                                       minLength: 1
                                       type: string
                                     regex:
-                                      description: Whether to match on equality (false)
-                                        or regular-expression (true). Deprecated as
-                                        of AlertManager >= v0.22.0 where a user should
-                                        use MatchType instead.
+                                      description: |-
+                                        Whether to match on equality (false) or regular-expression (true).
+                                        Deprecated as of AlertManager >= v0.22.0 where a user should use MatchType instead.
                                       type: boolean
                                     value:
                                       description: Label value to match.
@@ -4885,29 +4853,28 @@ spec:
                                   type: object
                                 type: array
                               muteTimeIntervals:
-                                description: 'Note: this comment applies to the field
-                                  definition above but appears below otherwise it
-                                  gets included in the generated manifest. CRD schema
-                                  doesn''t support self-referential types for now
-                                  (see https://github.com/kubernetes/kubernetes/issues/62872).
-                                  We have to use an alternative type to circumvent
-                                  the limitation. The downside is that the Kube API
-                                  can''t validate the data beyond the fact that it
-                                  is a valid JSON representation. MuteTimeIntervals
-                                  is a list of MuteTimeInterval names that will mute
-                                  this route when matched,'
+                                description: |-
+                                  Note: this comment applies to the field definition above but appears
+                                  below otherwise it gets included in the generated manifest.
+                                  CRD schema doesn't support self-referential types for now (see
+                                  https://github.com/kubernetes/kubernetes/issues/62872). We have to use
+                                  an alternative type to circumvent the limitation. The downside is that
+                                  the Kube API can't validate the data beyond the fact that it is a valid
+                                  JSON representation.
+                                  MuteTimeIntervals is a list of MuteTimeInterval names that will mute this route when matched,
                                 items:
                                   type: string
                                 type: array
                               receiver:
-                                description: Name of the receiver for this route.
-                                  If not empty, it should be listed in the `receivers`
-                                  field.
+                                description: |-
+                                  Name of the receiver for this route. If not empty, it should be listed in
+                                  the `receivers` field.
                                 type: string
                               repeatInterval:
-                                description: 'How long to wait before repeating the
-                                  last notification. Must match the regular expression`^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$`
-                                  Example: "4h"'
+                                description: |-
+                                  How long to wait before repeating the last notification.
+                                  Must match the regular expression`^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$`
+                                  Example: "4h"
                                 type: string
                               routes:
                                 description: Child routes.
@@ -4926,55 +4893,52 @@ spec:
                       ipFilter:
                         default:
                         - 0.0.0.0/0
-                        description: IPFilter is a list of allowed IPv4 CIDR ranges
-                          that can access the service. If no IP Filter is set, you
-                          may not be able to reach the service. A value of `0.0.0.0/0`
-                          will open the service to all addresses on the public internet.
+                        description: |-
+                          IPFilter is a list of allowed IPv4 CIDR ranges that can access the service.
+                          If no IP Filter is set, you may not be able to reach the service.
+                          A value of `0.0.0.0/0` will open the service to all addresses on the public internet.
                         items:
                           type: string
                         type: array
                       serviceType:
                         default: ClusterIP
-                        description: 'ServiceType defines the type of the service.
-                          Possible enum values: - `"ClusterIP"` indicates that the
-                          service is only reachable from within the cluster. - `"LoadBalancer"`
-                          indicates that the service is reachable from the public
-                          internet via dedicated Ipv4 address.'
+                        description: |-
+                          ServiceType defines the type of the service.
+                          Possible enum values:
+                            - `"ClusterIP"` indicates that the service is only reachable from within the cluster.
+                            - `"LoadBalancer"` indicates that the service is reachable from the public internet via dedicated Ipv4 address.
                         enum:
                         - ClusterIP
                         - LoadBalancer
                         type: string
                     type: object
                   replication:
-                    description: "This section allows to configure Postgres replication
-                      mode and HA roles groups. \n The main replication group is implicit
-                      and contains the total number of instances less the sum of all
-                      instances in other replication groups."
+                    description: |-
+                      This section allows to configure Postgres replication mode and HA roles groups.
+
+
+                      The main replication group is implicit and contains the total number of instances less the sum of all instances in other replication groups.
                     properties:
                       mode:
-                        description: "Mode defines the replication mode applied to
-                          the whole cluster. Possible values are: \"async\"(default),
-                          \"sync\", and \"strict-sync\" \n \"async\": When in asynchronous
-                          mode the cluster is allowed to lose some committed transactions.
-                          When the primary server fails or becomes unavailable for
-                          any other reason a sufficiently healthy standby will automatically
-                          be promoted to primary. Any transactions that have not been
-                          replicated to that standby remain in a “forked timeline”
-                          on the primary, and are effectively unrecoverable \n \"sync\":
-                          When in synchronous mode a standby will not be promoted
-                          unless it is certain that the standby contains all transactions
-                          that may have returned a successful commit status to client.
-                          This means that the system may be unavailable for writes
-                          even though some servers are available. \n \"strict-sync\":
-                          When it is absolutely necessary to guarantee that each write
-                          is stored durably on at least two nodes, use the strict
-                          synchronous mode. This mode prevents synchronous replication
-                          to be switched off on the primary when no synchronous standby
-                          candidates are available. As a downside, the primary will
-                          not be available for writes, blocking all client write requests
-                          until at least one synchronous replica comes up. \n NOTE:
-                          We recommend to always use three intances when setting the
-                          mode to \"strict-sync\"."
+                        description: |-
+                          Mode defines the replication mode applied to the whole cluster. Possible values are: "async"(default), "sync", and "strict-sync"
+
+
+                          "async": When in asynchronous mode the cluster is allowed to lose some committed transactions.
+                          When the primary server fails or becomes unavailable for any other reason a sufficiently healthy standby will automatically be promoted to primary.
+                          Any transactions that have not been replicated to that standby remain in a “forked timeline” on the primary, and are effectively unrecoverable
+
+
+                          "sync": When in synchronous mode a standby will not be promoted unless it is certain that the standby contains all transactions that may have returned a successful commit status to client.
+                           This means that the system may be unavailable for writes even though some servers are available.
+
+
+                          "strict-sync": When it is absolutely necessary to guarantee that each write is stored durably on at least two nodes, use the strict synchronous mode.
+                          This mode prevents synchronous replication to be switched off on the primary when no synchronous standby candidates are available.
+                          As a downside, the primary will not be available for writes, blocking all client write requests until at least one synchronous replica comes up.
+
+
+                          NOTE: We recommend to always use three intances when setting the mode to "strict-sync".
                         enum:
                         - async
                         - sync
@@ -4990,15 +4954,14 @@ spec:
                           you want to restore.
                         type: string
                       claimName:
-                        description: ClaimName specifies the name of the instance
-                          you want to restore from. The claim has to be in the same
-                          namespace as this new instance.
+                        description: |-
+                          ClaimName specifies the name of the instance you want to restore from.
+                          The claim has to be in the same namespace as this new instance.
                         type: string
                       recoveryTimeStamp:
-                        description: RecoveryTimeStamp an ISO 8601 date, that holds
-                          UTC date indicating at which point-in-time the database
-                          has to be restored. This is optional and if no PIT recovery
-                          is required, it can be left empty.
+                        description: |-
+                          RecoveryTimeStamp an ISO 8601 date, that holds UTC date indicating at which point-in-time the database has to be restored.
+                          This is optional and if no PIT recovery is required, it can be left empty.
                         pattern: ^(?:[1-9]\d{3}-(?:(?:0[1-9]|1[0-2])-(?:0[1-9]|1\d|2[0-8])|(?:0[13-9]|1[0-2])-(?:29|30)|(?:0[13578]|1[02])-31)|(?:[1-9]\d(?:0[48]|[2468][048]|[13579][26])|(?:[2468][048]|[13579][26])00)-02-29)T(?:[01]\d|2[0-3]):[0-5]\d:[0-5]\d(?:Z|[+-][01]\d:[0-5]\d)$
                         type: string
                     type: object
@@ -5024,16 +4987,17 @@ spec:
                             of a single extension.
                           properties:
                             name:
-                              description: Name is the name of the extension to enable.
+                              description: |-
+                                Name is the name of the extension to enable.
                                 For an extensive list, please consult https://stackgres.io/doc/latest/intro/extensions/
                               type: string
                           type: object
                         type: array
                       majorVersion:
                         default: "15"
-                        description: MajorVersion contains supported version of PostgreSQL.
-                          Multiple versions are supported. The latest version "15"
-                          is the default version.
+                        description: |-
+                          MajorVersion contains supported version of PostgreSQL.
+                          Multiple versions are supported. The latest version "15" is the default version.
                         enum:
                         - "12"
                         - "13"
@@ -5045,27 +5009,27 @@ spec:
                           to the pgBouncer instance.
                         properties:
                           databases:
-                            description: "The `pgbouncer.ini` (Section [databases])
-                              parameters the configuration contains, represented as
-                              an object where the keys are valid names for the `pgbouncer.ini`
-                              configuration file parameters. \n Check [pgbouncer configuration](https://www.pgbouncer.org/config.html#section-databases)
-                              for more information about supported parameters."
+                            description: |-
+                              The `pgbouncer.ini` (Section [databases]) parameters the configuration contains, represented as an object where the keys are valid names for the `pgbouncer.ini` configuration file parameters.
+
+
+                              Check [pgbouncer configuration](https://www.pgbouncer.org/config.html#section-databases) for more information about supported parameters.
                             type: object
                             x-kubernetes-preserve-unknown-fields: true
                           pgbouncer:
-                            description: "The `pgbouncer.ini` (Section [pgbouncer])
-                              parameters the configuration contains, represented as
-                              an object where the keys are valid names for the `pgbouncer.ini`
-                              configuration file parameters. \n Check [pgbouncer configuration](https://www.pgbouncer.org/config.html#generic-settings)
-                              for more information about supported parameters"
+                            description: |-
+                              The `pgbouncer.ini` (Section [pgbouncer]) parameters the configuration contains, represented as an object where the keys are valid names for the `pgbouncer.ini` configuration file parameters.
+
+
+                              Check [pgbouncer configuration](https://www.pgbouncer.org/config.html#generic-settings) for more information about supported parameters
                             type: object
                             x-kubernetes-preserve-unknown-fields: true
                           users:
-                            description: "The `pgbouncer.ini` (Section [users]) parameters
-                              the configuration contains, represented as an object
-                              where the keys are valid names for the `pgbouncer.ini`
-                              configuration file parameters. \n Check [pgbouncer configuration](https://www.pgbouncer.org/config.html#section-users)
-                              for more information about supported parameters."
+                            description: |-
+                              The `pgbouncer.ini` (Section [users]) parameters the configuration contains, represented as an object where the keys are valid names for the `pgbouncer.ini` configuration file parameters.
+
+
+                              Check [pgbouncer configuration](https://www.pgbouncer.org/config.html#section-users) for more information about supported parameters.
                             type: object
                             x-kubernetes-preserve-unknown-fields: true
                         type: object
@@ -5123,13 +5087,11 @@ spec:
                     properties:
                       type:
                         default: Immediate
-                        description: 'Type indicates the type of the UpdateStrategy.
-                          Default is OnRestart. Possible enum values: - `"OnRestart"`
-                          indicates that the changes to the spec will only be applied
-                          once the instance is restarted by other means, most likely
-                          during maintenance. - `"Immediate"` indicates that update
-                          will be applied to the instance as soon as the spec changes.
-                          Please be aware that this might lead to short downtime.'
+                        description: |-
+                          Type indicates the type of the UpdateStrategy. Default is OnRestart.
+                          Possible enum values:
+                            - `"OnRestart"` indicates that the changes to the spec will only be applied once the instance is restarted by other means, most likely during maintenance.
+                            - `"Immediate"` indicates that update will be applied to the instance as soon as the spec changes. Please be aware that this might lead to short downtime.
                         enum:
                         - Immediate
                         - OnRestart
@@ -5139,9 +5101,10 @@ spec:
               providerConfigRef:
                 default:
                   name: default
-                description: ProviderConfigReference specifies how the provider that
-                  will be used to create, observe, update, and delete this managed
-                  resource should be configured.
+                description: |-
+                  ProviderConfigReference specifies how the provider that will be used to
+                  create, observe, update, and delete this managed resource should be
+                  configured.
                 properties:
                   name:
                     description: Name of the referenced object.
@@ -5151,21 +5114,21 @@ spec:
                     properties:
                       resolution:
                         default: Required
-                        description: Resolution specifies whether resolution of this
-                          reference is required. The default is 'Required', which
-                          means the reconcile will fail if the reference cannot be
-                          resolved. 'Optional' means this reference will be a no-op
-                          if it cannot be resolved.
+                        description: |-
+                          Resolution specifies whether resolution of this reference is required.
+                          The default is 'Required', which means the reconcile will fail if the
+                          reference cannot be resolved. 'Optional' means this reference will be
+                          a no-op if it cannot be resolved.
                         enum:
                         - Required
                         - Optional
                         type: string
                       resolve:
-                        description: Resolve specifies when this reference should
-                          be resolved. The default is 'IfNotPresent', which will attempt
-                          to resolve the reference only when the corresponding field
-                          is not present. Use 'Always' to resolve the reference on
-                          every reconcile.
+                        description: |-
+                          Resolve specifies when this reference should be resolved. The default
+                          is 'IfNotPresent', which will attempt to resolve the reference only when
+                          the corresponding field is not present. Use 'Always' to resolve the
+                          reference on every reconcile.
                         enum:
                         - Always
                         - IfNotPresent
@@ -5175,17 +5138,19 @@ spec:
                 - name
                 type: object
               publishConnectionDetailsTo:
-                description: PublishConnectionDetailsTo specifies the connection secret
-                  config which contains a name, metadata and a reference to secret
-                  store config to which any connection details for this managed resource
-                  should be written. Connection details frequently include the endpoint,
-                  username, and password required to connect to the managed resource.
+                description: |-
+                  PublishConnectionDetailsTo specifies the connection secret config which
+                  contains a name, metadata and a reference to secret store config to
+                  which any connection details for this managed resource should be written.
+                  Connection details frequently include the endpoint, username,
+                  and password required to connect to the managed resource.
                 properties:
                   configRef:
                     default:
                       name: default
-                    description: SecretStoreConfigRef specifies which secret store
-                      config should be used for this ConnectionSecret.
+                    description: |-
+                      SecretStoreConfigRef specifies which secret store config should be used
+                      for this ConnectionSecret.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -5195,21 +5160,21 @@ spec:
                         properties:
                           resolution:
                             default: Required
-                            description: Resolution specifies whether resolution of
-                              this reference is required. The default is 'Required',
-                              which means the reconcile will fail if the reference
-                              cannot be resolved. 'Optional' means this reference
-                              will be a no-op if it cannot be resolved.
+                            description: |-
+                              Resolution specifies whether resolution of this reference is required.
+                              The default is 'Required', which means the reconcile will fail if the
+                              reference cannot be resolved. 'Optional' means this reference will be
+                              a no-op if it cannot be resolved.
                             enum:
                             - Required
                             - Optional
                             type: string
                           resolve:
-                            description: Resolve specifies when this reference should
-                              be resolved. The default is 'IfNotPresent', which will
-                              attempt to resolve the reference only when the corresponding
-                              field is not present. Use 'Always' to resolve the reference
-                              on every reconcile.
+                            description: |-
+                              Resolve specifies when this reference should be resolved. The default
+                              is 'IfNotPresent', which will attempt to resolve the reference only when
+                              the corresponding field is not present. Use 'Always' to resolve the
+                              reference on every reconcile.
                             enum:
                             - Always
                             - IfNotPresent
@@ -5224,21 +5189,22 @@ spec:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Annotations are the annotations to be added to
-                          connection secret. - For Kubernetes secrets, this will be
-                          used as "metadata.annotations". - It is up to Secret Store
-                          implementation for others store types.
+                        description: |-
+                          Annotations are the annotations to be added to connection secret.
+                          - For Kubernetes secrets, this will be used as "metadata.annotations".
+                          - It is up to Secret Store implementation for others store types.
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Labels are the labels/tags to be added to connection
-                          secret. - For Kubernetes secrets, this will be used as "metadata.labels".
-                          - It is up to Secret Store implementation for others store
-                          types.
+                        description: |-
+                          Labels are the labels/tags to be added to connection secret.
+                          - For Kubernetes secrets, this will be used as "metadata.labels".
+                          - It is up to Secret Store implementation for others store types.
                         type: object
                       type:
-                        description: Type is the SecretType for the connection secret.
+                        description: |-
+                          Type is the SecretType for the connection secret.
                           - Only valid for Kubernetes Secret Stores.
                         type: string
                     type: object
@@ -5249,14 +5215,15 @@ spec:
                 - name
                 type: object
               writeConnectionSecretToRef:
-                description: WriteConnectionSecretToReference specifies the namespace
-                  and name of a Secret to which any connection details for this managed
-                  resource should be written. Connection details frequently include
-                  the endpoint, username, and password required to connect to the
-                  managed resource. This field is planned to be replaced in a future
-                  release in favor of PublishConnectionDetailsTo. Currently, both
-                  could be set independently and connection details would be published
-                  to both without affecting each other.
+                description: |-
+                  WriteConnectionSecretToReference specifies the namespace and name of a
+                  Secret to which any connection details for this managed resource should
+                  be written. Connection details frequently include the endpoint, username,
+                  and password required to connect to the managed resource.
+                  This field is planned to be replaced in a future release in favor of
+                  PublishConnectionDetailsTo. Currently, both could be set independently
+                  and connection details would be published to both without affecting
+                  each other.
                 properties:
                   name:
                     description: Name of the secret.
@@ -5285,11 +5252,9 @@ spec:
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: ObservedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
+                      description: |-
+                        ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
@@ -5319,13 +5284,15 @@ spec:
                   description: A Condition that may apply to a resource.
                   properties:
                     lastTransitionTime:
-                      description: LastTransitionTime is the last time this condition
-                        transitioned from one status to another.
+                      description: |-
+                        LastTransitionTime is the last time this condition transitioned from one
+                        status to another.
                       format: date-time
                       type: string
                     message:
-                      description: A Message containing details about this condition's
-                        last transition from one status to another, if any.
+                      description: |-
+                        A Message containing details about this condition's last transition from
+                        one status to another, if any.
                       type: string
                     reason:
                       description: A Reason for this condition's last transition from
@@ -5336,8 +5303,9 @@ spec:
                         False, or Unknown?
                       type: string
                     type:
-                      description: Type of this condition. At most one of each condition
-                        type may apply to a resource at any point in time.
+                      description: |-
+                        Type of this condition. At most one of each condition type may apply to
+                        a resource at any point in time.
                       type: string
                   required:
                   - lastTransitionTime
@@ -5371,11 +5339,9 @@ spec:
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: ObservedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
+                      description: |-
+                        ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
@@ -5413,11 +5379,9 @@ spec:
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: ObservedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
+                      description: |-
+                        ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
@@ -5455,11 +5419,9 @@ spec:
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: ObservedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
+                      description: |-
+                        ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
@@ -5497,11 +5459,9 @@ spec:
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: ObservedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
+                      description: |-
+                        ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
@@ -5539,11 +5499,9 @@ spec:
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: ObservedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
+                      description: |-
+                        ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
@@ -5581,11 +5539,9 @@ spec:
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: ObservedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
+                      description: |-
+                        ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
@@ -5623,11 +5579,9 @@ spec:
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: ObservedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
+                      description: |-
+                        ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
@@ -5667,11 +5621,9 @@ spec:
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: ObservedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
+                      description: |-
+                        ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
@@ -5709,11 +5661,9 @@ spec:
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: ObservedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
+                      description: |-
+                        ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
@@ -5738,8 +5688,9 @@ spec:
                   type: object
                 type: array
               schedules:
-                description: Schedules keeps track of random generated schedules,
-                  is overwriten by schedules set in the service's spec.
+                description: |-
+                  Schedules keeps track of random generated schedules, is overwriten by
+                  schedules set in the service's spec.
                 properties:
                   backup:
                     description: Backup keeps track of the backup schedule.
@@ -5748,9 +5699,9 @@ spec:
                     description: Maintenance keeps track of the maintenance schedule.
                     properties:
                       dayOfWeek:
-                        description: DayOfWeek specifies at which weekday the maintenance
-                          is held place. Allowed values are [monday, tuesday, wednesday,
-                          thursday, friday, saturday, sunday]
+                        description: |-
+                          DayOfWeek specifies at which weekday the maintenance is held place.
+                          Allowed values are [monday, tuesday, wednesday, thursday, friday, saturday, sunday]
                         enum:
                         - monday
                         - tuesday
@@ -5761,8 +5712,9 @@ spec:
                         - sunday
                         type: string
                       timeOfDay:
-                        description: 'TimeOfDay for installing updates in UTC. Format:
-                          "hh:mm:ss".'
+                        description: |-
+                          TimeOfDay for installing updates in UTC.
+                          Format: "hh:mm:ss".
                         pattern: ^([0-1]?[0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9])$
                         type: string
                     type: object
@@ -5781,11 +5733,9 @@ spec:
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: ObservedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
+                      description: |-
+                        ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer

--- a/crds/vshn.appcat.vshn.io_xvshnredis.yaml
+++ b/crds/vshn.appcat.vshn.io_xvshnredis.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: xvshnredis.vshn.appcat.vshn.io
 spec:
   group: vshn.appcat.vshn.io
@@ -20,14 +20,19 @@ spec:
         description: XVSHNRedis represents the internal composite of this claim
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -36,13 +41,14 @@ spec:
             properties:
               deletionPolicy:
                 default: Delete
-                description: 'DeletionPolicy specifies what will happen to the underlying
-                  external when this managed resource is deleted - either "Delete"
-                  or "Orphan" the external resource. This field is planned to be deprecated
-                  in favor of the ManagementPolicies field in a future release. Currently,
-                  both could be set independently and non-default values would be
-                  honored if the feature flag is enabled. See the design doc for more
-                  information: https://github.com/crossplane/crossplane/blob/499895a25d1a1a0ba1604944ef98ac7a1a71f197/design/design-doc-observe-only-resources.md?plain=1#L223'
+                description: |-
+                  DeletionPolicy specifies what will happen to the underlying external
+                  when this managed resource is deleted - either "Delete" or "Orphan" the
+                  external resource.
+                  This field is planned to be deprecated in favor of the ManagementPolicies
+                  field in a future release. Currently, both could be set independently and
+                  non-default values would be honored if the feature flag is enabled.
+                  See the design doc for more information: https://github.com/crossplane/crossplane/blob/499895a25d1a1a0ba1604944ef98ac7a1a71f197/design/design-doc-observe-only-resources.md?plain=1#L223
                 enum:
                 - Orphan
                 - Delete
@@ -50,19 +56,21 @@ spec:
               managementPolicies:
                 default:
                 - '*'
-                description: 'THIS IS A BETA FIELD. It is on by default but can be
-                  opted out through a Crossplane feature flag. ManagementPolicies
-                  specify the array of actions Crossplane is allowed to take on the
-                  managed and external resources. This field is planned to replace
-                  the DeletionPolicy field in a future release. Currently, both could
-                  be set independently and non-default values would be honored if
-                  the feature flag is enabled. If both are custom, the DeletionPolicy
-                  field will be ignored. See the design doc for more information:
-                  https://github.com/crossplane/crossplane/blob/499895a25d1a1a0ba1604944ef98ac7a1a71f197/design/design-doc-observe-only-resources.md?plain=1#L223
-                  and this one: https://github.com/crossplane/crossplane/blob/444267e84783136daa93568b364a5f01228cacbe/design/one-pager-ignore-changes.md'
+                description: |-
+                  THIS IS A BETA FIELD. It is on by default but can be opted out
+                  through a Crossplane feature flag.
+                  ManagementPolicies specify the array of actions Crossplane is allowed to
+                  take on the managed and external resources.
+                  This field is planned to replace the DeletionPolicy field in a future
+                  release. Currently, both could be set independently and non-default
+                  values would be honored if the feature flag is enabled. If both are
+                  custom, the DeletionPolicy field will be ignored.
+                  See the design doc for more information: https://github.com/crossplane/crossplane/blob/499895a25d1a1a0ba1604944ef98ac7a1a71f197/design/design-doc-observe-only-resources.md?plain=1#L223
+                  and this one: https://github.com/crossplane/crossplane/blob/444267e84783136daa93568b364a5f01228cacbe/design/one-pager-ignore-changes.md
                 items:
-                  description: A ManagementAction represents an action that the Crossplane
-                    controllers can take on an external resource.
+                  description: |-
+                    A ManagementAction represents an action that the Crossplane controllers
+                    can take on an external resource.
                   enum:
                   - Observe
                   - Create
@@ -108,9 +116,9 @@ spec:
                       of an instance.
                     properties:
                       dayOfWeek:
-                        description: DayOfWeek specifies at which weekday the maintenance
-                          is held place. Allowed values are [monday, tuesday, wednesday,
-                          thursday, friday, saturday, sunday]
+                        description: |-
+                          DayOfWeek specifies at which weekday the maintenance is held place.
+                          Allowed values are [monday, tuesday, wednesday, thursday, friday, saturday, sunday]
                         enum:
                         - monday
                         - tuesday
@@ -121,8 +129,9 @@ spec:
                         - sunday
                         type: string
                       timeOfDay:
-                        description: 'TimeOfDay for installing updates in UTC. Format:
-                          "hh:mm:ss".'
+                        description: |-
+                          TimeOfDay for installing updates in UTC.
+                          Format: "hh:mm:ss".
                         pattern: ^([0-1]?[0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9])$
                         type: string
                     type: object
@@ -130,46 +139,50 @@ spec:
                     description: Monitoring contains settings to control monitoring.
                     properties:
                       alertmanagerConfigRef:
-                        description: AlertmanagerConfigRef contains the name of the
-                          AlertmanagerConfig that should be copied over to the namespace
-                          of the instance.
+                        description: |-
+                          AlertmanagerConfigRef contains the name of the AlertmanagerConfig that should be copied over to the
+                          namespace of the instance.
                         type: string
                       alertmanagerConfigSecretRef:
-                        description: AlertmanagerConfigSecretRef contains the name
-                          of the secret that is used in the referenced AlertmanagerConfig
+                        description: |-
+                          AlertmanagerConfigSecretRef contains the name of the secret that is used
+                          in the referenced AlertmanagerConfig
                         type: string
                       alertmanagerConfigTemplate:
-                        description: AlertmanagerConfigSpecTemplate takes an AlertmanagerConfigSpec
-                          object. This takes precedence over the AlertmanagerConfigRef.
+                        description: |-
+                          AlertmanagerConfigSpecTemplate takes an AlertmanagerConfigSpec object.
+                          This takes precedence over the AlertmanagerConfigRef.
                         properties:
                           inhibitRules:
-                            description: List of inhibition rules. The rules will
-                              only apply to alerts matching the resource's namespace.
+                            description: |-
+                              List of inhibition rules. The rules will only apply to alerts matching
+                              the resource's namespace.
                             items:
-                              description: InhibitRule defines an inhibition rule
-                                that allows to mute alerts when other alerts are already
-                                firing. See https://prometheus.io/docs/alerting/latest/configuration/#inhibit_rule
+                              description: |-
+                                InhibitRule defines an inhibition rule that allows to mute alerts when other
+                                alerts are already firing.
+                                See https://prometheus.io/docs/alerting/latest/configuration/#inhibit_rule
                               properties:
                                 equal:
-                                  description: Labels that must have an equal value
-                                    in the source and target alert for the inhibition
-                                    to take effect.
+                                  description: |-
+                                    Labels that must have an equal value in the source and target alert for
+                                    the inhibition to take effect.
                                   items:
                                     type: string
                                   type: array
                                 sourceMatch:
-                                  description: Matchers for which one or more alerts
-                                    have to exist for the inhibition to take effect.
-                                    The operator enforces that the alert matches the
+                                  description: |-
+                                    Matchers for which one or more alerts have to exist for the inhibition
+                                    to take effect. The operator enforces that the alert matches the
                                     resource's namespace.
                                   items:
                                     description: Matcher defines how to match on alert's
                                       labels.
                                     properties:
                                       matchType:
-                                        description: Match operation available with
-                                          AlertManager >= v0.22.0 and takes precedence
-                                          over Regex (deprecated) if non-empty.
+                                        description: |-
+                                          Match operation available with AlertManager >= v0.22.0 and
+                                          takes precedence over Regex (deprecated) if non-empty.
                                         enum:
                                         - '!='
                                         - "="
@@ -181,10 +194,9 @@ spec:
                                         minLength: 1
                                         type: string
                                       regex:
-                                        description: Whether to match on equality
-                                          (false) or regular-expression (true). Deprecated
-                                          as of AlertManager >= v0.22.0 where a user
-                                          should use MatchType instead.
+                                        description: |-
+                                          Whether to match on equality (false) or regular-expression (true).
+                                          Deprecated as of AlertManager >= v0.22.0 where a user should use MatchType instead.
                                         type: boolean
                                       value:
                                         description: Label value to match.
@@ -194,17 +206,17 @@ spec:
                                     type: object
                                   type: array
                                 targetMatch:
-                                  description: Matchers that have to be fulfilled
-                                    in the alerts to be muted. The operator enforces
-                                    that the alert matches the resource's namespace.
+                                  description: |-
+                                    Matchers that have to be fulfilled in the alerts to be muted. The
+                                    operator enforces that the alert matches the resource's namespace.
                                   items:
                                     description: Matcher defines how to match on alert's
                                       labels.
                                     properties:
                                       matchType:
-                                        description: Match operation available with
-                                          AlertManager >= v0.22.0 and takes precedence
-                                          over Regex (deprecated) if non-empty.
+                                        description: |-
+                                          Match operation available with AlertManager >= v0.22.0 and
+                                          takes precedence over Regex (deprecated) if non-empty.
                                         enum:
                                         - '!='
                                         - "="
@@ -216,10 +228,9 @@ spec:
                                         minLength: 1
                                         type: string
                                       regex:
-                                        description: Whether to match on equality
-                                          (false) or regular-expression (true). Deprecated
-                                          as of AlertManager >= v0.22.0 where a user
-                                          should use MatchType instead.
+                                        description: |-
+                                          Whether to match on equality (false) or regular-expression (true).
+                                          Deprecated as of AlertManager >= v0.22.0 where a user should use MatchType instead.
                                         type: boolean
                                       value:
                                         description: Label value to match.
@@ -269,12 +280,9 @@ spec:
                                       months:
                                         description: Months is a list of MonthRange
                                         items:
-                                          description: MonthRange is an inclusive
-                                            range of months of the year beginning
-                                            in January Months can be specified by
-                                            name (e.g 'January') by numerical month
-                                            (e.g '1') or as an inclusive range (e.g
-                                            'January:March', '1:3', '1:March')
+                                          description: |-
+                                            MonthRange is an inclusive range of months of the year beginning in January
+                                            Months can be specified by name (e.g 'January') by numerical month (e.g '1') or as an inclusive range (e.g 'January:March', '1:3', '1:March')
                                           pattern: ^((?i)january|february|march|april|may|june|july|august|september|october|november|december|[1-12])(?:((:((?i)january|february|march|april|may|june|july|august|september|october|november|december|[1-12]))$)|$)
                                           type: string
                                         type: array
@@ -299,11 +307,9 @@ spec:
                                       weekdays:
                                         description: Weekdays is a list of WeekdayRange
                                         items:
-                                          description: WeekdayRange is an inclusive
-                                            range of days of the week beginning on
-                                            Sunday Days can be specified by name (e.g
-                                            'Sunday') or as an inclusive range (e.g
-                                            'Monday:Friday')
+                                          description: |-
+                                            WeekdayRange is an inclusive range of days of the week beginning on Sunday
+                                            Days can be specified by name (e.g 'Sunday') or as an inclusive range (e.g 'Monday:Friday')
                                           pattern: ^((?i)sun|mon|tues|wednes|thurs|fri|satur)day(?:((:(sun|mon|tues|wednes|thurs|fri|satur)day)$)|$)
                                           type: string
                                         type: array
@@ -335,11 +341,10 @@ spec:
                                         description: The identity to use for authentication.
                                         type: string
                                       authPassword:
-                                        description: The secret's key that contains
-                                          the password to use for authentication.
-                                          The secret needs to be in the same namespace
-                                          as the AlertmanagerConfig object and accessible
-                                          by the Prometheus Operator.
+                                        description: |-
+                                          The secret's key that contains the password to use for authentication.
+                                          The secret needs to be in the same namespace as the AlertmanagerConfig
+                                          object and accessible by the Prometheus Operator.
                                         properties:
                                           key:
                                             description: The key of the secret to
@@ -347,10 +352,10 @@ spec:
                                               key.
                                             type: string
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
                                             description: Specify whether the Secret
@@ -361,11 +366,10 @@ spec:
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       authSecret:
-                                        description: The secret's key that contains
-                                          the CRAM-MD5 secret. The secret needs to
-                                          be in the same namespace as the AlertmanagerConfig
-                                          object and accessible by the Prometheus
-                                          Operator.
+                                        description: |-
+                                          The secret's key that contains the CRAM-MD5 secret.
+                                          The secret needs to be in the same namespace as the AlertmanagerConfig
+                                          object and accessible by the Prometheus Operator.
                                         properties:
                                           key:
                                             description: The key of the secret to
@@ -373,10 +377,10 @@ spec:
                                               key.
                                             type: string
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
                                             description: Specify whether the Secret
@@ -393,9 +397,9 @@ spec:
                                         description: The sender address.
                                         type: string
                                       headers:
-                                        description: Further headers email header
-                                          key/value pairs. Overrides any headers previously
-                                          set by the notification implementation.
+                                        description: |-
+                                          Further headers email header key/value pairs. Overrides any headers
+                                          previously set by the notification implementation.
                                         items:
                                           description: KeyValue defines a (key, value)
                                             tuple.
@@ -420,9 +424,9 @@ spec:
                                         description: The HTML body of the email notification.
                                         type: string
                                       requireTLS:
-                                        description: The SMTP TLS requirement. Note
-                                          that Go does not support unencrypted connections
-                                          to remote SMTP endpoints.
+                                        description: |-
+                                          The SMTP TLS requirement.
+                                          Note that Go does not support unencrypted connections to remote SMTP endpoints.
                                         type: boolean
                                       sendResolved:
                                         description: Whether or not to notify about
@@ -450,10 +454,10 @@ spec:
                                                     description: The key to select.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -474,10 +478,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -500,10 +504,10 @@ spec:
                                                     description: The key to select.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -524,10 +528,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -552,10 +556,10 @@ spec:
                                                   secret key.
                                                 type: string
                                               name:
-                                                description: 'Name of the referent.
+                                                description: |-
+                                                  Name of the referent.
                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
+                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                 type: string
                                               optional:
                                                 description: Specify whether the Secret
@@ -584,19 +588,19 @@ spec:
                                 opsgenieConfigs:
                                   description: List of OpsGenie configurations.
                                   items:
-                                    description: OpsGenieConfig configures notifications
-                                      via OpsGenie. See https://prometheus.io/docs/alerting/latest/configuration/#opsgenie_config
+                                    description: |-
+                                      OpsGenieConfig configures notifications via OpsGenie.
+                                      See https://prometheus.io/docs/alerting/latest/configuration/#opsgenie_config
                                     properties:
                                       actions:
                                         description: Comma separated list of actions
                                           that will be available for the alert.
                                         type: string
                                       apiKey:
-                                        description: The secret's key that contains
-                                          the OpsGenie API key. The secret needs to
-                                          be in the same namespace as the AlertmanagerConfig
-                                          object and accessible by the Prometheus
-                                          Operator.
+                                        description: |-
+                                          The secret's key that contains the OpsGenie API key.
+                                          The secret needs to be in the same namespace as the AlertmanagerConfig
+                                          object and accessible by the Prometheus Operator.
                                         properties:
                                           key:
                                             description: The key of the secret to
@@ -604,10 +608,10 @@ spec:
                                               key.
                                             type: string
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
                                             description: Specify whether the Secret
@@ -653,10 +657,9 @@ spec:
                                         description: HTTP client configuration.
                                         properties:
                                           authorization:
-                                            description: Authorization header configuration
-                                              for the client. This is mutually exclusive
-                                              with BasicAuth and is only available
-                                              starting from Alertmanager v0.22+.
+                                            description: |-
+                                              Authorization header configuration for the client.
+                                              This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
                                             properties:
                                               credentials:
                                                 description: The secret's key that
@@ -669,10 +672,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -683,21 +686,20 @@ spec:
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               type:
-                                                description: Set the authentication
-                                                  type. Defaults to Bearer, Basic
-                                                  will cause an error
+                                                description: |-
+                                                  Set the authentication type. Defaults to Bearer, Basic will cause an
+                                                  error
                                                 type: string
                                             type: object
                                           basicAuth:
-                                            description: BasicAuth for the client.
-                                              This is mutually exclusive with Authorization.
-                                              If both are defined, BasicAuth takes
-                                              precedence.
+                                            description: |-
+                                              BasicAuth for the client.
+                                              This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
                                             properties:
                                               password:
-                                                description: The secret in the service
-                                                  monitor namespace that contains
-                                                  the password for authentication.
+                                                description: |-
+                                                  The secret in the service monitor namespace that contains the password
+                                                  for authentication.
                                                 properties:
                                                   key:
                                                     description: The key of the secret
@@ -705,10 +707,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -719,9 +721,9 @@ spec:
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               username:
-                                                description: The secret in the service
-                                                  monitor namespace that contains
-                                                  the username for authentication.
+                                                description: |-
+                                                  The secret in the service monitor namespace that contains the username
+                                                  for authentication.
                                                 properties:
                                                   key:
                                                     description: The key of the secret
@@ -729,10 +731,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -744,12 +746,11 @@ spec:
                                                 x-kubernetes-map-type: atomic
                                             type: object
                                           bearerTokenSecret:
-                                            description: The secret's key that contains
-                                              the bearer token to be used by the client
-                                              for authentication. The secret needs
-                                              to be in the same namespace as the AlertmanagerConfig
-                                              object and accessible by the Prometheus
-                                              Operator.
+                                            description: |-
+                                              The secret's key that contains the bearer token to be used by the client
+                                              for authentication.
+                                              The secret needs to be in the same namespace as the AlertmanagerConfig
+                                              object and accessible by the Prometheus Operator.
                                             properties:
                                               key:
                                                 description: The key of the secret
@@ -757,10 +758,10 @@ spec:
                                                   secret key.
                                                 type: string
                                               name:
-                                                description: 'Name of the referent.
+                                                description: |-
+                                                  Name of the referent.
                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
+                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                 type: string
                                               optional:
                                                 description: Specify whether the Secret
@@ -791,10 +792,10 @@ spec:
                                                         description: The key to select.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -815,10 +816,10 @@ spec:
                                                           be a valid secret key.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -840,10 +841,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -894,10 +895,10 @@ spec:
                                                         description: The key to select.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -918,10 +919,10 @@ spec:
                                                           be a valid secret key.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -945,10 +946,10 @@ spec:
                                                         description: The key to select.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -969,10 +970,10 @@ spec:
                                                           be a valid secret key.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -998,10 +999,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -1031,9 +1032,9 @@ spec:
                                         description: List of responders responsible
                                           for notifications.
                                         items:
-                                          description: OpsGenieConfigResponder defines
-                                            a responder to an incident. One of `id`,
-                                            `name` or `username` has to be defined.
+                                          description: |-
+                                            OpsGenieConfigResponder defines a responder to an incident.
+                                            One of `id`, `name` or `username` has to be defined.
                                           properties:
                                             id:
                                               description: ID of the responder.
@@ -1071,19 +1072,18 @@ spec:
                                           attached to the notifications.
                                         type: string
                                       updateAlerts:
-                                        description: Whether to update message and
-                                          description of the alert in OpsGenie if
-                                          it already exists By default, the alert
-                                          is never updated in OpsGenie, the new message
-                                          only appears in activity log.
+                                        description: |-
+                                          Whether to update message and description of the alert in OpsGenie if it already exists
+                                          By default, the alert is never updated in OpsGenie, the new message only appears in activity log.
                                         type: boolean
                                     type: object
                                   type: array
                                 pagerdutyConfigs:
                                   description: List of PagerDuty configurations.
                                   items:
-                                    description: PagerDutyConfig configures notifications
-                                      via PagerDuty. See https://prometheus.io/docs/alerting/latest/configuration/#pagerduty_config
+                                    description: |-
+                                      PagerDutyConfig configures notifications via PagerDuty.
+                                      See https://prometheus.io/docs/alerting/latest/configuration/#pagerduty_config
                                     properties:
                                       class:
                                         description: The class/type of the event.
@@ -1127,10 +1127,9 @@ spec:
                                         description: HTTP client configuration.
                                         properties:
                                           authorization:
-                                            description: Authorization header configuration
-                                              for the client. This is mutually exclusive
-                                              with BasicAuth and is only available
-                                              starting from Alertmanager v0.22+.
+                                            description: |-
+                                              Authorization header configuration for the client.
+                                              This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
                                             properties:
                                               credentials:
                                                 description: The secret's key that
@@ -1143,10 +1142,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -1157,21 +1156,20 @@ spec:
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               type:
-                                                description: Set the authentication
-                                                  type. Defaults to Bearer, Basic
-                                                  will cause an error
+                                                description: |-
+                                                  Set the authentication type. Defaults to Bearer, Basic will cause an
+                                                  error
                                                 type: string
                                             type: object
                                           basicAuth:
-                                            description: BasicAuth for the client.
-                                              This is mutually exclusive with Authorization.
-                                              If both are defined, BasicAuth takes
-                                              precedence.
+                                            description: |-
+                                              BasicAuth for the client.
+                                              This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
                                             properties:
                                               password:
-                                                description: The secret in the service
-                                                  monitor namespace that contains
-                                                  the password for authentication.
+                                                description: |-
+                                                  The secret in the service monitor namespace that contains the password
+                                                  for authentication.
                                                 properties:
                                                   key:
                                                     description: The key of the secret
@@ -1179,10 +1177,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -1193,9 +1191,9 @@ spec:
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               username:
-                                                description: The secret in the service
-                                                  monitor namespace that contains
-                                                  the username for authentication.
+                                                description: |-
+                                                  The secret in the service monitor namespace that contains the username
+                                                  for authentication.
                                                 properties:
                                                   key:
                                                     description: The key of the secret
@@ -1203,10 +1201,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -1218,12 +1216,11 @@ spec:
                                                 x-kubernetes-map-type: atomic
                                             type: object
                                           bearerTokenSecret:
-                                            description: The secret's key that contains
-                                              the bearer token to be used by the client
-                                              for authentication. The secret needs
-                                              to be in the same namespace as the AlertmanagerConfig
-                                              object and accessible by the Prometheus
-                                              Operator.
+                                            description: |-
+                                              The secret's key that contains the bearer token to be used by the client
+                                              for authentication.
+                                              The secret needs to be in the same namespace as the AlertmanagerConfig
+                                              object and accessible by the Prometheus Operator.
                                             properties:
                                               key:
                                                 description: The key of the secret
@@ -1231,10 +1228,10 @@ spec:
                                                   secret key.
                                                 type: string
                                               name:
-                                                description: 'Name of the referent.
+                                                description: |-
+                                                  Name of the referent.
                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
+                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                 type: string
                                               optional:
                                                 description: Specify whether the Secret
@@ -1265,10 +1262,10 @@ spec:
                                                         description: The key to select.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -1289,10 +1286,10 @@ spec:
                                                           be a valid secret key.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -1314,10 +1311,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -1368,10 +1365,10 @@ spec:
                                                         description: The key to select.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -1392,10 +1389,10 @@ spec:
                                                           be a valid secret key.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -1419,10 +1416,10 @@ spec:
                                                         description: The key to select.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -1443,10 +1440,10 @@ spec:
                                                           be a valid secret key.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -1472,10 +1469,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -1531,13 +1528,11 @@ spec:
                                           type: object
                                         type: array
                                       routingKey:
-                                        description: The secret's key that contains
-                                          the PagerDuty integration key (when using
-                                          Events API v2). Either this field or `serviceKey`
-                                          needs to be defined. The secret needs to
-                                          be in the same namespace as the AlertmanagerConfig
-                                          object and accessible by the Prometheus
-                                          Operator.
+                                        description: |-
+                                          The secret's key that contains the PagerDuty integration key (when using
+                                          Events API v2). Either this field or `serviceKey` needs to be defined.
+                                          The secret needs to be in the same namespace as the AlertmanagerConfig
+                                          object and accessible by the Prometheus Operator.
                                         properties:
                                           key:
                                             description: The key of the secret to
@@ -1545,10 +1540,10 @@ spec:
                                               key.
                                             type: string
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
                                             description: Specify whether the Secret
@@ -1563,13 +1558,12 @@ spec:
                                           resolved alerts.
                                         type: boolean
                                       serviceKey:
-                                        description: The secret's key that contains
-                                          the PagerDuty service key (when using integration
-                                          type "Prometheus"). Either this field or
-                                          `routingKey` needs to be defined. The secret
-                                          needs to be in the same namespace as the
-                                          AlertmanagerConfig object and accessible
-                                          by the Prometheus Operator.
+                                        description: |-
+                                          The secret's key that contains the PagerDuty service key (when using
+                                          integration type "Prometheus"). Either this field or `routingKey` needs to
+                                          be defined.
+                                          The secret needs to be in the same namespace as the AlertmanagerConfig
+                                          object and accessible by the Prometheus Operator.
                                         properties:
                                           key:
                                             description: The key of the secret to
@@ -1577,10 +1571,10 @@ spec:
                                               key.
                                             type: string
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
                                             description: Specify whether the Secret
@@ -1601,12 +1595,13 @@ spec:
                                 pushoverConfigs:
                                   description: List of Pushover configurations.
                                   items:
-                                    description: PushoverConfig configures notifications
-                                      via Pushover. See https://prometheus.io/docs/alerting/latest/configuration/#pushover_config
+                                    description: |-
+                                      PushoverConfig configures notifications via Pushover.
+                                      See https://prometheus.io/docs/alerting/latest/configuration/#pushover_config
                                     properties:
                                       expire:
-                                        description: How long your notification will
-                                          continue to be retried for, unless the user
+                                        description: |-
+                                          How long your notification will continue to be retried for, unless the user
                                           acknowledges the notification.
                                         pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
                                         type: string
@@ -1618,10 +1613,9 @@ spec:
                                         description: HTTP client configuration.
                                         properties:
                                           authorization:
-                                            description: Authorization header configuration
-                                              for the client. This is mutually exclusive
-                                              with BasicAuth and is only available
-                                              starting from Alertmanager v0.22+.
+                                            description: |-
+                                              Authorization header configuration for the client.
+                                              This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
                                             properties:
                                               credentials:
                                                 description: The secret's key that
@@ -1634,10 +1628,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -1648,21 +1642,20 @@ spec:
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               type:
-                                                description: Set the authentication
-                                                  type. Defaults to Bearer, Basic
-                                                  will cause an error
+                                                description: |-
+                                                  Set the authentication type. Defaults to Bearer, Basic will cause an
+                                                  error
                                                 type: string
                                             type: object
                                           basicAuth:
-                                            description: BasicAuth for the client.
-                                              This is mutually exclusive with Authorization.
-                                              If both are defined, BasicAuth takes
-                                              precedence.
+                                            description: |-
+                                              BasicAuth for the client.
+                                              This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
                                             properties:
                                               password:
-                                                description: The secret in the service
-                                                  monitor namespace that contains
-                                                  the password for authentication.
+                                                description: |-
+                                                  The secret in the service monitor namespace that contains the password
+                                                  for authentication.
                                                 properties:
                                                   key:
                                                     description: The key of the secret
@@ -1670,10 +1663,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -1684,9 +1677,9 @@ spec:
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               username:
-                                                description: The secret in the service
-                                                  monitor namespace that contains
-                                                  the username for authentication.
+                                                description: |-
+                                                  The secret in the service monitor namespace that contains the username
+                                                  for authentication.
                                                 properties:
                                                   key:
                                                     description: The key of the secret
@@ -1694,10 +1687,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -1709,12 +1702,11 @@ spec:
                                                 x-kubernetes-map-type: atomic
                                             type: object
                                           bearerTokenSecret:
-                                            description: The secret's key that contains
-                                              the bearer token to be used by the client
-                                              for authentication. The secret needs
-                                              to be in the same namespace as the AlertmanagerConfig
-                                              object and accessible by the Prometheus
-                                              Operator.
+                                            description: |-
+                                              The secret's key that contains the bearer token to be used by the client
+                                              for authentication.
+                                              The secret needs to be in the same namespace as the AlertmanagerConfig
+                                              object and accessible by the Prometheus Operator.
                                             properties:
                                               key:
                                                 description: The key of the secret
@@ -1722,10 +1714,10 @@ spec:
                                                   secret key.
                                                 type: string
                                               name:
-                                                description: 'Name of the referent.
+                                                description: |-
+                                                  Name of the referent.
                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
+                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                 type: string
                                               optional:
                                                 description: Specify whether the Secret
@@ -1756,10 +1748,10 @@ spec:
                                                         description: The key to select.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -1780,10 +1772,10 @@ spec:
                                                           be a valid secret key.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -1805,10 +1797,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -1859,10 +1851,10 @@ spec:
                                                         description: The key to select.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -1883,10 +1875,10 @@ spec:
                                                           be a valid secret key.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -1910,10 +1902,10 @@ spec:
                                                         description: The key to select.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -1934,10 +1926,10 @@ spec:
                                                           be a valid secret key.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -1963,10 +1955,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -1989,8 +1981,8 @@ spec:
                                         description: Priority, see https://pushover.net/api#priority
                                         type: string
                                       retry:
-                                        description: How often the Pushover servers
-                                          will send the same notification to the user.
+                                        description: |-
+                                          How often the Pushover servers will send the same notification to the user.
                                           Must be at least 30 seconds.
                                         pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
                                         type: string
@@ -2007,12 +1999,10 @@ spec:
                                         description: Notification title.
                                         type: string
                                       token:
-                                        description: The secret's key that contains
-                                          the registered application's API token,
-                                          see https://pushover.net/apps. The secret
-                                          needs to be in the same namespace as the
-                                          AlertmanagerConfig object and accessible
-                                          by the Prometheus Operator.
+                                        description: |-
+                                          The secret's key that contains the registered application's API token, see https://pushover.net/apps.
+                                          The secret needs to be in the same namespace as the AlertmanagerConfig
+                                          object and accessible by the Prometheus Operator.
                                         properties:
                                           key:
                                             description: The key of the secret to
@@ -2020,10 +2010,10 @@ spec:
                                               key.
                                             type: string
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
                                             description: Specify whether the Secret
@@ -2042,11 +2032,10 @@ spec:
                                           otherwise just the URL is shown
                                         type: string
                                       userKey:
-                                        description: The secret's key that contains
-                                          the recipient user's user key. The secret
-                                          needs to be in the same namespace as the
-                                          AlertmanagerConfig object and accessible
-                                          by the Prometheus Operator.
+                                        description: |-
+                                          The secret's key that contains the recipient user's user key.
+                                          The secret needs to be in the same namespace as the AlertmanagerConfig
+                                          object and accessible by the Prometheus Operator.
                                         properties:
                                           key:
                                             description: The key of the secret to
@@ -2054,10 +2043,10 @@ spec:
                                               key.
                                             type: string
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
                                             description: Specify whether the Secret
@@ -2072,25 +2061,26 @@ spec:
                                 slackConfigs:
                                   description: List of Slack configurations.
                                   items:
-                                    description: SlackConfig configures notifications
-                                      via Slack. See https://prometheus.io/docs/alerting/latest/configuration/#slack_config
+                                    description: |-
+                                      SlackConfig configures notifications via Slack.
+                                      See https://prometheus.io/docs/alerting/latest/configuration/#slack_config
                                     properties:
                                       actions:
                                         description: A list of Slack actions that
                                           are sent with each notification.
                                         items:
-                                          description: SlackAction configures a single
-                                            Slack action that is sent with each notification.
-                                            See https://api.slack.com/docs/message-attachments#action_fields
-                                            and https://api.slack.com/docs/message-buttons
-                                            for more information.
+                                          description: |-
+                                            SlackAction configures a single Slack action that is sent with each
+                                            notification.
+                                            See https://api.slack.com/docs/message-attachments#action_fields and
+                                            https://api.slack.com/docs/message-buttons for more information.
                                           properties:
                                             confirm:
-                                              description: SlackConfirmationField
-                                                protect users from destructive actions
-                                                or particularly distinguished decisions
-                                                by asking them to confirm their button
-                                                click one more time. See https://api.slack.com/docs/interactive-message-field-guide#confirmation_fields
+                                              description: |-
+                                                SlackConfirmationField protect users from destructive actions or
+                                                particularly distinguished decisions by asking them to confirm their button
+                                                click one more time.
+                                                See https://api.slack.com/docs/interactive-message-field-guide#confirmation_fields
                                                 for more information.
                                               properties:
                                                 dismissText:
@@ -2125,11 +2115,10 @@ spec:
                                           type: object
                                         type: array
                                       apiURL:
-                                        description: The secret's key that contains
-                                          the Slack webhook URL. The secret needs
-                                          to be in the same namespace as the AlertmanagerConfig
-                                          object and accessible by the Prometheus
-                                          Operator.
+                                        description: |-
+                                          The secret's key that contains the Slack webhook URL.
+                                          The secret needs to be in the same namespace as the AlertmanagerConfig
+                                          object and accessible by the Prometheus Operator.
                                         properties:
                                           key:
                                             description: The key of the secret to
@@ -2137,10 +2126,10 @@ spec:
                                               key.
                                             type: string
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
                                             description: Specify whether the Secret
@@ -2164,14 +2153,11 @@ spec:
                                         description: A list of Slack fields that are
                                           sent with each notification.
                                         items:
-                                          description: SlackField configures a single
-                                            Slack field that is sent with each notification.
-                                            Each field must contain a title, value,
-                                            and optionally, a boolean value to indicate
-                                            if the field is short enough to be displayed
-                                            next to other fields designated as short.
-                                            See https://api.slack.com/docs/message-attachments#fields
-                                            for more information.
+                                          description: |-
+                                            SlackField configures a single Slack field that is sent with each notification.
+                                            Each field must contain a title, value, and optionally, a boolean value to indicate if the field
+                                            is short enough to be displayed next to other fields designated as short.
+                                            See https://api.slack.com/docs/message-attachments#fields for more information.
                                           properties:
                                             short:
                                               type: boolean
@@ -2192,10 +2178,9 @@ spec:
                                         description: HTTP client configuration.
                                         properties:
                                           authorization:
-                                            description: Authorization header configuration
-                                              for the client. This is mutually exclusive
-                                              with BasicAuth and is only available
-                                              starting from Alertmanager v0.22+.
+                                            description: |-
+                                              Authorization header configuration for the client.
+                                              This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
                                             properties:
                                               credentials:
                                                 description: The secret's key that
@@ -2208,10 +2193,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -2222,21 +2207,20 @@ spec:
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               type:
-                                                description: Set the authentication
-                                                  type. Defaults to Bearer, Basic
-                                                  will cause an error
+                                                description: |-
+                                                  Set the authentication type. Defaults to Bearer, Basic will cause an
+                                                  error
                                                 type: string
                                             type: object
                                           basicAuth:
-                                            description: BasicAuth for the client.
-                                              This is mutually exclusive with Authorization.
-                                              If both are defined, BasicAuth takes
-                                              precedence.
+                                            description: |-
+                                              BasicAuth for the client.
+                                              This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
                                             properties:
                                               password:
-                                                description: The secret in the service
-                                                  monitor namespace that contains
-                                                  the password for authentication.
+                                                description: |-
+                                                  The secret in the service monitor namespace that contains the password
+                                                  for authentication.
                                                 properties:
                                                   key:
                                                     description: The key of the secret
@@ -2244,10 +2228,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -2258,9 +2242,9 @@ spec:
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               username:
-                                                description: The secret in the service
-                                                  monitor namespace that contains
-                                                  the username for authentication.
+                                                description: |-
+                                                  The secret in the service monitor namespace that contains the username
+                                                  for authentication.
                                                 properties:
                                                   key:
                                                     description: The key of the secret
@@ -2268,10 +2252,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -2283,12 +2267,11 @@ spec:
                                                 x-kubernetes-map-type: atomic
                                             type: object
                                           bearerTokenSecret:
-                                            description: The secret's key that contains
-                                              the bearer token to be used by the client
-                                              for authentication. The secret needs
-                                              to be in the same namespace as the AlertmanagerConfig
-                                              object and accessible by the Prometheus
-                                              Operator.
+                                            description: |-
+                                              The secret's key that contains the bearer token to be used by the client
+                                              for authentication.
+                                              The secret needs to be in the same namespace as the AlertmanagerConfig
+                                              object and accessible by the Prometheus Operator.
                                             properties:
                                               key:
                                                 description: The key of the secret
@@ -2296,10 +2279,10 @@ spec:
                                                   secret key.
                                                 type: string
                                               name:
-                                                description: 'Name of the referent.
+                                                description: |-
+                                                  Name of the referent.
                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
+                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                 type: string
                                               optional:
                                                 description: Specify whether the Secret
@@ -2330,10 +2313,10 @@ spec:
                                                         description: The key to select.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -2354,10 +2337,10 @@ spec:
                                                           be a valid secret key.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -2379,10 +2362,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -2433,10 +2416,10 @@ spec:
                                                         description: The key to select.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -2457,10 +2440,10 @@ spec:
                                                           be a valid secret key.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -2484,10 +2467,10 @@ spec:
                                                         description: The key to select.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -2508,10 +2491,10 @@ spec:
                                                           be a valid secret key.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -2537,10 +2520,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -2591,13 +2574,14 @@ spec:
                                 snsConfigs:
                                   description: List of SNS configurations
                                   items:
-                                    description: SNSConfig configures notifications
-                                      via AWS SNS. See https://prometheus.io/docs/alerting/latest/configuration/#sns_configs
+                                    description: |-
+                                      SNSConfig configures notifications via AWS SNS.
+                                      See https://prometheus.io/docs/alerting/latest/configuration/#sns_configs
                                     properties:
                                       apiURL:
-                                        description: The SNS API URL i.e. https://sns.us-east-2.amazonaws.com.
-                                          If not specified, the SNS API URL from the
-                                          SNS SDK will be used.
+                                        description: |-
+                                          The SNS API URL i.e. https://sns.us-east-2.amazonaws.com.
+                                          If not specified, the SNS API URL from the SNS SDK will be used.
                                         type: string
                                       attributes:
                                         additionalProperties:
@@ -2608,10 +2592,9 @@ spec:
                                         description: HTTP client configuration.
                                         properties:
                                           authorization:
-                                            description: Authorization header configuration
-                                              for the client. This is mutually exclusive
-                                              with BasicAuth and is only available
-                                              starting from Alertmanager v0.22+.
+                                            description: |-
+                                              Authorization header configuration for the client.
+                                              This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
                                             properties:
                                               credentials:
                                                 description: The secret's key that
@@ -2624,10 +2607,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -2638,21 +2621,20 @@ spec:
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               type:
-                                                description: Set the authentication
-                                                  type. Defaults to Bearer, Basic
-                                                  will cause an error
+                                                description: |-
+                                                  Set the authentication type. Defaults to Bearer, Basic will cause an
+                                                  error
                                                 type: string
                                             type: object
                                           basicAuth:
-                                            description: BasicAuth for the client.
-                                              This is mutually exclusive with Authorization.
-                                              If both are defined, BasicAuth takes
-                                              precedence.
+                                            description: |-
+                                              BasicAuth for the client.
+                                              This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
                                             properties:
                                               password:
-                                                description: The secret in the service
-                                                  monitor namespace that contains
-                                                  the password for authentication.
+                                                description: |-
+                                                  The secret in the service monitor namespace that contains the password
+                                                  for authentication.
                                                 properties:
                                                   key:
                                                     description: The key of the secret
@@ -2660,10 +2642,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -2674,9 +2656,9 @@ spec:
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               username:
-                                                description: The secret in the service
-                                                  monitor namespace that contains
-                                                  the username for authentication.
+                                                description: |-
+                                                  The secret in the service monitor namespace that contains the username
+                                                  for authentication.
                                                 properties:
                                                   key:
                                                     description: The key of the secret
@@ -2684,10 +2666,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -2699,12 +2681,11 @@ spec:
                                                 x-kubernetes-map-type: atomic
                                             type: object
                                           bearerTokenSecret:
-                                            description: The secret's key that contains
-                                              the bearer token to be used by the client
-                                              for authentication. The secret needs
-                                              to be in the same namespace as the AlertmanagerConfig
-                                              object and accessible by the Prometheus
-                                              Operator.
+                                            description: |-
+                                              The secret's key that contains the bearer token to be used by the client
+                                              for authentication.
+                                              The secret needs to be in the same namespace as the AlertmanagerConfig
+                                              object and accessible by the Prometheus Operator.
                                             properties:
                                               key:
                                                 description: The key of the secret
@@ -2712,10 +2693,10 @@ spec:
                                                   secret key.
                                                 type: string
                                               name:
-                                                description: 'Name of the referent.
+                                                description: |-
+                                                  Name of the referent.
                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
+                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                 type: string
                                               optional:
                                                 description: Specify whether the Secret
@@ -2746,10 +2727,10 @@ spec:
                                                         description: The key to select.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -2770,10 +2751,10 @@ spec:
                                                           be a valid secret key.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -2795,10 +2776,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -2849,10 +2830,10 @@ spec:
                                                         description: The key to select.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -2873,10 +2854,10 @@ spec:
                                                           be a valid secret key.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -2900,10 +2881,10 @@ spec:
                                                         description: The key to select.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -2924,10 +2905,10 @@ spec:
                                                           be a valid secret key.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -2953,10 +2934,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -2977,10 +2958,9 @@ spec:
                                           notification.
                                         type: string
                                       phoneNumber:
-                                        description: Phone number if message is delivered
-                                          via SMS in E.164 format. If you don't specify
-                                          this value, you must specify a value for
-                                          the TopicARN or TargetARN.
+                                        description: |-
+                                          Phone number if message is delivered via SMS in E.164 format.
+                                          If you don't specify this value, you must specify a value for the TopicARN or TargetARN.
                                         type: string
                                       sendResolved:
                                         description: Whether or not to notify about
@@ -3001,10 +2981,10 @@ spec:
                                                   secret key.
                                                 type: string
                                               name:
-                                                description: 'Name of the referent.
+                                                description: |-
+                                                  Name of the referent.
                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
+                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                 type: string
                                               optional:
                                                 description: Specify whether the Secret
@@ -3038,10 +3018,10 @@ spec:
                                                   secret key.
                                                 type: string
                                               name:
-                                                description: 'Name of the referent.
+                                                description: |-
+                                                  Name of the referent.
                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
+                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                 type: string
                                               optional:
                                                 description: Specify whether the Secret
@@ -3057,34 +3037,34 @@ spec:
                                           is delivered to email endpoints.
                                         type: string
                                       targetARN:
-                                        description: The  mobile platform endpoint
-                                          ARN if message is delivered via mobile notifications.
-                                          If you don't specify this value, you must
-                                          specify a value for the topic_arn or PhoneNumber.
+                                        description: |-
+                                          The  mobile platform endpoint ARN if message is delivered via mobile notifications.
+                                          If you don't specify this value, you must specify a value for the topic_arn or PhoneNumber.
                                         type: string
                                       topicARN:
-                                        description: SNS topic ARN, i.e. arn:aws:sns:us-east-2:698519295917:My-Topic
-                                          If you don't specify this value, you must
-                                          specify a value for the PhoneNumber or TargetARN.
+                                        description: |-
+                                          SNS topic ARN, i.e. arn:aws:sns:us-east-2:698519295917:My-Topic
+                                          If you don't specify this value, you must specify a value for the PhoneNumber or TargetARN.
                                         type: string
                                     type: object
                                   type: array
                                 telegramConfigs:
                                   description: List of Telegram configurations.
                                   items:
-                                    description: TelegramConfig configures notifications
-                                      via Telegram. See https://prometheus.io/docs/alerting/latest/configuration/#telegram_config
+                                    description: |-
+                                      TelegramConfig configures notifications via Telegram.
+                                      See https://prometheus.io/docs/alerting/latest/configuration/#telegram_config
                                     properties:
                                       apiURL:
-                                        description: The Telegram API URL i.e. https://api.telegram.org.
-                                          If not specified, default API URL will be
-                                          used.
+                                        description: |-
+                                          The Telegram API URL i.e. https://api.telegram.org.
+                                          If not specified, default API URL will be used.
                                         type: string
                                       botToken:
-                                        description: Telegram bot token The secret
-                                          needs to be in the same namespace as the
-                                          AlertmanagerConfig object and accessible
-                                          by the Prometheus Operator.
+                                        description: |-
+                                          Telegram bot token
+                                          The secret needs to be in the same namespace as the AlertmanagerConfig
+                                          object and accessible by the Prometheus Operator.
                                         properties:
                                           key:
                                             description: The key of the secret to
@@ -3092,10 +3072,10 @@ spec:
                                               key.
                                             type: string
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
                                             description: Specify whether the Secret
@@ -3116,10 +3096,9 @@ spec:
                                         description: HTTP client configuration.
                                         properties:
                                           authorization:
-                                            description: Authorization header configuration
-                                              for the client. This is mutually exclusive
-                                              with BasicAuth and is only available
-                                              starting from Alertmanager v0.22+.
+                                            description: |-
+                                              Authorization header configuration for the client.
+                                              This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
                                             properties:
                                               credentials:
                                                 description: The secret's key that
@@ -3132,10 +3111,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -3146,21 +3125,20 @@ spec:
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               type:
-                                                description: Set the authentication
-                                                  type. Defaults to Bearer, Basic
-                                                  will cause an error
+                                                description: |-
+                                                  Set the authentication type. Defaults to Bearer, Basic will cause an
+                                                  error
                                                 type: string
                                             type: object
                                           basicAuth:
-                                            description: BasicAuth for the client.
-                                              This is mutually exclusive with Authorization.
-                                              If both are defined, BasicAuth takes
-                                              precedence.
+                                            description: |-
+                                              BasicAuth for the client.
+                                              This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
                                             properties:
                                               password:
-                                                description: The secret in the service
-                                                  monitor namespace that contains
-                                                  the password for authentication.
+                                                description: |-
+                                                  The secret in the service monitor namespace that contains the password
+                                                  for authentication.
                                                 properties:
                                                   key:
                                                     description: The key of the secret
@@ -3168,10 +3146,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -3182,9 +3160,9 @@ spec:
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               username:
-                                                description: The secret in the service
-                                                  monitor namespace that contains
-                                                  the username for authentication.
+                                                description: |-
+                                                  The secret in the service monitor namespace that contains the username
+                                                  for authentication.
                                                 properties:
                                                   key:
                                                     description: The key of the secret
@@ -3192,10 +3170,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -3207,12 +3185,11 @@ spec:
                                                 x-kubernetes-map-type: atomic
                                             type: object
                                           bearerTokenSecret:
-                                            description: The secret's key that contains
-                                              the bearer token to be used by the client
-                                              for authentication. The secret needs
-                                              to be in the same namespace as the AlertmanagerConfig
-                                              object and accessible by the Prometheus
-                                              Operator.
+                                            description: |-
+                                              The secret's key that contains the bearer token to be used by the client
+                                              for authentication.
+                                              The secret needs to be in the same namespace as the AlertmanagerConfig
+                                              object and accessible by the Prometheus Operator.
                                             properties:
                                               key:
                                                 description: The key of the secret
@@ -3220,10 +3197,10 @@ spec:
                                                   secret key.
                                                 type: string
                                               name:
-                                                description: 'Name of the referent.
+                                                description: |-
+                                                  Name of the referent.
                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
+                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                 type: string
                                               optional:
                                                 description: Specify whether the Secret
@@ -3254,10 +3231,10 @@ spec:
                                                         description: The key to select.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -3278,10 +3255,10 @@ spec:
                                                           be a valid secret key.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -3303,10 +3280,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -3357,10 +3334,10 @@ spec:
                                                         description: The key to select.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -3381,10 +3358,10 @@ spec:
                                                           be a valid secret key.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -3408,10 +3385,10 @@ spec:
                                                         description: The key to select.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -3432,10 +3409,10 @@ spec:
                                                           be a valid secret key.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -3461,10 +3438,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -3499,15 +3476,15 @@ spec:
                                 victoropsConfigs:
                                   description: List of VictorOps configurations.
                                   items:
-                                    description: VictorOpsConfig configures notifications
-                                      via VictorOps. See https://prometheus.io/docs/alerting/latest/configuration/#victorops_config
+                                    description: |-
+                                      VictorOpsConfig configures notifications via VictorOps.
+                                      See https://prometheus.io/docs/alerting/latest/configuration/#victorops_config
                                     properties:
                                       apiKey:
-                                        description: The secret's key that contains
-                                          the API key to use when talking to the VictorOps
-                                          API. The secret needs to be in the same
-                                          namespace as the AlertmanagerConfig object
-                                          and accessible by the Prometheus Operator.
+                                        description: |-
+                                          The secret's key that contains the API key to use when talking to the VictorOps API.
+                                          The secret needs to be in the same namespace as the AlertmanagerConfig
+                                          object and accessible by the Prometheus Operator.
                                         properties:
                                           key:
                                             description: The key of the secret to
@@ -3515,10 +3492,10 @@ spec:
                                               key.
                                             type: string
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
                                             description: Specify whether the Secret
@@ -3558,10 +3535,9 @@ spec:
                                         description: The HTTP client's configuration.
                                         properties:
                                           authorization:
-                                            description: Authorization header configuration
-                                              for the client. This is mutually exclusive
-                                              with BasicAuth and is only available
-                                              starting from Alertmanager v0.22+.
+                                            description: |-
+                                              Authorization header configuration for the client.
+                                              This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
                                             properties:
                                               credentials:
                                                 description: The secret's key that
@@ -3574,10 +3550,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -3588,21 +3564,20 @@ spec:
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               type:
-                                                description: Set the authentication
-                                                  type. Defaults to Bearer, Basic
-                                                  will cause an error
+                                                description: |-
+                                                  Set the authentication type. Defaults to Bearer, Basic will cause an
+                                                  error
                                                 type: string
                                             type: object
                                           basicAuth:
-                                            description: BasicAuth for the client.
-                                              This is mutually exclusive with Authorization.
-                                              If both are defined, BasicAuth takes
-                                              precedence.
+                                            description: |-
+                                              BasicAuth for the client.
+                                              This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
                                             properties:
                                               password:
-                                                description: The secret in the service
-                                                  monitor namespace that contains
-                                                  the password for authentication.
+                                                description: |-
+                                                  The secret in the service monitor namespace that contains the password
+                                                  for authentication.
                                                 properties:
                                                   key:
                                                     description: The key of the secret
@@ -3610,10 +3585,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -3624,9 +3599,9 @@ spec:
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               username:
-                                                description: The secret in the service
-                                                  monitor namespace that contains
-                                                  the username for authentication.
+                                                description: |-
+                                                  The secret in the service monitor namespace that contains the username
+                                                  for authentication.
                                                 properties:
                                                   key:
                                                     description: The key of the secret
@@ -3634,10 +3609,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -3649,12 +3624,11 @@ spec:
                                                 x-kubernetes-map-type: atomic
                                             type: object
                                           bearerTokenSecret:
-                                            description: The secret's key that contains
-                                              the bearer token to be used by the client
-                                              for authentication. The secret needs
-                                              to be in the same namespace as the AlertmanagerConfig
-                                              object and accessible by the Prometheus
-                                              Operator.
+                                            description: |-
+                                              The secret's key that contains the bearer token to be used by the client
+                                              for authentication.
+                                              The secret needs to be in the same namespace as the AlertmanagerConfig
+                                              object and accessible by the Prometheus Operator.
                                             properties:
                                               key:
                                                 description: The key of the secret
@@ -3662,10 +3636,10 @@ spec:
                                                   secret key.
                                                 type: string
                                               name:
-                                                description: 'Name of the referent.
+                                                description: |-
+                                                  Name of the referent.
                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
+                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                 type: string
                                               optional:
                                                 description: Specify whether the Secret
@@ -3696,10 +3670,10 @@ spec:
                                                         description: The key to select.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -3720,10 +3694,10 @@ spec:
                                                           be a valid secret key.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -3745,10 +3719,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -3799,10 +3773,10 @@ spec:
                                                         description: The key to select.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -3823,10 +3797,10 @@ spec:
                                                           be a valid secret key.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -3850,10 +3824,10 @@ spec:
                                                         description: The key to select.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -3874,10 +3848,10 @@ spec:
                                                           be a valid secret key.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -3903,10 +3877,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -3947,18 +3921,17 @@ spec:
                                 webhookConfigs:
                                   description: List of webhook configurations.
                                   items:
-                                    description: WebhookConfig configures notifications
-                                      via a generic receiver supporting the webhook
-                                      payload. See https://prometheus.io/docs/alerting/latest/configuration/#webhook_config
+                                    description: |-
+                                      WebhookConfig configures notifications via a generic receiver supporting the webhook payload.
+                                      See https://prometheus.io/docs/alerting/latest/configuration/#webhook_config
                                     properties:
                                       httpConfig:
                                         description: HTTP client configuration.
                                         properties:
                                           authorization:
-                                            description: Authorization header configuration
-                                              for the client. This is mutually exclusive
-                                              with BasicAuth and is only available
-                                              starting from Alertmanager v0.22+.
+                                            description: |-
+                                              Authorization header configuration for the client.
+                                              This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
                                             properties:
                                               credentials:
                                                 description: The secret's key that
@@ -3971,10 +3944,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -3985,21 +3958,20 @@ spec:
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               type:
-                                                description: Set the authentication
-                                                  type. Defaults to Bearer, Basic
-                                                  will cause an error
+                                                description: |-
+                                                  Set the authentication type. Defaults to Bearer, Basic will cause an
+                                                  error
                                                 type: string
                                             type: object
                                           basicAuth:
-                                            description: BasicAuth for the client.
-                                              This is mutually exclusive with Authorization.
-                                              If both are defined, BasicAuth takes
-                                              precedence.
+                                            description: |-
+                                              BasicAuth for the client.
+                                              This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
                                             properties:
                                               password:
-                                                description: The secret in the service
-                                                  monitor namespace that contains
-                                                  the password for authentication.
+                                                description: |-
+                                                  The secret in the service monitor namespace that contains the password
+                                                  for authentication.
                                                 properties:
                                                   key:
                                                     description: The key of the secret
@@ -4007,10 +3979,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -4021,9 +3993,9 @@ spec:
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               username:
-                                                description: The secret in the service
-                                                  monitor namespace that contains
-                                                  the username for authentication.
+                                                description: |-
+                                                  The secret in the service monitor namespace that contains the username
+                                                  for authentication.
                                                 properties:
                                                   key:
                                                     description: The key of the secret
@@ -4031,10 +4003,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -4046,12 +4018,11 @@ spec:
                                                 x-kubernetes-map-type: atomic
                                             type: object
                                           bearerTokenSecret:
-                                            description: The secret's key that contains
-                                              the bearer token to be used by the client
-                                              for authentication. The secret needs
-                                              to be in the same namespace as the AlertmanagerConfig
-                                              object and accessible by the Prometheus
-                                              Operator.
+                                            description: |-
+                                              The secret's key that contains the bearer token to be used by the client
+                                              for authentication.
+                                              The secret needs to be in the same namespace as the AlertmanagerConfig
+                                              object and accessible by the Prometheus Operator.
                                             properties:
                                               key:
                                                 description: The key of the secret
@@ -4059,10 +4030,10 @@ spec:
                                                   secret key.
                                                 type: string
                                               name:
-                                                description: 'Name of the referent.
+                                                description: |-
+                                                  Name of the referent.
                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
+                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                 type: string
                                               optional:
                                                 description: Specify whether the Secret
@@ -4093,10 +4064,10 @@ spec:
                                                         description: The key to select.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -4117,10 +4088,10 @@ spec:
                                                           be a valid secret key.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -4142,10 +4113,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -4196,10 +4167,10 @@ spec:
                                                         description: The key to select.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -4220,10 +4191,10 @@ spec:
                                                           be a valid secret key.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -4247,10 +4218,10 @@ spec:
                                                         description: The key to select.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -4271,10 +4242,10 @@ spec:
                                                           be a valid secret key.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -4300,10 +4271,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -4331,18 +4302,17 @@ spec:
                                           resolved alerts.
                                         type: boolean
                                       url:
-                                        description: The URL to send HTTP POST requests
-                                          to. `urlSecret` takes precedence over `url`.
-                                          One of `urlSecret` and `url` should be defined.
+                                        description: |-
+                                          The URL to send HTTP POST requests to. `urlSecret` takes precedence over
+                                          `url`. One of `urlSecret` and `url` should be defined.
                                         type: string
                                       urlSecret:
-                                        description: The secret's key that contains
-                                          the webhook URL to send HTTP requests to.
-                                          `urlSecret` takes precedence over `url`.
-                                          One of `urlSecret` and `url` should be defined.
-                                          The secret needs to be in the same namespace
-                                          as the AlertmanagerConfig object and accessible
-                                          by the Prometheus Operator.
+                                        description: |-
+                                          The secret's key that contains the webhook URL to send HTTP requests to.
+                                          `urlSecret` takes precedence over `url`. One of `urlSecret` and `url`
+                                          should be defined.
+                                          The secret needs to be in the same namespace as the AlertmanagerConfig
+                                          object and accessible by the Prometheus Operator.
                                         properties:
                                           key:
                                             description: The key of the secret to
@@ -4350,10 +4320,10 @@ spec:
                                               key.
                                             type: string
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
                                             description: Specify whether the Secret
@@ -4368,17 +4338,17 @@ spec:
                                 wechatConfigs:
                                   description: List of WeChat configurations.
                                   items:
-                                    description: WeChatConfig configures notifications
-                                      via WeChat. See https://prometheus.io/docs/alerting/latest/configuration/#wechat_config
+                                    description: |-
+                                      WeChatConfig configures notifications via WeChat.
+                                      See https://prometheus.io/docs/alerting/latest/configuration/#wechat_config
                                     properties:
                                       agentID:
                                         type: string
                                       apiSecret:
-                                        description: The secret's key that contains
-                                          the WeChat API key. The secret needs to
-                                          be in the same namespace as the AlertmanagerConfig
-                                          object and accessible by the Prometheus
-                                          Operator.
+                                        description: |-
+                                          The secret's key that contains the WeChat API key.
+                                          The secret needs to be in the same namespace as the AlertmanagerConfig
+                                          object and accessible by the Prometheus Operator.
                                         properties:
                                           key:
                                             description: The key of the secret to
@@ -4386,10 +4356,10 @@ spec:
                                               key.
                                             type: string
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
                                             description: Specify whether the Secret
@@ -4409,10 +4379,9 @@ spec:
                                         description: HTTP client configuration.
                                         properties:
                                           authorization:
-                                            description: Authorization header configuration
-                                              for the client. This is mutually exclusive
-                                              with BasicAuth and is only available
-                                              starting from Alertmanager v0.22+.
+                                            description: |-
+                                              Authorization header configuration for the client.
+                                              This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
                                             properties:
                                               credentials:
                                                 description: The secret's key that
@@ -4425,10 +4394,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -4439,21 +4408,20 @@ spec:
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               type:
-                                                description: Set the authentication
-                                                  type. Defaults to Bearer, Basic
-                                                  will cause an error
+                                                description: |-
+                                                  Set the authentication type. Defaults to Bearer, Basic will cause an
+                                                  error
                                                 type: string
                                             type: object
                                           basicAuth:
-                                            description: BasicAuth for the client.
-                                              This is mutually exclusive with Authorization.
-                                              If both are defined, BasicAuth takes
-                                              precedence.
+                                            description: |-
+                                              BasicAuth for the client.
+                                              This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
                                             properties:
                                               password:
-                                                description: The secret in the service
-                                                  monitor namespace that contains
-                                                  the password for authentication.
+                                                description: |-
+                                                  The secret in the service monitor namespace that contains the password
+                                                  for authentication.
                                                 properties:
                                                   key:
                                                     description: The key of the secret
@@ -4461,10 +4429,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -4475,9 +4443,9 @@ spec:
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               username:
-                                                description: The secret in the service
-                                                  monitor namespace that contains
-                                                  the username for authentication.
+                                                description: |-
+                                                  The secret in the service monitor namespace that contains the username
+                                                  for authentication.
                                                 properties:
                                                   key:
                                                     description: The key of the secret
@@ -4485,10 +4453,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -4500,12 +4468,11 @@ spec:
                                                 x-kubernetes-map-type: atomic
                                             type: object
                                           bearerTokenSecret:
-                                            description: The secret's key that contains
-                                              the bearer token to be used by the client
-                                              for authentication. The secret needs
-                                              to be in the same namespace as the AlertmanagerConfig
-                                              object and accessible by the Prometheus
-                                              Operator.
+                                            description: |-
+                                              The secret's key that contains the bearer token to be used by the client
+                                              for authentication.
+                                              The secret needs to be in the same namespace as the AlertmanagerConfig
+                                              object and accessible by the Prometheus Operator.
                                             properties:
                                               key:
                                                 description: The key of the secret
@@ -4513,10 +4480,10 @@ spec:
                                                   secret key.
                                                 type: string
                                               name:
-                                                description: 'Name of the referent.
+                                                description: |-
+                                                  Name of the referent.
                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
+                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                 type: string
                                               optional:
                                                 description: Specify whether the Secret
@@ -4547,10 +4514,10 @@ spec:
                                                         description: The key to select.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -4571,10 +4538,10 @@ spec:
                                                           be a valid secret key.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -4596,10 +4563,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -4650,10 +4617,10 @@ spec:
                                                         description: The key to select.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -4674,10 +4641,10 @@ spec:
                                                           be a valid secret key.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -4701,10 +4668,10 @@ spec:
                                                         description: The key to select.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -4725,10 +4692,10 @@ spec:
                                                           be a valid secret key.
                                                         type: string
                                                       name:
-                                                        description: 'Name of the
-                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                          TODO: Add other useful fields.
-                                                          apiVersion, kind, uid?'
+                                                        description: |-
+                                                          Name of the referent.
+                                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                                         type: string
                                                       optional:
                                                         description: Specify whether
@@ -4754,10 +4721,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -4796,10 +4763,10 @@ spec:
                               type: object
                             type: array
                           route:
-                            description: The Alertmanager route definition for alerts
-                              matching the resource's namespace. If present, it will
-                              be added to the generated Alertmanager configuration
-                              as a first-level route.
+                            description: |-
+                              The Alertmanager route definition for alerts matching the resource's
+                              namespace. If present, it will be added to the generated Alertmanager
+                              configuration as a first-level route.
                             properties:
                               activeTimeIntervals:
                                 description: ActiveTimeIntervals is a list of MuteTimeInterval
@@ -4808,43 +4775,45 @@ spec:
                                   type: string
                                 type: array
                               continue:
-                                description: Boolean indicating whether an alert should
-                                  continue matching subsequent sibling nodes. It will
-                                  always be overridden to true for the first-level
+                                description: |-
+                                  Boolean indicating whether an alert should continue matching subsequent
+                                  sibling nodes. It will always be overridden to true for the first-level
                                   route by the Prometheus operator.
                                 type: boolean
                               groupBy:
-                                description: List of labels to group by. Labels must
-                                  not be repeated (unique list). Special label "..."
-                                  (aggregate by all possible labels), if provided,
-                                  must be the only element in the list.
+                                description: |-
+                                  List of labels to group by.
+                                  Labels must not be repeated (unique list).
+                                  Special label "..." (aggregate by all possible labels), if provided, must be the only element in the list.
                                 items:
                                   type: string
                                 type: array
                               groupInterval:
-                                description: 'How long to wait before sending an updated
-                                  notification. Must match the regular expression`^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$`
-                                  Example: "5m"'
+                                description: |-
+                                  How long to wait before sending an updated notification.
+                                  Must match the regular expression`^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$`
+                                  Example: "5m"
                                 type: string
                               groupWait:
-                                description: 'How long to wait before sending the
-                                  initial notification. Must match the regular expression`^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$`
-                                  Example: "30s"'
+                                description: |-
+                                  How long to wait before sending the initial notification.
+                                  Must match the regular expression`^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$`
+                                  Example: "30s"
                                 type: string
                               matchers:
-                                description: 'List of matchers that the alert''s labels
-                                  should match. For the first level route, the operator
-                                  removes any existing equality and regexp matcher
-                                  on the `namespace` label and adds a `namespace:
-                                  <object namespace>` matcher.'
+                                description: |-
+                                  List of matchers that the alert's labels should match. For the first
+                                  level route, the operator removes any existing equality and regexp
+                                  matcher on the `namespace` label and adds a `namespace: <object
+                                  namespace>` matcher.
                                 items:
                                   description: Matcher defines how to match on alert's
                                     labels.
                                   properties:
                                     matchType:
-                                      description: Match operation available with
-                                        AlertManager >= v0.22.0 and takes precedence
-                                        over Regex (deprecated) if non-empty.
+                                      description: |-
+                                        Match operation available with AlertManager >= v0.22.0 and
+                                        takes precedence over Regex (deprecated) if non-empty.
                                       enum:
                                       - '!='
                                       - "="
@@ -4856,10 +4825,9 @@ spec:
                                       minLength: 1
                                       type: string
                                     regex:
-                                      description: Whether to match on equality (false)
-                                        or regular-expression (true). Deprecated as
-                                        of AlertManager >= v0.22.0 where a user should
-                                        use MatchType instead.
+                                      description: |-
+                                        Whether to match on equality (false) or regular-expression (true).
+                                        Deprecated as of AlertManager >= v0.22.0 where a user should use MatchType instead.
                                       type: boolean
                                     value:
                                       description: Label value to match.
@@ -4869,29 +4837,28 @@ spec:
                                   type: object
                                 type: array
                               muteTimeIntervals:
-                                description: 'Note: this comment applies to the field
-                                  definition above but appears below otherwise it
-                                  gets included in the generated manifest. CRD schema
-                                  doesn''t support self-referential types for now
-                                  (see https://github.com/kubernetes/kubernetes/issues/62872).
-                                  We have to use an alternative type to circumvent
-                                  the limitation. The downside is that the Kube API
-                                  can''t validate the data beyond the fact that it
-                                  is a valid JSON representation. MuteTimeIntervals
-                                  is a list of MuteTimeInterval names that will mute
-                                  this route when matched,'
+                                description: |-
+                                  Note: this comment applies to the field definition above but appears
+                                  below otherwise it gets included in the generated manifest.
+                                  CRD schema doesn't support self-referential types for now (see
+                                  https://github.com/kubernetes/kubernetes/issues/62872). We have to use
+                                  an alternative type to circumvent the limitation. The downside is that
+                                  the Kube API can't validate the data beyond the fact that it is a valid
+                                  JSON representation.
+                                  MuteTimeIntervals is a list of MuteTimeInterval names that will mute this route when matched,
                                 items:
                                   type: string
                                 type: array
                               receiver:
-                                description: Name of the receiver for this route.
-                                  If not empty, it should be listed in the `receivers`
-                                  field.
+                                description: |-
+                                  Name of the receiver for this route. If not empty, it should be listed in
+                                  the `receivers` field.
                                 type: string
                               repeatInterval:
-                                description: 'How long to wait before repeating the
-                                  last notification. Must match the regular expression`^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$`
-                                  Example: "4h"'
+                                description: |-
+                                  How long to wait before repeating the last notification.
+                                  Must match the regular expression`^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$`
+                                  Example: "4h"
                                 type: string
                               routes:
                                 description: Child routes.
@@ -4913,9 +4880,9 @@ spec:
                           you want to restore.
                         type: string
                       claimName:
-                        description: ClaimName specifies the name of the instance
-                          you want to restore from. The claim has to be in the same
-                          namespace as this new instance.
+                        description: |-
+                          ClaimName specifies the name of the instance you want to restore from.
+                          The claim has to be in the same namespace as this new instance.
                         type: string
                     type: object
                   scheduling:
@@ -4946,9 +4913,9 @@ spec:
                         type: string
                       version:
                         default: "7.0"
-                        description: Version contains supported version of Redis.
-                          Multiple versions are supported. The latest version "7.0"
-                          is the default version.
+                        description: |-
+                          Version contains supported version of Redis.
+                          Multiple versions are supported. The latest version "7.0" is the default version.
                         enum:
                         - "6.2"
                         - "7.0"
@@ -5001,9 +4968,10 @@ spec:
               providerConfigRef:
                 default:
                   name: default
-                description: ProviderConfigReference specifies how the provider that
-                  will be used to create, observe, update, and delete this managed
-                  resource should be configured.
+                description: |-
+                  ProviderConfigReference specifies how the provider that will be used to
+                  create, observe, update, and delete this managed resource should be
+                  configured.
                 properties:
                   name:
                     description: Name of the referenced object.
@@ -5013,21 +4981,21 @@ spec:
                     properties:
                       resolution:
                         default: Required
-                        description: Resolution specifies whether resolution of this
-                          reference is required. The default is 'Required', which
-                          means the reconcile will fail if the reference cannot be
-                          resolved. 'Optional' means this reference will be a no-op
-                          if it cannot be resolved.
+                        description: |-
+                          Resolution specifies whether resolution of this reference is required.
+                          The default is 'Required', which means the reconcile will fail if the
+                          reference cannot be resolved. 'Optional' means this reference will be
+                          a no-op if it cannot be resolved.
                         enum:
                         - Required
                         - Optional
                         type: string
                       resolve:
-                        description: Resolve specifies when this reference should
-                          be resolved. The default is 'IfNotPresent', which will attempt
-                          to resolve the reference only when the corresponding field
-                          is not present. Use 'Always' to resolve the reference on
-                          every reconcile.
+                        description: |-
+                          Resolve specifies when this reference should be resolved. The default
+                          is 'IfNotPresent', which will attempt to resolve the reference only when
+                          the corresponding field is not present. Use 'Always' to resolve the
+                          reference on every reconcile.
                         enum:
                         - Always
                         - IfNotPresent
@@ -5037,17 +5005,19 @@ spec:
                 - name
                 type: object
               publishConnectionDetailsTo:
-                description: PublishConnectionDetailsTo specifies the connection secret
-                  config which contains a name, metadata and a reference to secret
-                  store config to which any connection details for this managed resource
-                  should be written. Connection details frequently include the endpoint,
-                  username, and password required to connect to the managed resource.
+                description: |-
+                  PublishConnectionDetailsTo specifies the connection secret config which
+                  contains a name, metadata and a reference to secret store config to
+                  which any connection details for this managed resource should be written.
+                  Connection details frequently include the endpoint, username,
+                  and password required to connect to the managed resource.
                 properties:
                   configRef:
                     default:
                       name: default
-                    description: SecretStoreConfigRef specifies which secret store
-                      config should be used for this ConnectionSecret.
+                    description: |-
+                      SecretStoreConfigRef specifies which secret store config should be used
+                      for this ConnectionSecret.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -5057,21 +5027,21 @@ spec:
                         properties:
                           resolution:
                             default: Required
-                            description: Resolution specifies whether resolution of
-                              this reference is required. The default is 'Required',
-                              which means the reconcile will fail if the reference
-                              cannot be resolved. 'Optional' means this reference
-                              will be a no-op if it cannot be resolved.
+                            description: |-
+                              Resolution specifies whether resolution of this reference is required.
+                              The default is 'Required', which means the reconcile will fail if the
+                              reference cannot be resolved. 'Optional' means this reference will be
+                              a no-op if it cannot be resolved.
                             enum:
                             - Required
                             - Optional
                             type: string
                           resolve:
-                            description: Resolve specifies when this reference should
-                              be resolved. The default is 'IfNotPresent', which will
-                              attempt to resolve the reference only when the corresponding
-                              field is not present. Use 'Always' to resolve the reference
-                              on every reconcile.
+                            description: |-
+                              Resolve specifies when this reference should be resolved. The default
+                              is 'IfNotPresent', which will attempt to resolve the reference only when
+                              the corresponding field is not present. Use 'Always' to resolve the
+                              reference on every reconcile.
                             enum:
                             - Always
                             - IfNotPresent
@@ -5086,21 +5056,22 @@ spec:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Annotations are the annotations to be added to
-                          connection secret. - For Kubernetes secrets, this will be
-                          used as "metadata.annotations". - It is up to Secret Store
-                          implementation for others store types.
+                        description: |-
+                          Annotations are the annotations to be added to connection secret.
+                          - For Kubernetes secrets, this will be used as "metadata.annotations".
+                          - It is up to Secret Store implementation for others store types.
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Labels are the labels/tags to be added to connection
-                          secret. - For Kubernetes secrets, this will be used as "metadata.labels".
-                          - It is up to Secret Store implementation for others store
-                          types.
+                        description: |-
+                          Labels are the labels/tags to be added to connection secret.
+                          - For Kubernetes secrets, this will be used as "metadata.labels".
+                          - It is up to Secret Store implementation for others store types.
                         type: object
                       type:
-                        description: Type is the SecretType for the connection secret.
+                        description: |-
+                          Type is the SecretType for the connection secret.
                           - Only valid for Kubernetes Secret Stores.
                         type: string
                     type: object
@@ -5111,14 +5082,15 @@ spec:
                 - name
                 type: object
               writeConnectionSecretToRef:
-                description: WriteConnectionSecretToReference specifies the namespace
-                  and name of a Secret to which any connection details for this managed
-                  resource should be written. Connection details frequently include
-                  the endpoint, username, and password required to connect to the
-                  managed resource. This field is planned to be replaced in a future
-                  release in favor of PublishConnectionDetailsTo. Currently, both
-                  could be set independently and connection details would be published
-                  to both without affecting each other.
+                description: |-
+                  WriteConnectionSecretToReference specifies the namespace and name of a
+                  Secret to which any connection details for this managed resource should
+                  be written. Connection details frequently include the endpoint, username,
+                  and password required to connect to the managed resource.
+                  This field is planned to be replaced in a future release in favor of
+                  PublishConnectionDetailsTo. Currently, both could be set independently
+                  and connection details would be published to both without affecting
+                  each other.
                 properties:
                   name:
                     description: Name of the secret.
@@ -5147,11 +5119,9 @@ spec:
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: ObservedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
+                      description: |-
+                        ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
@@ -5189,11 +5159,9 @@ spec:
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: ObservedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
+                      description: |-
+                        ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
@@ -5223,13 +5191,15 @@ spec:
                   description: A Condition that may apply to a resource.
                   properties:
                     lastTransitionTime:
-                      description: LastTransitionTime is the last time this condition
-                        transitioned from one status to another.
+                      description: |-
+                        LastTransitionTime is the last time this condition transitioned from one
+                        status to another.
                       format: date-time
                       type: string
                     message:
-                      description: A Message containing details about this condition's
-                        last transition from one status to another, if any.
+                      description: |-
+                        A Message containing details about this condition's last transition from
+                        one status to another, if any.
                       type: string
                     reason:
                       description: A Reason for this condition's last transition from
@@ -5240,8 +5210,9 @@ spec:
                         False, or Unknown?
                       type: string
                     type:
-                      description: Type of this condition. At most one of each condition
-                        type may apply to a resource at any point in time.
+                      description: |-
+                        Type of this condition. At most one of each condition type may apply to
+                        a resource at any point in time.
                       type: string
                   required:
                   - lastTransitionTime
@@ -5271,11 +5242,9 @@ spec:
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: ObservedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
+                      description: |-
+                        ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
@@ -5315,11 +5284,9 @@ spec:
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: ObservedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
+                      description: |-
+                        ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
@@ -5344,8 +5311,9 @@ spec:
                   type: object
                 type: array
               schedules:
-                description: Schedules keeps track of random generated schedules,
-                  is overwriten by schedules set in the service's spec.
+                description: |-
+                  Schedules keeps track of random generated schedules, is overwriten by
+                  schedules set in the service's spec.
                 properties:
                   backup:
                     description: Backup keeps track of the backup schedule.
@@ -5354,9 +5322,9 @@ spec:
                     description: Maintenance keeps track of the maintenance schedule.
                     properties:
                       dayOfWeek:
-                        description: DayOfWeek specifies at which weekday the maintenance
-                          is held place. Allowed values are [monday, tuesday, wednesday,
-                          thursday, friday, saturday, sunday]
+                        description: |-
+                          DayOfWeek specifies at which weekday the maintenance is held place.
+                          Allowed values are [monday, tuesday, wednesday, thursday, friday, saturday, sunday]
                         enum:
                         - monday
                         - tuesday
@@ -5367,8 +5335,9 @@ spec:
                         - sunday
                         type: string
                       timeOfDay:
-                        description: 'TimeOfDay for installing updates in UTC. Format:
-                          "hh:mm:ss".'
+                        description: |-
+                          TimeOfDay for installing updates in UTC.
+                          Format: "hh:mm:ss".
                         pattern: ^([0-1]?[0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9])$
                         type: string
                     type: object
@@ -5387,11 +5356,9 @@ spec:
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: ObservedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
+                      description: |-
+                        ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
@@ -5429,11 +5396,9 @@ spec:
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: ObservedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
+                      description: |-
+                        ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer


### PR DESCRIPTION
## Summary

Without the `inline` json tag, the field will be nested a level deeper in the object. This will lead to empty fields during runtime, as the marshaller can't correctly unmarshal the K8s objects.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
