### PR TITLE
Escape the names of generated secrets

### DIFF
--- a/pkg/comp-functions/functions/common/password.go
+++ b/pkg/comp-functions/functions/common/password.go
@@ -24,7 +24,7 @@ func AddCredentialsSecret(comp InfoGetter, svc *runtime.ServiceRuntime, fieldLis
 // With the difference that the resource name can be chosen.
 // This is helpful if multiple different random generated passwords are necessary.
 func AddGenericSecret(comp InfoGetter, svc *runtime.ServiceRuntime, suffix string, fieldList []string) (string, error) {
-	secretObjectName := comp.GetName() + "-" + suffix
+	secretObjectName := runtime.EscapeDNS1123(comp.GetName()+"-"+suffix, false)
 	secret := &corev1.Secret{}
 	cd := []xkube.ConnectionDetail{}
 	err := svc.GetObservedKubeObject(secret, secretObjectName)

--- a/pkg/comp-functions/runtime/function_mgr.go
+++ b/pkg/comp-functions/runtime/function_mgr.go
@@ -335,7 +335,7 @@ func (s *ServiceRuntime) SetDesiredComposedResourceWithName(obj xpresource.Manag
 	s.addOwnerReferenceAnnotation(obj, true)
 
 	escapeK8sNames(obj)
-	name = escapeDNS1123(name, false)
+	name = EscapeDNS1123(name, false)
 
 	for _, opt := range opts {
 		opt(obj)
@@ -412,7 +412,7 @@ func KubeOptionAddRefs(refs ...xkube.Reference) KubeObjectOption {
 // The associated secret will have the UID of the parent object as the name.
 func KubeOptionAddConnectionDetails(destNamespace string, cd ...xkube.ConnectionDetail) KubeObjectOption {
 	return func(obj *xkube.Object) {
-		objName := escapeDNS1123(obj.GetName()+"-cd", false)
+		objName := EscapeDNS1123(obj.GetName()+"-cd", false)
 
 		obj.Spec.ConnectionDetails = cd
 		obj.Spec.WriteConnectionSecretToReference = &xpv1.SecretReference{
@@ -621,7 +621,7 @@ func (s *ServiceRuntime) GetConnectionDetails() map[string][]byte {
 // composed resource.
 // Returns an empty map if not found.
 func (s *ServiceRuntime) GetObservedComposedResourceConnectionDetails(objectName string) (map[string][]byte, error) {
-	objectName = escapeDNS1123(objectName, false)
+	objectName = EscapeDNS1123(objectName, false)
 	object, ok := s.req.Observed.Resources[objectName]
 	if !ok {
 		return map[string][]byte{}, ErrNotFound
@@ -632,7 +632,7 @@ func (s *ServiceRuntime) GetObservedComposedResourceConnectionDetails(objectName
 
 // GetObservedComposedResource returns and unmarshalls the observed object into the given managed resource.
 func (s *ServiceRuntime) GetObservedComposedResource(obj xpresource.Managed, name string) error {
-	name = escapeDNS1123(name, false)
+	name = EscapeDNS1123(name, false)
 	resources, err := request.GetObservedComposedResources(s.req)
 	if err != nil {
 		return err
@@ -655,7 +655,7 @@ func (s *ServiceRuntime) GetObservedComposedResource(obj xpresource.Managed, nam
 // GetDesiredComposedResourceByName will return a desired composed resource from the request.
 // Use this, if you want anything from a previous function in the pipeline.
 func (s *ServiceRuntime) GetDesiredComposedResourceByName(obj xpresource.Managed, name string) error {
-	name = escapeDNS1123(name, false)
+	name = EscapeDNS1123(name, false)
 	if res, ok := s.desiredResources[resource.Name(name)]; ok {
 		jsonString, err := res.Resource.Unstructured.MarshalJSON()
 		if err != nil {
@@ -718,7 +718,7 @@ func (s *ServiceRuntime) AddObservedConnectionDetails(name string) error {
 
 // GetObservedKubeObject returns the object as is on the cluster.
 func (s *ServiceRuntime) GetObservedKubeObject(obj client.Object, name string) error {
-	name = escapeDNS1123(name, false)
+	name = EscapeDNS1123(name, false)
 	resources, err := request.GetObservedComposedResources(s.req)
 	if err != nil {
 		return err
@@ -750,7 +750,7 @@ func (s *ServiceRuntime) GetObservedKubeObject(obj client.Object, name string) e
 
 // GetDesiredKubeObject returns the object as is on the cluster.
 func (s *ServiceRuntime) GetDesiredKubeObject(obj client.Object, name string) error {
-	name = escapeDNS1123(name, false)
+	name = EscapeDNS1123(name, false)
 	res, ok := s.desiredResources[resource.Name(name)]
 	if !ok {
 		return ErrNotFound

--- a/pkg/comp-functions/runtime/naming.go
+++ b/pkg/comp-functions/runtime/naming.go
@@ -16,32 +16,32 @@ import (
 func escapeK8sNames(obj client.Object) {
 	kind, _, err := composed.Scheme.ObjectKinds(obj)
 	if err != nil {
-		obj.SetName(escapeDNS1123(obj.GetName(), false))
+		obj.SetName(EscapeDNS1123(obj.GetName(), false))
 	}
 
 	switch kind[0].Kind {
 	case "Pod":
-		obj.SetName(escapeDNS1123Label(obj.GetName()))
+		obj.SetName(EscapeDNS1123Label(obj.GetName()))
 	case "Namespace":
-		obj.SetName(escapeDNS1123Label(obj.GetName()))
+		obj.SetName(EscapeDNS1123Label(obj.GetName()))
 	case "Service":
-		obj.SetName(escapeDNS1123Label(obj.GetName()))
+		obj.SetName(EscapeDNS1123Label(obj.GetName()))
 	case "Role":
-		obj.SetName(escapeDNS1123(obj.GetName(), true))
+		obj.SetName(EscapeDNS1123(obj.GetName(), true))
 	case "ClusterRole":
-		obj.SetName(escapeDNS1123(obj.GetName(), true))
+		obj.SetName(EscapeDNS1123(obj.GetName(), true))
 	case "RoleBinding":
-		obj.SetName(escapeDNS1123(obj.GetName(), true))
+		obj.SetName(EscapeDNS1123(obj.GetName(), true))
 	case "ClusterRoleBinding":
-		obj.SetName(escapeDNS1123(obj.GetName(), true))
+		obj.SetName(EscapeDNS1123(obj.GetName(), true))
 	default:
-		obj.SetName(escapeDNS1123(obj.GetName(), false))
+		obj.SetName(EscapeDNS1123(obj.GetName(), false))
 	}
 }
 
-// escapeDNS1123Label does the same as escapeDNS1123 but also limit to 63 chars
-func escapeDNS1123Label(name string) string {
-	name = escapeDNS1123(name, false)
+// EscapeDNS1123Label does the same as escapeDNS1123 but also limit to 63 chars
+func EscapeDNS1123Label(name string) string {
+	name = EscapeDNS1123(name, false)
 	if len(name) > 63 {
 		suffix := hashString(name)
 		name = name[:58] + suffix
@@ -49,14 +49,14 @@ func escapeDNS1123Label(name string) string {
 	return name
 }
 
-// escapeDNS1123 will always return a string that conforms to K8s' DNS subdomain naming scheme
+// EscapeDNS1123 will always return a string that conforms to K8s' DNS subdomain naming scheme
 // contain no more than 253 characters
 // contain only lowercase alphanumeric characters, '-' or '.'
 // start with an alphanumeric character
 // end with an alphanumeric character
 // We also remove any '.' here, so that it can be used as a base function for escaping
 // label names as well.
-func escapeDNS1123(name string, allowColons bool) string {
+func EscapeDNS1123(name string, allowColons bool) string {
 	escapeNameStart := regexp.MustCompile("^[^a-zA-Z0-9]+")
 	escapeNameEnd := regexp.MustCompile("[^a-zA-Z0-9]+$")
 	escapeExpression := regexp.MustCompile("[^a-zA-Z0-9]+")

--- a/pkg/comp-functions/runtime/naming_test.go
+++ b/pkg/comp-functions/runtime/naming_test.go
@@ -63,7 +63,7 @@ func TestServiceRuntime_escapeK8sNames(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := escapeDNS1123(tt.args.name, tt.args.allowColon)
+			got := EscapeDNS1123(tt.args.name, tt.args.allowColon)
 			assert.Equal(t, tt.want, got)
 		})
 	}


### PR DESCRIPTION
## Summary

I think I dropped this escape call at one point when doing a rebase...


## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [ ] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
