### PR TITLE
Fix loadbalancer issues

### DIFF
--- a/pkg/comp-functions/functions/vshnpostgres/connection_details.go
+++ b/pkg/comp-functions/functions/vshnpostgres/connection_details.go
@@ -32,12 +32,6 @@ const (
 	defaultDB     = "postgres"
 )
 
-// connectionSecretResourceName is the resource name defined in the composition
-// This name is different from metadata.name of the same resource
-// The value is hardcoded in the composition for each resource and due to crossplane limitation
-// it cannot be matched to the metadata.name
-var connectionSecretResourceName = "connection"
-
 // AddConnectionDetails changes the desired state of a FunctionIO
 func AddConnectionDetails(ctx context.Context, svc *runtime.ServiceRuntime) *v1beta1.Result {
 	log := controllerruntime.LoggerFrom(ctx)

--- a/pkg/comp-functions/functions/vshnpostgres/loadBalancer.go
+++ b/pkg/comp-functions/functions/vshnpostgres/loadBalancer.go
@@ -74,9 +74,7 @@ func AddLoadBalancerIPToConnectionDetails(ctx context.Context, svc *runtime.Serv
 		return runtime.NewWarningResult("LoadBalancerIP is not ready yet")
 	}
 
-	if err := updateConnectionSecretWithLoadBalancerIP(ctx, svc, k8sservice); err != nil {
-		return runtime.NewFatalResult(fmt.Errorf("Cannot update connection secret: %w", err))
-	}
+	updateConnectionSecretWithLoadBalancerIP(ctx, svc, k8sservice)
 
 	return nil
 }
@@ -92,15 +90,9 @@ func getObservedService(ctx context.Context, svc *runtime.ServiceRuntime, servic
 	return service, err
 }
 
-func updateConnectionSecretWithLoadBalancerIP(ctx context.Context, svc *runtime.ServiceRuntime, service *v1.Service) error {
-	s := &v1.Secret{}
-	err := svc.GetObservedKubeObject(s, connectionSecretResourceName)
-	if err != nil {
-		return err
-	}
+func updateConnectionSecretWithLoadBalancerIP(ctx context.Context, svc *runtime.ServiceRuntime, service *v1.Service) {
 
 	ip := service.Status.LoadBalancer.Ingress[0].IP
 	svc.SetConnectionDetail("LOADBALANCER_IP", []byte(ip))
 
-	return nil
 }


### PR DESCRIPTION
## Summary

* The loadbalancer logic still relied on the old connection detail secret, that has been removed 
* This prevented the service to ever get synced/ready, as it was erroring while looking for the secret

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
