### PR TITLE
Don't override pgSettings with observed values

### DIFF
--- a/pkg/comp-functions/functions/vshnpostgres/extensions.go
+++ b/pkg/comp-functions/functions/vshnpostgres/extensions.go
@@ -89,9 +89,9 @@ func enableTimescaleDB(ctx context.Context, svc *runtime.ServiceRuntime) error {
 
 	config := &stackgresv1.SGPostgresConfig{}
 
-	err := svc.GetObservedKubeObject(config, configResourceName)
+	err := svc.GetDesiredKubeObject(config, configResourceName)
 	if err != nil && err == runtime.ErrNotFound {
-		controllerruntime.LoggerFrom(ctx).Info("no pg-conf observed")
+		controllerruntime.LoggerFrom(ctx).Info("no pg-conf found")
 		return nil
 	} else if err != nil {
 		return err
@@ -102,8 +102,8 @@ func enableTimescaleDB(ctx context.Context, svc *runtime.ServiceRuntime) error {
 	}
 
 	if !strings.Contains(config.Spec.PostgresqlConf[sharedLibraries], timescaleExtName) {
-		append := config.Spec.PostgresqlConf[sharedLibraries]
-		config.Spec.PostgresqlConf[sharedLibraries] = fmt.Sprintf("%s,%s", append, timescaleExtName)
+		toAppend := config.Spec.PostgresqlConf[sharedLibraries]
+		config.Spec.PostgresqlConf[sharedLibraries] = fmt.Sprintf("%s,%s", toAppend, timescaleExtName)
 	}
 
 	return svc.SetDesiredKubeObject(config, configResourceName)
@@ -113,9 +113,9 @@ func disableTimescaleDB(ctx context.Context, svc *runtime.ServiceRuntime) error 
 
 	config := &stackgresv1.SGPostgresConfig{}
 
-	err := svc.GetObservedKubeObject(config, configResourceName)
+	err := svc.GetDesiredKubeObject(config, configResourceName)
 	if err != nil && err == runtime.ErrNotFound {
-		controllerruntime.LoggerFrom(ctx).Info("no pg-conf observed")
+		controllerruntime.LoggerFrom(ctx).Info("no pg-conf found")
 		return nil
 	} else if err != nil {
 		return err

--- a/pkg/comp-functions/functions/vshnpostgres/extensions_test.go
+++ b/pkg/comp-functions/functions/vshnpostgres/extensions_test.go
@@ -43,6 +43,8 @@ func Test_enableTimescaleDB(t *testing.T) {
 		assert.NoError(t, svc.GetDesiredKubeObject(config, configResourceName))
 
 		assert.Contains(t, config.Spec.PostgresqlConf[sharedLibraries], timescaleExtName)
+
+		assert.Contains(t, config.Spec.PostgresqlConf["max_connections"], "200")
 	}
 }
 

--- a/test/functions/vshn-postgres/extensions/01-GivenAlreadyEnabled.yaml
+++ b/test/functions/vshn-postgres/extensions/01-GivenAlreadyEnabled.yaml
@@ -23,6 +23,44 @@ desired:
         writeConnectionSecretToRef: {}
       status: {}
   resources:
+    pg-conf:
+      resource:
+        apiVersion: kubernetes.crossplane.io/v1alpha1
+        kind: Object
+        metadata:
+          generateName: pgsql-app1-prod-wdhkp-
+          name: pgsql-app1-prod-wdhkp-pgconf
+        spec:
+          deletionPolicy: Delete
+          forProvider:
+            manifest:
+              apiVersion: stackgres.io/v1
+              kind: SGPostgresConfig
+              metadata:
+                name: pgsql-app1-prod-wdhkp
+                namespace: vshn-postgresql-pgsql-app1-prod-wdhkp
+              spec:
+                postgresVersion: "15"
+                postgresql.conf:
+                  shared_preload_libraries: pg_stat_statements, auto_explain
+                  max_connections: "200"
+          managementPolicy: Default
+          providerConfigRef:
+            name: kubernetes
+        status:
+          atProvider:
+            manifest:
+              apiVersion: stackgres.io/v1
+              kind: SGPostgresConfig
+              metadata:
+                name: pgsql-app1-prod-wdhkp
+              spec:
+                postgresVersion: "15"
+                postgresql.conf:
+                  shared_preload_libraries: pg_stat_statements, auto_explain
+              status:
+                defaultParameters:
+                  shared_preload_libraries: pg_stat_statements, auto_explain
     cluster:
       resource:
         apiVersion: kubernetes.crossplane.io/v1alpha1
@@ -88,42 +126,3 @@ observed:
           maintenance:
             dayOfWeek: tuesday
             timeOfDay: "23:32:00"
-  resources:
-    pg-conf:
-      resource:
-        apiVersion: kubernetes.crossplane.io/v1alpha1
-        kind: Object
-        metadata:
-          generateName: pgsql-app1-prod-wdhkp-
-          name: pgsql-app1-prod-wdhkp-pgconf
-        spec:
-          deletionPolicy: Delete
-          forProvider:
-            manifest:
-              apiVersion: stackgres.io/v1
-              kind: SGPostgresConfig
-              metadata:
-                name: pgsql-app1-prod-wdhkp
-                namespace: vshn-postgresql-pgsql-app1-prod-wdhkp
-              spec:
-                postgresVersion: "15"
-                postgresql.conf:
-                  shared_preload_libraries: pg_stat_statements, auto_explain
-          managementPolicy: Default
-          providerConfigRef:
-            name: kubernetes
-        status:
-          atProvider:
-            manifest:
-              apiVersion: stackgres.io/v1
-              kind: SGPostgresConfig
-              metadata:
-                name: pgsql-app1-prod-wdhkp
-              spec:
-                postgresVersion: "15"
-                postgresql.conf:
-                  shared_preload_libraries: pg_stat_statements, auto_explain
-              status:
-                defaultParameters:
-                  shared_preload_libraries: pg_stat_statements, auto_explain
-

--- a/test/functions/vshn-postgres/extensions/01-GivenFreshConfig.yaml
+++ b/test/functions/vshn-postgres/extensions/01-GivenFreshConfig.yaml
@@ -23,6 +23,44 @@ desired:
         writeConnectionSecretToRef: {}
       status: {}
   resources:
+    pg-conf:
+      resource:
+        apiVersion: kubernetes.crossplane.io/v1alpha1
+        kind: Object
+        metadata:
+          generateName: pgsql-app1-prod-wdhkp-
+          name: pgsql-app1-prod-wdhkp-pgconf
+        spec:
+          deletionPolicy: Delete
+          forProvider:
+            manifest:
+              apiVersion: stackgres.io/v1
+              kind: SGPostgresConfig
+              metadata:
+                name: pgsql-app1-prod-wdhkp
+                namespace: vshn-postgresql-pgsql-app1-prod-wdhkp
+              spec:
+                postgresVersion: "15"
+                postgresql.conf:
+                  shared_preload_libraries: pg_stat_statements, auto_explain
+                  max_connections: "200"
+          managementPolicy: Default
+          providerConfigRef:
+            name: kubernetes
+        status:
+          atProvider:
+            manifest:
+              apiVersion: stackgres.io/v1
+              kind: SGPostgresConfig
+              metadata:
+                name: pgsql-app1-prod-wdhkp
+              spec:
+                postgresVersion: "15"
+                postgresql.conf:
+                  shared_preload_libraries: pg_stat_statements, auto_explain
+              status:
+                defaultParameters:
+                  shared_preload_libraries: pg_stat_statements, auto_explain
     cluster:
       resource:
         apiVersion: kubernetes.crossplane.io/v1alpha1
@@ -88,42 +126,3 @@ observed:
           maintenance:
             dayOfWeek: tuesday
             timeOfDay: "23:32:00"
-  resources:
-    pg-conf:
-      resource:
-        apiVersion: kubernetes.crossplane.io/v1alpha1
-        kind: Object
-        metadata:
-          generateName: pgsql-app1-prod-wdhkp-
-          name: pgsql-app1-prod-wdhkp-pgconf
-        spec:
-          deletionPolicy: Delete
-          forProvider:
-            manifest:
-              apiVersion: stackgres.io/v1
-              kind: SGPostgresConfig
-              metadata:
-                name: pgsql-app1-prod-wdhkp
-                namespace: vshn-postgresql-pgsql-app1-prod-wdhkp
-              spec:
-                postgresVersion: "15"
-                postgresql.conf:
-                  shared_preload_libraries: pg_stat_statements, auto_explain
-          managementPolicy: Default
-          providerConfigRef:
-            name: kubernetes
-        status:
-          atProvider:
-            manifest:
-              apiVersion: stackgres.io/v1
-              kind: SGPostgresConfig
-              metadata:
-                name: pgsql-app1-prod-wdhkp
-              spec:
-                postgresVersion: "15"
-                postgresql.conf:
-                  shared_preload_libraries: pg_stat_statements, auto_explain
-              status:
-                defaultParameters:
-                  shared_preload_libraries: pg_stat_statements, auto_explain
-


### PR DESCRIPTION
## Summary

This commit fixes a bug where we overwrote observed pg settings to the desired pg settings.

This caused custom settings specified in the claim to never reach the K8s API in the first place. So the observed state always contained the default settings that StackGres injects into the object.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
