### PR TITLE
Refactor and fix Resource calculations

### DIFF
--- a/pkg/comp-functions/functions/common/resources.go
+++ b/pkg/comp-functions/functions/common/resources.go
@@ -17,47 +17,48 @@ type Resources struct {
 // GetResources will return a `Resources` object with the correctly calculated requests,
 // limits and disk space according to the definitions in the plan as well as the overrides
 // in the claim.
-func GetResources(size *vshnv1.VSHNSizeSpec, plan utils.Resources) (Resources, error) {
+func GetResources(size *vshnv1.VSHNSizeSpec, plan utils.Resources) (Resources, []error) {
 	reqMem := resource.Quantity{}
 	reqCPU := resource.Quantity{}
 	mem := resource.Quantity{}
 	cpu := resource.Quantity{}
 	disk := plan.Disk
 
+	var errors []error
 	var err error
 
 	if size.Requests.Memory != "" {
 		reqMem, err = resource.ParseQuantity(size.Requests.Memory)
 		if err != nil {
-			return Resources{}, err
+			errors = append(errors, err)
 		}
 	}
 
 	if size.Requests.CPU != "" {
 		reqCPU, err = resource.ParseQuantity(size.Requests.CPU)
 		if err != nil {
-			return Resources{}, err
+			errors = append(errors, err)
 		}
 	}
 
 	if size.Memory != "" {
 		mem, err = resource.ParseQuantity(size.Memory)
 		if err != nil {
-			return Resources{}, err
+			errors = append(errors, err)
 		}
 	}
 
 	if size.CPU != "" {
 		cpu, err = resource.ParseQuantity(size.CPU)
 		if err != nil {
-			return Resources{}, err
+			errors = append(errors, err)
 		}
 	}
 
 	if size.Disk != "" {
 		disk, err = resource.ParseQuantity(size.Disk)
 		if err != nil {
-			return Resources{}, err
+			errors = append(errors, err)
 		}
 	}
 
@@ -73,7 +74,7 @@ func GetResources(size *vshnv1.VSHNSizeSpec, plan utils.Resources) (Resources, e
 		Mem:    memLimit,
 		CPU:    cpuLimit,
 		Disk:   disk,
-	}, nil
+	}, errors
 }
 
 // getLimit will compare a given limit and request as well as the limit defined in the plan

--- a/pkg/comp-functions/functions/common/resources.go
+++ b/pkg/comp-functions/functions/common/resources.go
@@ -14,6 +14,9 @@ type Resources struct {
 	Disk   resource.Quantity
 }
 
+// GetResources will return a `Resources` object with the correctly calculated requests,
+// limits and disk space according to the definitions in the plan as well as the overrides
+// in the claim.
 func GetResources(size *vshnv1.VSHNSizeSpec, plan utils.Resources) (Resources, error) {
 	reqMem := resource.Quantity{}
 	reqCPU := resource.Quantity{}
@@ -73,6 +76,15 @@ func GetResources(size *vshnv1.VSHNSizeSpec, plan utils.Resources) (Resources, e
 	}, nil
 }
 
+// getLimit will compare a given limit and request as well as the limit defined in the plan
+// and return the appropriate limit.
+// The limit is chosen based on the following logic:
+//   - If claim contains a limit but no request: Use the limit from the claim  as the final limit
+//   - If claim contains a limit and a request: Use the higher of both as the final limit
+//     This avoids having higher requests then limits, which is not supported in k8s.
+//   - If claim contains only request: Use the higher of request and limit in the plan as the final limit
+//     this avoids having higher requests then limits, which is not supported in k8s.
+//   - If no limit or request is defined in the claim, use the plans limit as the final limit.
 func getLimit(req, limit, planLimit resource.Quantity) resource.Quantity {
 
 	finalMem := resource.Quantity{}
@@ -89,21 +101,30 @@ func getLimit(req, limit, planLimit resource.Quantity) resource.Quantity {
 	return finalMem
 }
 
+// getRequest will compare a given limit and request as well as the limit defined in the plan
+// and return the appropriate request.
+// This function assumes, that the given limit is already calculated with the `getLimit` function
+// and passed to this function.
+// The request is chosen based on the following logic:
+//   - If no requests is defined in the claim, use the plans request as the final requests.
+//   - If the claim contains a limt and request, use the lower of both as the final request.
+//     This avoids having higher requests then limits, which is not supported in k8s.
 func getRequest(req, limit, planRequests resource.Quantity) resource.Quantity {
 
-	finalMem := req
+	finalReq := req
 
 	if req.IsZero() {
-		finalMem = planRequests
+		finalReq = planRequests
 	}
 
-	if limit.Cmp(finalMem) == -1 {
-		finalMem = limit
+	if limit.Cmp(finalReq) == -1 {
+		finalReq = limit
 	}
 
-	return finalMem
+	return finalReq
 }
 
+// getHigherQuantity will compare the given quantities and return the higher one.
 func getHigherQuantity(a, b resource.Quantity) resource.Quantity {
 
 	if a.Cmp(b) == -1 {

--- a/pkg/comp-functions/functions/common/resources.go
+++ b/pkg/comp-functions/functions/common/resources.go
@@ -3,43 +3,111 @@ package common
 import (
 	vshnv1 "github.com/vshn/appcat/v4/apis/vshn/v1"
 	"github.com/vshn/appcat/v4/pkg/common/utils"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 type Resources struct {
-	ReqMem string
-	ReqCPU string
-	Mem    string
-	CPU    string
-	Disk   string
+	ReqMem resource.Quantity
+	ReqCPU resource.Quantity
+	Mem    resource.Quantity
+	CPU    resource.Quantity
+	Disk   resource.Quantity
 }
 
-func GetResources(size *vshnv1.VSHNSizeSpec, r utils.Resources) Resources {
-	reqMem := size.Requests.Memory
-	reqCPU := size.Requests.CPU
-	mem := size.Memory
-	cpu := size.CPU
-	disk := size.Disk
+func GetResources(size *vshnv1.VSHNSizeSpec, plan utils.Resources) (Resources, error) {
+	reqMem := resource.Quantity{}
+	reqCPU := resource.Quantity{}
+	mem := resource.Quantity{}
+	cpu := resource.Quantity{}
+	disk := plan.Disk
 
-	if reqMem == "" {
-		reqMem = r.MemoryRequests.String()
+	var err error
+
+	if size.Requests.Memory != "" {
+		reqMem, err = resource.ParseQuantity(size.Requests.Memory)
+		if err != nil {
+			return Resources{}, err
+		}
 	}
-	if reqCPU == "" {
-		reqCPU = r.CPURequests.String()
+
+	if size.Requests.CPU != "" {
+		reqCPU, err = resource.ParseQuantity(size.Requests.CPU)
+		if err != nil {
+			return Resources{}, err
+		}
 	}
-	if mem == "" {
-		mem = r.MemoryLimits.String()
+
+	if size.Memory != "" {
+		mem, err = resource.ParseQuantity(size.Memory)
+		if err != nil {
+			return Resources{}, err
+		}
 	}
-	if cpu == "" {
-		cpu = r.CPULimits.String()
+
+	if size.CPU != "" {
+		cpu, err = resource.ParseQuantity(size.CPU)
+		if err != nil {
+			return Resources{}, err
+		}
 	}
-	if disk == "" {
-		disk = r.Disk.String()
+
+	if size.Disk != "" {
+		disk, err = resource.ParseQuantity(size.Disk)
+		if err != nil {
+			return Resources{}, err
+		}
 	}
+
+	memLimit := getLimit(reqMem, mem, plan.MemoryLimits)
+	memReq := getRequest(reqMem, memLimit, plan.MemoryRequests)
+
+	cpuLimit := getLimit(reqCPU, cpu, plan.CPULimits)
+	cpuReq := getRequest(reqCPU, cpuLimit, plan.CPURequests)
+
 	return Resources{
-		ReqMem: reqMem,
-		ReqCPU: reqCPU,
-		Mem:    mem,
-		CPU:    cpu,
+		ReqMem: memReq,
+		ReqCPU: cpuReq,
+		Mem:    memLimit,
+		CPU:    cpuLimit,
 		Disk:   disk,
+	}, nil
+}
+
+func getLimit(req, limit, planLimit resource.Quantity) resource.Quantity {
+
+	finalMem := resource.Quantity{}
+
+	if !limit.IsZero() && req.IsZero() {
+		finalMem = limit
+	} else if !limit.IsZero() && !req.IsZero() {
+		finalMem = getHigherQuantity(req, limit)
+	} else if limit.IsZero() && !req.IsZero() {
+		finalMem = getHigherQuantity(req, planLimit)
+	} else {
+		finalMem = planLimit
 	}
+	return finalMem
+}
+
+func getRequest(req, limit, planRequests resource.Quantity) resource.Quantity {
+
+	finalMem := req
+
+	if req.IsZero() {
+		finalMem = planRequests
+	}
+
+	if limit.Cmp(finalMem) == -1 {
+		finalMem = limit
+	}
+
+	return finalMem
+}
+
+func getHigherQuantity(a, b resource.Quantity) resource.Quantity {
+
+	if a.Cmp(b) == -1 {
+		return b
+	}
+	return a
 }

--- a/pkg/comp-functions/functions/common/resources_test.go
+++ b/pkg/comp-functions/functions/common/resources_test.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -101,8 +102,8 @@ func TestResources(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 
-			res, err := GetResources(&tt.claimResources, planResources)
-			assert.NoError(t, err)
+			res, errs := GetResources(&tt.claimResources, planResources)
+			assert.NoError(t, errors.Join(errs...))
 
 			assert.Equal(t, tt.expResult, res)
 		})

--- a/pkg/comp-functions/functions/common/resources_test.go
+++ b/pkg/comp-functions/functions/common/resources_test.go
@@ -15,42 +15,42 @@ func TestResources(t *testing.T) {
 
 	ctx := context.Background()
 	svc := commontest.LoadRuntimeFromFile(t, "plans.yaml")
-	resources, err := utils.FetchPlansFromConfig(ctx, svc, svc.Config.Data["defaultPlan"])
+	planResources, err := utils.FetchPlansFromConfig(ctx, svc, svc.Config.Data["defaultPlan"])
 	assert.NoError(t, err)
 
 	tests := []struct {
-		name      string
-		size      vshnv1.VSHNSizeSpec
-		expResult Resources
+		name           string
+		claimResources vshnv1.VSHNSizeSpec
+		expResult      Resources
 	}{
 		{
-			name: "GivenDefaultPlanNoResources",
-			size: vshnv1.VSHNSizeSpec{},
+			name:           "GivenDefaultPlanNoResources",
+			claimResources: vshnv1.VSHNSizeSpec{},
 			expResult: Resources{
-				ReqMem: resources.MemoryRequests,
-				ReqCPU: resources.CPURequests,
-				Mem:    resources.MemoryLimits,
-				CPU:    resources.CPULimits,
-				Disk:   resources.Disk,
+				ReqMem: planResources.MemoryRequests,
+				ReqCPU: planResources.CPURequests,
+				Mem:    planResources.MemoryLimits,
+				CPU:    planResources.CPULimits,
+				Disk:   planResources.Disk,
 			},
 		},
 		{
 			name: "GivenDefaultPlanCustomLimitHigherThanPlan",
-			size: vshnv1.VSHNSizeSpec{
+			claimResources: vshnv1.VSHNSizeSpec{
 				Memory: "2Gi",
 				CPU:    "500m",
 			},
 			expResult: Resources{
-				ReqMem: resources.MemoryRequests,
-				ReqCPU: resources.CPURequests,
+				ReqMem: planResources.MemoryRequests,
+				ReqCPU: planResources.CPURequests,
 				Mem:    resource.MustParse("2Gi"),
 				CPU:    resource.MustParse("500m"),
-				Disk:   resources.Disk,
+				Disk:   planResources.Disk,
 			},
 		},
 		{
 			name: "GivenDefaultPlanCustomMemoryLimitLowerThanPlan",
-			size: vshnv1.VSHNSizeSpec{
+			claimResources: vshnv1.VSHNSizeSpec{
 				Memory: "100Mi",
 				CPU:    "100m",
 			},
@@ -59,12 +59,12 @@ func TestResources(t *testing.T) {
 				ReqCPU: resource.MustParse("100m"),
 				Mem:    resource.MustParse("100Mi"),
 				CPU:    resource.MustParse("100m"),
-				Disk:   resources.Disk,
+				Disk:   planResources.Disk,
 			},
 		},
 		{
 			name: "GivenDefaultPlanCustomMemoryRequestsHigherThanPlan",
-			size: vshnv1.VSHNSizeSpec{
+			claimResources: vshnv1.VSHNSizeSpec{
 				Requests: vshnv1.VSHNDBaaSSizeRequestsSpec{
 					Memory: "2Gi",
 					CPU:    "1",
@@ -75,12 +75,12 @@ func TestResources(t *testing.T) {
 				ReqCPU: resource.MustParse("1"),
 				Mem:    resource.MustParse("2Gi"),
 				CPU:    resource.MustParse("1"),
-				Disk:   resources.Disk,
+				Disk:   planResources.Disk,
 			},
 		},
 		{
 			name: "GivenDefaultPlanCustomMemoryRequestsHigherThanLimit",
-			size: vshnv1.VSHNSizeSpec{
+			claimResources: vshnv1.VSHNSizeSpec{
 				Requests: vshnv1.VSHNDBaaSSizeRequestsSpec{
 					Memory: "2Gi",
 					CPU:    "1",
@@ -93,7 +93,7 @@ func TestResources(t *testing.T) {
 				ReqCPU: resource.MustParse("1"),
 				Mem:    resource.MustParse("2Gi"),
 				CPU:    resource.MustParse("1"),
-				Disk:   resources.Disk,
+				Disk:   planResources.Disk,
 			},
 		},
 	}
@@ -101,7 +101,7 @@ func TestResources(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 
-			res, err := GetResources(&tt.size, resources)
+			res, err := GetResources(&tt.claimResources, planResources)
 			assert.NoError(t, err)
 
 			assert.Equal(t, tt.expResult, res)

--- a/pkg/comp-functions/functions/common/resources_test.go
+++ b/pkg/comp-functions/functions/common/resources_test.go
@@ -1,0 +1,110 @@
+package common
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	vshnv1 "github.com/vshn/appcat/v4/apis/vshn/v1"
+	"github.com/vshn/appcat/v4/pkg/common/utils"
+	"github.com/vshn/appcat/v4/pkg/comp-functions/functions/commontest"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func TestResources(t *testing.T) {
+
+	ctx := context.Background()
+	svc := commontest.LoadRuntimeFromFile(t, "plans.yaml")
+	resources, err := utils.FetchPlansFromConfig(ctx, svc, svc.Config.Data["defaultPlan"])
+	assert.NoError(t, err)
+
+	tests := []struct {
+		name      string
+		size      vshnv1.VSHNSizeSpec
+		expResult Resources
+	}{
+		{
+			name: "GivenDefaultPlanNoResources",
+			size: vshnv1.VSHNSizeSpec{},
+			expResult: Resources{
+				ReqMem: resources.MemoryRequests,
+				ReqCPU: resources.CPURequests,
+				Mem:    resources.MemoryLimits,
+				CPU:    resources.CPULimits,
+				Disk:   resources.Disk,
+			},
+		},
+		{
+			name: "GivenDefaultPlanCustomLimitHigherThanPlan",
+			size: vshnv1.VSHNSizeSpec{
+				Memory: "2Gi",
+				CPU:    "500m",
+			},
+			expResult: Resources{
+				ReqMem: resources.MemoryRequests,
+				ReqCPU: resources.CPURequests,
+				Mem:    resource.MustParse("2Gi"),
+				CPU:    resource.MustParse("500m"),
+				Disk:   resources.Disk,
+			},
+		},
+		{
+			name: "GivenDefaultPlanCustomMemoryLimitLowerThanPlan",
+			size: vshnv1.VSHNSizeSpec{
+				Memory: "100Mi",
+				CPU:    "100m",
+			},
+			expResult: Resources{
+				ReqMem: resource.MustParse("100Mi"),
+				ReqCPU: resource.MustParse("100m"),
+				Mem:    resource.MustParse("100Mi"),
+				CPU:    resource.MustParse("100m"),
+				Disk:   resources.Disk,
+			},
+		},
+		{
+			name: "GivenDefaultPlanCustomMemoryRequestsHigherThanPlan",
+			size: vshnv1.VSHNSizeSpec{
+				Requests: vshnv1.VSHNDBaaSSizeRequestsSpec{
+					Memory: "2Gi",
+					CPU:    "1",
+				},
+			},
+			expResult: Resources{
+				ReqMem: resource.MustParse("2Gi"),
+				ReqCPU: resource.MustParse("1"),
+				Mem:    resource.MustParse("2Gi"),
+				CPU:    resource.MustParse("1"),
+				Disk:   resources.Disk,
+			},
+		},
+		{
+			name: "GivenDefaultPlanCustomMemoryRequestsHigherThanLimit",
+			size: vshnv1.VSHNSizeSpec{
+				Requests: vshnv1.VSHNDBaaSSizeRequestsSpec{
+					Memory: "2Gi",
+					CPU:    "1",
+				},
+				Memory: "500Mi",
+				CPU:    "500m",
+			},
+			expResult: Resources{
+				ReqMem: resource.MustParse("2Gi"),
+				ReqCPU: resource.MustParse("1"),
+				Mem:    resource.MustParse("2Gi"),
+				CPU:    resource.MustParse("1"),
+				Disk:   resources.Disk,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			res, err := GetResources(&tt.size, resources)
+			assert.NoError(t, err)
+
+			assert.Equal(t, tt.expResult, res)
+		})
+	}
+}

--- a/pkg/comp-functions/functions/vshnkeycloak/deploy.go
+++ b/pkg/comp-functions/functions/vshnkeycloak/deploy.go
@@ -233,7 +233,11 @@ func getResources(ctx context.Context, svc *runtime.ServiceRuntime, comp *vshnv1
 		return common.Resources{}, err
 	}
 
-	res := common.GetResources(&comp.Spec.Parameters.Size, resources)
+	res, err := common.GetResources(&comp.Spec.Parameters.Size, resources)
+	if err != nil {
+		err = fmt.Errorf("Cannot get Resources from plan and claim: %w", err)
+		return common.Resources{}, err
+	}
 
 	return res, nil
 }
@@ -411,12 +415,12 @@ func newValues(ctx context.Context, svc *runtime.ServiceRuntime, comp *vshnv1.VS
 		},
 		"resources": map[string]any{
 			"requests": map[string]any{
-				"memory": res.ReqMem,
-				"cpu":    res.ReqCPU,
+				"memory": res.ReqMem.String(),
+				"cpu":    res.ReqCPU.String(),
 			},
 			"limits": map[string]any{
-				"memory": res.Mem,
-				"cpu":    res.CPU,
+				"memory": res.Mem.String(),
+				"cpu":    res.CPU.String(),
 			},
 		},
 		"nodeSelector": nodeSelector,

--- a/test/functions/plans.yaml
+++ b/test/functions/plans.yaml
@@ -1,0 +1,9 @@
+desired: {}
+input:
+  apiVersion: v1
+  data:
+    defaultPlan: standard-1
+    plans:
+      '{"standard-1": {"size": {"cpu": "250m", "disk": "16Gi", "enabled": true,
+      "memory": "1Gi"}}}'
+observed: {}


### PR DESCRIPTION
## Summary

The resource calculation between the used plan and the overridden values in the claim for the respective resources contained wrong calculations.

We refactored the whole calculations sections to get correct calculations while keeping the code as readable as possible.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
