### PR TITLE
Also log if the probe has a timeout

### DIFF
--- a/pkg/sliexporter/probes/manager.go
+++ b/pkg/sliexporter/probes/manager.go
@@ -175,6 +175,7 @@ func (m Manager) sendProbe(ctx context.Context, p Prober) {
 			prometheus.Labels{"reason": "success"},
 		).Observe(latency.Seconds())
 	case errors.Is(err, ErrTimeout) || errors.Is(ctx.Err(), context.DeadlineExceeded):
+		l.V(0).Error(err, "Probe Timeout")
 		o.With(
 			prometheus.Labels{"reason": "fail-timeout"},
 		).Observe(latency.Seconds())


### PR DESCRIPTION
## Summary
Currently, the logs don't indicate at all that the probes are failing if there are timeouts. We only export that information.

This makes it hard to find these, as the Sloth metrics don't indicate the type of errors. We have to look at the raw SLI metrics to find out that there are timeouts.


## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
