### PR TITLE
Update netpol postgres status

### DIFF
--- a/apis/vshn/v1/dbaas_vshn_postgresql.go
+++ b/apis/vshn/v1/dbaas_vshn_postgresql.go
@@ -218,17 +218,17 @@ type VSHNPostgreSQLStatus struct {
 	// InstanceNamespace contains the name of the namespace where the instance resides
 	InstanceNamespace string `json:"instanceNamespace,omitempty"`
 	// PostgreSQLConditions contains the status conditions of the backing object.
-	PostgreSQLConditions         []v1.Condition `json:"postgresqlConditions,omitempty"`
-	NamespaceConditions          []v1.Condition `json:"namespaceConditions,omitempty"`
-	ProfileConditions            []v1.Condition `json:"profileConditions,omitempty"`
-	PGConfigConditions           []v1.Condition `json:"pgconfigConditions,omitempty"`
-	PGClusterConditions          []v1.Condition `json:"pgclusterConditions,omitempty"`
-	SecretsConditions            []v1.Condition `json:"secretConditions,omitempty"`
-	ObjectBucketConditions       []v1.Condition `json:"objectBucketConditions,omitempty"`
-	ObjectBackupConfigConditions []v1.Condition `json:"objectBackupConfigConditions,omitempty"`
-	NetworkPolicyConditions      []v1.Condition `json:"networkPolicyConditions,omitempty"`
-	LocalCAConditions            []v1.Condition `json:"localCAConditions,omitempty"`
-	CertificateConditions        []v1.Condition `json:"certificateConditions,omitempty"`
+	PostgreSQLConditions         []v1.Condition   `json:"postgresqlConditions,omitempty"`
+	NamespaceConditions          []v1.Condition   `json:"namespaceConditions,omitempty"`
+	ProfileConditions            []v1.Condition   `json:"profileConditions,omitempty"`
+	PGConfigConditions           []v1.Condition   `json:"pgconfigConditions,omitempty"`
+	PGClusterConditions          []v1.Condition   `json:"pgclusterConditions,omitempty"`
+	SecretsConditions            []v1.Condition   `json:"secretConditions,omitempty"`
+	ObjectBucketConditions       []v1.Condition   `json:"objectBucketConditions,omitempty"`
+	ObjectBackupConfigConditions []v1.Condition   `json:"objectBackupConfigConditions,omitempty"`
+	NetworkPolicyConditions      []xpv1.Condition `json:"networkPolicyConditions,omitempty"`
+	LocalCAConditions            []v1.Condition   `json:"localCAConditions,omitempty"`
+	CertificateConditions        []v1.Condition   `json:"certificateConditions,omitempty"`
 	// IsEOL indicates if this instance is using an EOL version of PostgreSQL.
 	IsEOL bool `json:"isEOL,omitempty"`
 	// Schedules keeps track of random generated schedules, is overwriten by

--- a/apis/vshn/v1/zz_generated.deepcopy.go
+++ b/apis/vshn/v1/zz_generated.deepcopy.go
@@ -5,6 +5,7 @@
 package v1
 
 import (
+	commonv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
 	stackgresv1 "github.com/vshn/appcat/v4/apis/stackgres/v1"
 	apisv1 "github.com/vshn/appcat/v4/apis/v1"
@@ -958,7 +959,7 @@ func (in *VSHNPostgreSQLStatus) DeepCopyInto(out *VSHNPostgreSQLStatus) {
 	}
 	if in.NetworkPolicyConditions != nil {
 		in, out := &in.NetworkPolicyConditions, &out.NetworkPolicyConditions
-		*out = make([]apisv1.Condition, len(*in))
+		*out = make([]commonv1.Condition, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}

--- a/crds/vshn.appcat.vshn.io_vshnpostgresqls.yaml
+++ b/crds/vshn.appcat.vshn.io_vshnpostgresqls.yaml
@@ -4683,39 +4683,35 @@ spec:
                   type: array
                 networkPolicyConditions:
                   items:
+                    description: A Condition that may apply to a resource.
                     properties:
                       lastTransitionTime:
-                        description: LastTransitionTime is the last time the condition transitioned from one status to another.
+                        description: |-
+                          LastTransitionTime is the last time this condition transitioned from one
+                          status to another.
                         format: date-time
                         type: string
                       message:
-                        description: Message is a human-readable message indicating details about the transition.
-                        maxLength: 32768
-                        type: string
-                      observedGeneration:
                         description: |-
-                          ObservedGeneration represents the .metadata.generation that the condition was set based upon.
-                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
-                        format: int64
-                        minimum: 0
-                        type: integer
+                          A Message containing details about this condition's last transition from
+                          one status to another, if any.
+                        type: string
                       reason:
-                        description: Reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                        maxLength: 1024
-                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        description: A Reason for this condition's last transition from one status to another.
                         type: string
                       status:
-                        description: Status of the condition, one of True, False, Unknown.
-                        enum:
-                          - "True"
-                          - "False"
-                          - Unknown
+                        description: Status of this condition; is it currently True, False, or Unknown?
                         type: string
                       type:
-                        description: Type of condition.
-                        maxLength: 316
-                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        description: |-
+                          Type of this condition. At most one of each condition type may apply to
+                          a resource at any point in time.
                         type: string
+                    required:
+                      - lastTransitionTime
+                      - reason
+                      - status
+                      - type
                     type: object
                   type: array
                 objectBackupConfigConditions:

--- a/crds/vshn.appcat.vshn.io_xvshnpostgresqls.yaml
+++ b/crds/vshn.appcat.vshn.io_xvshnpostgresqls.yaml
@@ -5423,42 +5423,37 @@ spec:
                 type: array
               networkPolicyConditions:
                 items:
+                  description: A Condition that may apply to a resource.
                   properties:
                     lastTransitionTime:
-                      description: LastTransitionTime is the last time the condition
-                        transitioned from one status to another.
+                      description: |-
+                        LastTransitionTime is the last time this condition transitioned from one
+                        status to another.
                       format: date-time
                       type: string
                     message:
-                      description: Message is a human-readable message indicating
-                        details about the transition.
-                      maxLength: 32768
-                      type: string
-                    observedGeneration:
                       description: |-
-                        ObservedGeneration represents the .metadata.generation that the condition was set based upon.
-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
-                      format: int64
-                      minimum: 0
-                      type: integer
+                        A Message containing details about this condition's last transition from
+                        one status to another, if any.
+                      type: string
                     reason:
-                      description: Reason contains a programmatic identifier indicating
-                        the reason for the condition's last transition.
-                      maxLength: 1024
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      description: A Reason for this condition's last transition from
+                        one status to another.
                       type: string
                     status:
-                      description: Status of the condition, one of True, False, Unknown.
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
+                      description: Status of this condition; is it currently True,
+                        False, or Unknown?
                       type: string
                     type:
-                      description: Type of condition.
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      description: |-
+                        Type of this condition. At most one of each condition type may apply to
+                        a resource at any point in time.
                       type: string
+                  required:
+                  - lastTransitionTime
+                  - reason
+                  - status
+                  - type
                   type: object
                 type: array
               objectBackupConfigConditions:

--- a/pkg/comp-functions/functions/vshnpostgres/register.go
+++ b/pkg/comp-functions/functions/vshnpostgres/register.go
@@ -77,6 +77,10 @@ func init() {
 				Name:    "ensure-objectbucket-labels",
 				Execute: EnsureObjectBucketLabels,
 			},
+			{
+				Name:    "update-status",
+				Execute: UpdateStatus,
+			},
 		},
 	})
 }

--- a/pkg/comp-functions/functions/vshnpostgres/status.go
+++ b/pkg/comp-functions/functions/vshnpostgres/status.go
@@ -1,0 +1,37 @@
+package vshnpostgres
+
+import (
+	"context"
+	"fmt"
+	xkube "github.com/crossplane-contrib/provider-kubernetes/apis/object/v1alpha1"
+	xfnproto "github.com/crossplane/function-sdk-go/proto/v1beta1"
+	vshnv1 "github.com/vshn/appcat/v4/apis/vshn/v1"
+	"github.com/vshn/appcat/v4/pkg/comp-functions/runtime"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+)
+
+func UpdateStatus(ctx context.Context, svc *runtime.ServiceRuntime) *xfnproto.Result {
+	log := controllerruntime.LoggerFrom(ctx)
+
+	comp := &vshnv1.VSHNPostgreSQL{}
+	err := svc.GetObservedComposite(comp)
+	if err != nil {
+		return runtime.NewFatalResult(fmt.Errorf("cannot get composite: %w", err))
+	}
+
+	np := &xkube.Object{}
+	err = svc.GetObservedComposedResource(np, comp.GetName()+"-netpol")
+	if err != nil && err == runtime.ErrNotFound {
+		return runtime.NewNormalResult(fmt.Sprintf("Object %s missing. Skipping status update", comp.GetName()+"-netpol"))
+	} else if err != nil {
+		return runtime.NewFatalResult(fmt.Errorf("cannot get network policy: %w", err))
+	}
+
+	log.Info("Update network policy conditions")
+	comp.Status.NetworkPolicyConditions = np.Status.Conditions
+	err = svc.SetDesiredCompositeStatus(comp)
+	if err != nil {
+		return runtime.NewFatalResult(fmt.Errorf("cannot get update composite status: %w", err))
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

The status of network policy in the composite of postgresql has been removed when the netpol has been moved to comp-function. As a consequence the e2e tests would not pass and the status of netpol would miss from the composite. This PR makes sure the status is back in the composite.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
