### PR TITLE
Support for both Vacuum and Repack

### DIFF
--- a/apis/vshn/v1/dbaas_vshn_postgresql.go
+++ b/apis/vshn/v1/dbaas_vshn_postgresql.go
@@ -148,10 +148,9 @@ type VSHNPostgreSQLServiceSpec struct {
 	// PgBouncerSettings passes additional configuration to the pgBouncer instance.
 	PgBouncerSettings *sgv1.SGPoolingConfigSpecPgBouncerPgbouncerIni `json:"pgBouncerSettings,omitempty"`
 
-	// +kubebuilder:validation:Enum=true;false
 	// +kubebuilder:default=true
+	// This is default option if neither repack or vacuum are selected
 	RepackEnabled bool `json:"repackEnabled,omitempty"`
-	// +kubebuilder:validation:Enum=true;false
 	// +kubebuilder:default=false
 	VacuumEnabled bool `json:"vacuumEnabled,omitempty"`
 }

--- a/apis/vshn/v1/dbaas_vshn_postgresql.go
+++ b/apis/vshn/v1/dbaas_vshn_postgresql.go
@@ -147,6 +147,13 @@ type VSHNPostgreSQLServiceSpec struct {
 
 	// PgBouncerSettings passes additional configuration to the pgBouncer instance.
 	PgBouncerSettings *sgv1.SGPoolingConfigSpecPgBouncerPgbouncerIni `json:"pgBouncerSettings,omitempty"`
+
+	// +kubebuilder:validation:Enum=true;false
+	// +kubebuilder:default=true
+	RepackEnabled bool `json:"repackEnabled,omitempty"`
+	// +kubebuilder:validation:Enum=true;false
+	// +kubebuilder:default=false
+	VacuumEnabled bool `json:"vacuumEnabled,omitempty"`
 }
 
 // VSHNDBaaSPostgresExtension contains the name of a single extension.

--- a/crds/vshn.appcat.vshn.io_vshnkeycloaks.yaml
+++ b/crds/vshn.appcat.vshn.io_vshnkeycloaks.yaml
@@ -4454,9 +4454,7 @@ spec:
                                   x-kubernetes-preserve-unknown-fields: true
                                 repackEnabled:
                                   default: true
-                                  enum:
-                                    - true
-                                    - false
+                                  description: This is default option if neither repack or vacuum are selected
                                   type: boolean
                                 serviceLevel:
                                   default: besteffort
@@ -4467,9 +4465,6 @@ spec:
                                   type: string
                                 vacuumEnabled:
                                   default: false
-                                  enum:
-                                    - true
-                                    - false
                                   type: boolean
                               type: object
                             size:

--- a/crds/vshn.appcat.vshn.io_vshnkeycloaks.yaml
+++ b/crds/vshn.appcat.vshn.io_vshnkeycloaks.yaml
@@ -4452,6 +4452,12 @@ spec:
                                   description: PGSettings contains additional PostgreSQL settings.
                                   type: object
                                   x-kubernetes-preserve-unknown-fields: true
+                                repackEnabled:
+                                  default: true
+                                  enum:
+                                    - true
+                                    - false
+                                  type: boolean
                                 serviceLevel:
                                   default: besteffort
                                   description: ServiceLevel defines the service level of this service. Either Best Effort or Guaranteed Availability is allowed.
@@ -4459,6 +4465,12 @@ spec:
                                     - besteffort
                                     - guaranteed
                                   type: string
+                                vacuumEnabled:
+                                  default: false
+                                  enum:
+                                    - true
+                                    - false
+                                  type: boolean
                               type: object
                             size:
                               description: Size contains settings to control the sizing of a service.

--- a/crds/vshn.appcat.vshn.io_vshnpostgresqls.yaml
+++ b/crds/vshn.appcat.vshn.io_vshnpostgresqls.yaml
@@ -4372,9 +4372,7 @@ spec:
                           x-kubernetes-preserve-unknown-fields: true
                         repackEnabled:
                           default: true
-                          enum:
-                            - true
-                            - false
+                          description: This is default option if neither repack or vacuum are selected
                           type: boolean
                         serviceLevel:
                           default: besteffort
@@ -4385,9 +4383,6 @@ spec:
                           type: string
                         vacuumEnabled:
                           default: false
-                          enum:
-                            - true
-                            - false
                           type: boolean
                       type: object
                       default: {}

--- a/crds/vshn.appcat.vshn.io_vshnpostgresqls.yaml
+++ b/crds/vshn.appcat.vshn.io_vshnpostgresqls.yaml
@@ -4370,6 +4370,12 @@ spec:
                           description: PGSettings contains additional PostgreSQL settings.
                           type: object
                           x-kubernetes-preserve-unknown-fields: true
+                        repackEnabled:
+                          default: true
+                          enum:
+                            - true
+                            - false
+                          type: boolean
                         serviceLevel:
                           default: besteffort
                           description: ServiceLevel defines the service level of this service. Either Best Effort or Guaranteed Availability is allowed.
@@ -4377,6 +4383,12 @@ spec:
                             - besteffort
                             - guaranteed
                           type: string
+                        vacuumEnabled:
+                          default: false
+                          enum:
+                            - true
+                            - false
+                          type: boolean
                       type: object
                       default: {}
                     size:

--- a/crds/vshn.appcat.vshn.io_xvshnkeycloaks.yaml
+++ b/crds/vshn.appcat.vshn.io_xvshnkeycloaks.yaml
@@ -5561,6 +5561,12 @@ spec:
                                   settings.
                                 type: object
                                 x-kubernetes-preserve-unknown-fields: true
+                              repackEnabled:
+                                default: true
+                                enum:
+                                - true
+                                - false
+                                type: boolean
                               serviceLevel:
                                 default: besteffort
                                 description: ServiceLevel defines the service level
@@ -5570,6 +5576,12 @@ spec:
                                 - besteffort
                                 - guaranteed
                                 type: string
+                              vacuumEnabled:
+                                default: false
+                                enum:
+                                - true
+                                - false
+                                type: boolean
                             type: object
                           size:
                             description: Size contains settings to control the sizing

--- a/crds/vshn.appcat.vshn.io_xvshnkeycloaks.yaml
+++ b/crds/vshn.appcat.vshn.io_xvshnkeycloaks.yaml
@@ -5563,9 +5563,8 @@ spec:
                                 x-kubernetes-preserve-unknown-fields: true
                               repackEnabled:
                                 default: true
-                                enum:
-                                - true
-                                - false
+                                description: This is default option if neither repack
+                                  or vacuum are selected
                                 type: boolean
                               serviceLevel:
                                 default: besteffort
@@ -5578,9 +5577,6 @@ spec:
                                 type: string
                               vacuumEnabled:
                                 default: false
-                                enum:
-                                - true
-                                - false
                                 type: boolean
                             type: object
                           size:

--- a/crds/vshn.appcat.vshn.io_xvshnpostgresqls.yaml
+++ b/crds/vshn.appcat.vshn.io_xvshnpostgresqls.yaml
@@ -5053,6 +5053,12 @@ spec:
                         description: PGSettings contains additional PostgreSQL settings.
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
+                      repackEnabled:
+                        default: true
+                        enum:
+                        - true
+                        - false
+                        type: boolean
                       serviceLevel:
                         default: besteffort
                         description: ServiceLevel defines the service level of this
@@ -5062,6 +5068,12 @@ spec:
                         - besteffort
                         - guaranteed
                         type: string
+                      vacuumEnabled:
+                        default: false
+                        enum:
+                        - true
+                        - false
+                        type: boolean
                     type: object
                   size:
                     description: Size contains settings to control the sizing of a

--- a/crds/vshn.appcat.vshn.io_xvshnpostgresqls.yaml
+++ b/crds/vshn.appcat.vshn.io_xvshnpostgresqls.yaml
@@ -5055,9 +5055,8 @@ spec:
                         x-kubernetes-preserve-unknown-fields: true
                       repackEnabled:
                         default: true
-                        enum:
-                        - true
-                        - false
+                        description: This is default option if neither repack or vacuum
+                          are selected
                         type: boolean
                       serviceLevel:
                         default: besteffort
@@ -5070,9 +5069,6 @@ spec:
                         type: string
                       vacuumEnabled:
                         default: false
-                        enum:
-                        - true
-                        - false
                         type: boolean
                     type: object
                   size:

--- a/pkg/comp-functions/functions/vshnpostgres/maintenance.go
+++ b/pkg/comp-functions/functions/vshnpostgres/maintenance.go
@@ -61,6 +61,20 @@ var (
 			},
 		},
 	}
+	clusterPolicyRules = []rbacv1.PolicyRule{
+		{
+			APIGroups: []string{
+				"vshn.appcat.vshn.io",
+			},
+			Resources: []string{
+				"vshnpostgresqls",
+			},
+			Verbs: []string{
+				"get",
+				"list",
+			},
+		},
+	}
 	extraEnvVars = []corev1.EnvVar{
 		{
 			Name: "SG_NAMESPACE",
@@ -130,6 +144,7 @@ func addSchedules(ctx context.Context, svc *runtime.ServiceRuntime) *xfnproto.Re
 		WithPolicyRules(policyRules).
 		WithExtraEnvs(extraEnvVars...).
 		WithExtraResources(createMaintenanceSecret(instanceNamespace, sgNamespace, comp.GetName()+"-maintenance-secret")).
+		WithClusterRole(clusterPolicyRules).
 		Run(ctx)
 }
 

--- a/pkg/comp-functions/functions/vshnpostgres/maintenance.go
+++ b/pkg/comp-functions/functions/vshnpostgres/maintenance.go
@@ -3,10 +3,12 @@ package vshnpostgres
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	xkubev1 "github.com/crossplane-contrib/provider-kubernetes/apis/object/v1alpha1"
 	xfnproto "github.com/crossplane/function-sdk-go/proto/v1beta1"
 	stackgresv1 "github.com/vshn/appcat/v4/apis/stackgres/v1"
+
 	vshnv1 "github.com/vshn/appcat/v4/apis/vshn/v1"
 	"github.com/vshn/appcat/v4/pkg/comp-functions/functions/common/maintenance"
 	"github.com/vshn/appcat/v4/pkg/comp-functions/runtime"
@@ -96,6 +98,14 @@ var (
 				},
 			},
 		},
+		{
+			Name:  "REPACK_ENABLED",
+			Value: "",
+		},
+		{
+			Name:  "VACUUM_ENABLED",
+			Value: "",
+		},
 	}
 )
 
@@ -116,6 +126,9 @@ func addSchedules(ctx context.Context, svc *runtime.ServiceRuntime) *xfnproto.Re
 	if err != nil {
 		return runtime.NewFatalResult(fmt.Errorf("cannot get cluster object: %w", err))
 	}
+
+	extraEnvVars[3].Value = strconv.FormatBool(comp.Spec.Parameters.Service.RepackEnabled)
+	extraEnvVars[4].Value = strconv.FormatBool(comp.Spec.Parameters.Service.VacuumEnabled)
 
 	backups := *cluster.Spec.Configurations.Backups
 	backups[0].CronSchedule = ptr.To(comp.GetBackupSchedule())

--- a/pkg/comp-functions/functions/vshnpostgres/maintenance.go
+++ b/pkg/comp-functions/functions/vshnpostgres/maintenance.go
@@ -61,20 +61,7 @@ var (
 			},
 		},
 	}
-	clusterPolicyRules = []rbacv1.PolicyRule{
-		{
-			APIGroups: []string{
-				"vshn.appcat.vshn.io",
-			},
-			Resources: []string{
-				"vshnpostgresqls",
-			},
-			Verbs: []string{
-				"get",
-				"list",
-			},
-		},
-	}
+
 	extraEnvVars = []corev1.EnvVar{
 		{
 			Name: "SG_NAMESPACE",
@@ -144,7 +131,6 @@ func addSchedules(ctx context.Context, svc *runtime.ServiceRuntime) *xfnproto.Re
 		WithPolicyRules(policyRules).
 		WithExtraEnvs(extraEnvVars...).
 		WithExtraResources(createMaintenanceSecret(instanceNamespace, sgNamespace, comp.GetName()+"-maintenance-secret")).
-		WithClusterRole(clusterPolicyRules).
 		Run(ctx)
 }
 

--- a/pkg/controller/webhooks/postgresql_test.go
+++ b/pkg/controller/webhooks/postgresql_test.go
@@ -146,6 +146,9 @@ func TestPostgreSQLWebhookHandler_ValidateCreate(t *testing.T) {
 					Memory: "1Gi",
 				},
 				Instances: 1,
+				Service: vshnv1.VSHNPostgreSQLServiceSpec{
+					RepackEnabled: true,
+				},
 			},
 		},
 	}

--- a/pkg/maintenance/postgresql_test.go
+++ b/pkg/maintenance/postgresql_test.go
@@ -228,6 +228,13 @@ func TestPostgreSQL_DoMaintenance(t *testing.T) {
 						Name:      "myclaim",
 						Namespace: "default",
 					},
+					Spec: vshnv1.VSHNPostgreSQLSpec{
+						Parameters: vshnv1.VSHNPostgreSQLParameters{
+							Service: vshnv1.VSHNPostgreSQLServiceSpec{
+								RepackEnabled: true,
+							},
+						},
+					},
 				},
 			},
 			wantedClaim: &vshnv1.VSHNPostgreSQL{
@@ -253,6 +260,19 @@ func TestPostgreSQL_DoMaintenance(t *testing.T) {
 					Spec: stackgresv1.SGClusterSpec{
 						Postgres: stackgresv1.SGClusterSpecPostgres{
 							Version: "15.0",
+						},
+					},
+				},
+				&vshnv1.VSHNPostgreSQL{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "myclaim",
+						Namespace: "default",
+					},
+					Spec: vshnv1.VSHNPostgreSQLSpec{
+						Parameters: vshnv1.VSHNPostgreSQLParameters{
+							Service: vshnv1.VSHNPostgreSQLServiceSpec{
+								RepackEnabled: true,
+							},
 						},
 					},
 				},
@@ -289,6 +309,19 @@ func TestPostgreSQL_DoMaintenance(t *testing.T) {
 						},
 					},
 				},
+				&vshnv1.VSHNPostgreSQL{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "myclaim",
+						Namespace: "default",
+					},
+					Spec: vshnv1.VSHNPostgreSQLSpec{
+						Parameters: vshnv1.VSHNPostgreSQLParameters{
+							Service: vshnv1.VSHNPostgreSQLServiceSpec{
+								RepackEnabled: true,
+							},
+						},
+					},
+				},
 			},
 			wantedOps: &stackgresv1.SGDbOps{
 				ObjectMeta: metav1.ObjectMeta{
@@ -318,6 +351,19 @@ func TestPostgreSQL_DoMaintenance(t *testing.T) {
 					Spec: stackgresv1.SGClusterSpec{
 						Postgres: stackgresv1.SGClusterSpecPostgres{
 							Version: "15.0",
+						},
+					},
+				},
+				&vshnv1.VSHNPostgreSQL{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "myclaim",
+						Namespace: "default",
+					},
+					Spec: vshnv1.VSHNPostgreSQLSpec{
+						Parameters: vshnv1.VSHNPostgreSQLParameters{
+							Service: vshnv1.VSHNPostgreSQLServiceSpec{
+								RepackEnabled: true,
+							},
 						},
 					},
 				},


### PR DESCRIPTION
## Summary

* This PR gives possibility to set vacuum and/or repack to be run during maintenance

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [x] Link this PR to related issues.

