### PR TITLE
Reduce max length even further

### DIFF
--- a/config/controller/webhooks.yaml
+++ b/config/controller/webhooks.yaml
@@ -42,7 +42,7 @@ webhooks:
     - UPDATE
     - DELETE
     resources:
-    - postgresqls
+    - vshnpostgresqls
   sideEffects: None
 - admissionReviewVersions:
   - v1

--- a/pkg/controller/webhooks/postgresql.go
+++ b/pkg/controller/webhooks/postgresql.go
@@ -20,7 +20,7 @@ import (
 )
 
 // See https://book.kubebuilder.io/reference/markers/webhook for docs
-//+kubebuilder:webhook:verbs=create;update;delete,path=/validate-vshn-appcat-vshn-io-v1-vshnpostgresql,mutating=false,failurePolicy=fail,groups=vshn.appcat.vshn.io,resources=postgresqls,versions=v1,name=postgresql.vshn.appcat.vshn.io,sideEffects=None,admissionReviewVersions=v1
+//+kubebuilder:webhook:verbs=create;update;delete,path=/validate-vshn-appcat-vshn-io-v1-vshnpostgresql,mutating=false,failurePolicy=fail,groups=vshn.appcat.vshn.io,resources=vshnpostgresqls,versions=v1,name=postgresql.vshn.appcat.vshn.io,sideEffects=None,admissionReviewVersions=v1
 
 //RBAC
 //+kubebuilder:rbac:groups=vshn.appcat.vshn.io,resources=xvshnpostgresqls,verbs=get;list;watch;patch;update
@@ -86,7 +86,7 @@ func (p *PostgreSQLWebhookHandler) ValidateCreate(ctx context.Context, obj runti
 	if err != nil {
 		allErrs = append(allErrs, &field.Error{
 			Field: ".metadata.name",
-			Detail: fmt.Sprintf("Please shorten PostgreSQL name, currently it is: %s",
+			Detail: fmt.Sprintf("Please shorten PostgreSQL name to 30 characters or less: %s",
 				err.Error()),
 			BadValue: pg.GetName(),
 			Type:     field.ErrorTypeTooLong,
@@ -278,7 +278,7 @@ func (p *PostgreSQLWebhookHandler) checkGuaranteedAvailability(ctx context.Conte
 // https://kubernetes.io/docs/concepts/overview/working-with-objects/names/
 func (r *PostgreSQLWebhookHandler) validateResourceNameLength(name string) error {
 	if len(name) > 30 {
-		return fmt.Errorf("name is too long: %d. We add various postfixes and CronJob name length has it's own limitations: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names", len(name))
+		return fmt.Errorf("current length: %d. We add various postfixes and CronJob name length has it's own limitations: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names", len(name))
 	}
 	return nil
 }

--- a/pkg/controller/webhooks/postgresql.go
+++ b/pkg/controller/webhooks/postgresql.go
@@ -274,10 +274,10 @@ func (p *PostgreSQLWebhookHandler) checkGuaranteedAvailability(ctx context.Conte
 	return fieldErrs
 }
 
-// k8s limitation is 52 characters, our longest postfix we add is 15 character, therefore 37 chracters is the maximum length
+// k8s limitation is 56 characters, longest postfix for sgbackups is 26 character, therefore 30 chracters is the maximum length
 // https://kubernetes.io/docs/concepts/overview/working-with-objects/names/
 func (r *PostgreSQLWebhookHandler) validateResourceNameLength(name string) error {
-	if len(name) > 37 {
+	if len(name) > 30 {
 		return fmt.Errorf("name is too long: %d. We add various postfixes and CronJob name length has it's own limitations: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names", len(name))
 	}
 	return nil


### PR DESCRIPTION
## Summary

* There's a case where stackgres produces even longer suffixes

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
