### PR TITLE
Fix bug in copyjob

### DIFF
--- a/pkg/comp-functions/functions/vshnpostgres/postgresql_deploy.go
+++ b/pkg/comp-functions/functions/vshnpostgres/postgresql_deploy.go
@@ -81,7 +81,7 @@ func DeployPostgreSQL(ctx context.Context, svc *runtime.ServiceRuntime) *xfnprot
 		return runtime.NewWarningResult(fmt.Errorf("cannot create podMonitor object: %w", err).Error())
 	}
 
-	if comp.Spec.Parameters.Restore != nil {
+	if comp.Spec.Parameters.Restore != nil && comp.Spec.Parameters.Restore.BackupName != "" && comp.Spec.Parameters.Restore.ClaimName != "" {
 		l.Info("Create copy job")
 		err = createCopyJob(comp, svc)
 		if err != nil {


### PR DESCRIPTION
## Summary

The Restore object will never be nil.
We need to check for the fields in the Restore object directly.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [ ] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
