### PR TITLE
Fix typo preventing the correct api being called

### DIFF
--- a/pkg/maintenance/helm/helmpatcher.go
+++ b/pkg/maintenance/helm/helmpatcher.go
@@ -221,7 +221,7 @@ func GetRelease(ctx context.Context, k8sClient client.Client, instanceNamespace 
 
 func (h *ImagePatcher) getVersions(imageURL string) (VersionLister, error) {
 	// We're using docker hub's rich api to list the image tags, if it's on docker hub.
-	if strings.Contains(imageURL, "http://hub.docker.com") {
+	if strings.Contains(imageURL, "https//hub.docker.com") {
 		return h.getHubVersions(imageURL)
 	}
 	// For the rest we use the default registry API.


### PR DESCRIPTION


## Summary

There was a typo in the api detection which lead to chosing the wrong API, thus breaking the maintenance.
## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
