### PR TITLE
Fix setting broken tags

### DIFF
--- a/pkg/maintenance/helm/helmpatcher.go
+++ b/pkg/maintenance/helm/helmpatcher.go
@@ -135,6 +135,10 @@ func (h *ImagePatcher) DoMaintenance(ctx context.Context, tagURL string, tagPath
 		return fmt.Errorf("cannot get versions from Docker Hub: %v", err)
 	}
 
+	if len(results.GetVersions()) == 0 {
+		return fmt.Errorf("no images found! Please check url")
+	}
+
 	h.log.Info("Getting release")
 	release, err := GetRelease(ctx, h.k8sClient, h.instanceNamespace)
 	if err != nil {
@@ -301,7 +305,9 @@ func SemVerPatchesOnly(ignoreBuild bool) func(results VersionLister, currentTag 
 			}
 		}
 		if currentV.EQ(newV) {
-			return currentV.String(), nil
+			// Don't return the semver representation! Sometimes there might be
+			// a v1.0 but no v1.0.0 tag for an image (AKA Bitnami doing an oopsie).
+			return currentTag, nil
 		}
 		return newV.String(), nil
 	}

--- a/pkg/maintenance/helm/helmpatcher_test.go
+++ b/pkg/maintenance/helm/helmpatcher_test.go
@@ -139,13 +139,13 @@ func Test_PatchRelease(t *testing.T) {
 }
 
 func Test_compareSemanticVersion(t *testing.T) {
-	defaultV, _ := semver.ParseTolerant("7.0")
+	defaultV := "7.0"
 	tests := []struct {
 		name              string
 		instanceNamespace string
 		release           *v1beta1.Release
 		results           []Result
-		expectedVer       semver.Version
+		expectedVer       string
 		expectedNew       bool
 		expectedErr       string
 	}{
@@ -185,7 +185,7 @@ func Test_compareSemanticVersion(t *testing.T) {
 				getResult("7.0.14-alpha", "active", "image"),
 				getResult("7.0.14%alpa", "active", "image"),
 			},
-			expectedVer: semver.MustParse("7.0.13"),
+			expectedVer: semver.MustParse("7.0.13").String(),
 		},
 		{
 			name:              "WhenNoNewVersion_ThenReleaseNoNewVersion",
@@ -289,7 +289,7 @@ func Test_compareSemanticVersion(t *testing.T) {
 			}
 
 			assert.NoError(t, err)
-			assert.Equal(t, tt.expectedVer.String(), version)
+			assert.Equal(t, tt.expectedVer, version)
 		})
 	}
 }


### PR DESCRIPTION
This commit fixes two things:

* If the slice with tags is empty, it will exit with an error. This should help detect issues with wrong urls.
* If current tag is the latest one, it will return the exact same tag. Not a semver representation of it.

The second point avoids issues if there is a tag v1.0 of an image, but no tag v1.0.0. As the semver representation will always contain three parts for the version.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
