### PR TITLE
Inject loadbalancer specific annotations

### DIFF
--- a/pkg/comp-functions/functions/vshnpostgres/loadBalancer.go
+++ b/pkg/comp-functions/functions/vshnpostgres/loadBalancer.go
@@ -17,7 +17,7 @@ import (
 
 var serviceName = "primary-service"
 
-func AddLoadBalancerIPToConnectionDetails(ctx context.Context, svc *runtime.ServiceRuntime) *xfnproto.Result {
+func AddPrimaryService(ctx context.Context, svc *runtime.ServiceRuntime) *xfnproto.Result {
 
 	comp, err := getVSHNPostgreSQL(ctx, svc)
 

--- a/pkg/comp-functions/functions/vshnpostgres/loadBalancer.go
+++ b/pkg/comp-functions/functions/vshnpostgres/loadBalancer.go
@@ -19,10 +19,6 @@ var serviceName = "primary-service"
 
 func AddLoadBalancerIPToConnectionDetails(ctx context.Context, svc *runtime.ServiceRuntime) *xfnproto.Result {
 
-	if !svc.GetBoolFromCompositionConfig("externalDatabaseConnectionsEnabled") {
-		return nil
-	}
-
 	comp, err := getVSHNPostgreSQL(ctx, svc)
 
 	if err != nil {
@@ -30,7 +26,7 @@ func AddLoadBalancerIPToConnectionDetails(ctx context.Context, svc *runtime.Serv
 	}
 
 	annotations := map[string]string{}
-	if svc.Config.Data["loadbalancerAnnotations"] != "" {
+	if svc.Config.Data["loadbalancerAnnotations"] != "" && svc.GetBoolFromCompositionConfig("externalDatabaseConnectionsEnabled") {
 
 		err := yaml.Unmarshal([]byte(svc.Config.Data["loadbalancerAnnotations"]), annotations)
 		if err != nil {
@@ -63,7 +59,7 @@ func AddLoadBalancerIPToConnectionDetails(ctx context.Context, svc *runtime.Serv
 		},
 	}
 
-	if comp.Spec.Parameters.Network.ServiceType == "LoadBalancer" {
+	if comp.Spec.Parameters.Network.ServiceType == "LoadBalancer" && svc.GetBoolFromCompositionConfig("externalDatabaseConnectionsEnabled") {
 		k8sservice.Spec.Type = v1.ServiceTypeLoadBalancer
 	} else {
 		k8sservice.Spec.Type = v1.ServiceTypeClusterIP

--- a/pkg/comp-functions/functions/vshnpostgres/loadBalancer_test.go
+++ b/pkg/comp-functions/functions/vshnpostgres/loadBalancer_test.go
@@ -18,13 +18,11 @@ func TestNothingToDo(t *testing.T) {
 		svc.Config.Data["externalDatabaseConnectionsEnabled"] = "true"
 
 		// When
-		result := AddLoadBalancerIPToConnectionDetails(ctx, svc)
+		result := AddPrimaryService(ctx, svc)
 
 		desired := svc.GetAllDesired()
 
-		if len(desired) != 2 {
-			t.Fatal("Expected 2 resources in desired, got", len(desired))
-		}
+		assert.Len(t, desired, 2)
 
 		// Then
 		assert.NotNil(t, result)
@@ -42,7 +40,7 @@ func TestLoadBalancerParameterSet(t *testing.T) {
 		svc.Config.Data["externalDatabaseConnectionsEnabled"] = "true"
 
 		// When
-		result := AddLoadBalancerIPToConnectionDetails(ctx, svc)
+		result := AddPrimaryService(ctx, svc)
 
 		// Then
 		assert.NotNil(t, result)
@@ -59,26 +57,26 @@ func TestLoadBalancerServiceObserverCreated(t *testing.T) {
 		svc.Config.Data["externalDatabaseConnectionsEnabled"] = "true"
 
 		// When
-		result := AddLoadBalancerIPToConnectionDetails(ctx, svc)
+		result := AddPrimaryService(ctx, svc)
 
 		// Then
 		assert.Nil(t, result)
 	})
 }
 
-// this test normally should return Warning because it's copy of TestLoadBalancerParameterSet()
-// but due to disabled LoadBalancer in config it returns Normal
+// The primary-service should be deployed even if loadbalancing is disabled.
+// However it should not be allowed to be set to type LoadBalancer.
 func TestLoadBalancerNotEnabled(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("Verify composition", func(t *testing.T) {
 
 		//Given
-		svc := commontest.LoadRuntimeFromFile(t, "vshn-postgres/loadbalancer/01-LoadBalancerSet.yaml")
+		svc := commontest.LoadRuntimeFromFile(t, "vshn-postgres/loadbalancer/02-ServiceObserverPresent.yaml")
 		svc.Config.Data["externalDatabaseConnectionsEnabled"] = "false"
 
 		// When
-		result := AddLoadBalancerIPToConnectionDetails(ctx, svc)
+		result := AddPrimaryService(ctx, svc)
 
 		// Then
 		assert.Nil(t, result)

--- a/pkg/comp-functions/functions/vshnpostgres/register.go
+++ b/pkg/comp-functions/functions/vshnpostgres/register.go
@@ -51,7 +51,7 @@ func init() {
 			},
 			{
 				Name:    "load-balancer",
-				Execute: AddLoadBalancerIPToConnectionDetails,
+				Execute: AddPrimaryService,
 			},
 			{
 				Name:    "namespaceQuotas",


### PR DESCRIPTION
## Summary

* Some APPUiO managed instances need specific labels on the `service` objects to work properly
* This change allows passing these annotations via the composition inputs
* Also fix an issue where the `primary-service` is not deployed if loadbalancer is disabled. It's still necessary for port-forwarding

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
