### PR TITLE
Get namespace via claimnamespace label

### DIFF
--- a/pkg/sliexporter/vshnkeycloak_controller/vshnkeycloak_controller.go
+++ b/pkg/sliexporter/vshnkeycloak_controller/vshnkeycloak_controller.go
@@ -97,7 +97,7 @@ func (r VSHNKeycloakReconciler) getKeycloakProber(ctx context.Context, obj slire
 		return nil, fmt.Errorf("cannot parse certificate: %w", err)
 	}
 
-	return probes.NewHTTP(url, true, cert, vshnKeycloakServiceKey, inst.GetName(), inst.GetNamespace(), org, string(sla), ha), nil
+	return probes.NewHTTP(url, true, cert, vshnKeycloakServiceKey, inst.GetName(), inst.GetLabels()[slireconciler.ClaimNamespaceLabel], org, string(sla), ha), nil
 }
 
 // SetupWithManager sets up the controller with the Manager.


### PR DESCRIPTION


## Summary

The composite is cluster scoped, so it does not contain a namespace. Instead it needs to be read from the labels.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
