### PR TITLE
Fix wrong usage of `useExternalPostgreSQL` parameter and add better tests

### DIFF
--- a/pkg/comp-functions/functions/vshnnextcloud/deploy.go
+++ b/pkg/comp-functions/functions/vshnnextcloud/deploy.go
@@ -61,7 +61,7 @@ func DeployNextcloud(ctx context.Context, svc *runtime.ServiceRuntime) *xfnproto
 		return runtime.NewWarningResult(fmt.Sprintf("cannot bootstrap instance namespace: %s", err))
 	}
 
-	if !comp.Spec.Parameters.Service.UseExternalPostgreSQL {
+	if comp.Spec.Parameters.Service.UseExternalPostgreSQL {
 		svc.Log.Info("Adding postgresql instance")
 		err = addPostgreSQL(svc, comp)
 		if err != nil {
@@ -231,7 +231,7 @@ func newValues(ctx context.Context, svc *runtime.ServiceRuntime, comp *vshnv1.VS
 
 	externalDb := map[string]any{}
 
-	if !comp.Spec.Parameters.Service.UseExternalPostgreSQL {
+	if comp.Spec.Parameters.Service.UseExternalPostgreSQL {
 		cd, err := svc.GetObservedComposedResourceConnectionDetails(comp.GetName() + pgInstanceNameSuffix)
 		if err != nil {
 			return nil, err
@@ -321,7 +321,7 @@ func newValues(ctx context.Context, svc *runtime.ServiceRuntime, comp *vshnv1.VS
 		},
 		"securityContext": securityContext,
 		"internalDatabase": map[string]any{
-			"enabled": comp.Spec.Parameters.Service.UseExternalPostgreSQL,
+			"enabled": !comp.Spec.Parameters.Service.UseExternalPostgreSQL,
 		},
 		"startupProbe": map[string]any{
 			"initialDelaySeconds": "5",

--- a/pkg/comp-functions/functions/vshnnextcloud/deploy_test.go
+++ b/pkg/comp-functions/functions/vshnnextcloud/deploy_test.go
@@ -2,13 +2,14 @@ package vshnnextcloud
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	xhelmv1 "github.com/vshn/appcat/v4/apis/helm/release/v1beta1"
 	vshnv1 "github.com/vshn/appcat/v4/apis/vshn/v1"
 	"github.com/vshn/appcat/v4/pkg/comp-functions/functions/commontest"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"github.com/vshn/appcat/v4/pkg/comp-functions/runtime"
 	"k8s.io/utils/ptr"
 )
 
@@ -42,27 +43,55 @@ func Test_addPostgreSQL(t *testing.T) {
 	assert.Equal(t, 1, pg.Spec.Parameters.Backup.Retention)
 }
 
-func Test_addRelease(t *testing.T) {
-	svc := commontest.LoadRuntimeFromFile(t, "vshnnextcloud/01_default.yaml")
+func Test_addNextcloud(t *testing.T) {
+	svc, comp := getNextcloudComp(t, "vshnnextcloud/01_default.yaml")
 
-	comp := &vshnv1.VSHNNextcloud{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "mynextcloud",
-			Namespace: "default",
-		},
-		Spec: vshnv1.VSHNNextcloudSpec{
-			Parameters: vshnv1.VSHNNextcloudParameters{
-				Service: vshnv1.VSHNNextcloudServiceSpec{
-					Version: "29",
-				},
-			},
-		},
-	}
+	ctx := context.TODO()
 
-	assert.NoError(t, addRelease(context.TODO(), svc, comp, "mysecret"))
+	assert.Nil(t, DeployNextcloud(ctx, svc))
+
+	pg := &vshnv1.XVSHNPostgreSQL{}
+	assert.NoError(t, svc.GetDesiredComposedResourceByName(pg, comp.GetName()+pgInstanceNameSuffix))
 
 	release := &xhelmv1.Release{}
-
 	assert.NoError(t, svc.GetDesiredComposedResourceByName(release, comp.GetName()+"-release"))
 
+	values := map[string]any{}
+	assert.NoError(t, json.Unmarshal(release.Spec.ForProvider.Values.Raw, &values))
+	extDb := values["externalDatabase"].(map[string]any)
+	assert.Equal(t, true, extDb["enabled"])
+	intDb := values["internalDatabase"].(map[string]any)
+	assert.Equal(t, false, intDb["enabled"])
+
+}
+
+func Test_addReleaseInternalDB(t *testing.T) {
+	svc, comp := getNextcloudComp(t, "vshnnextcloud/02_no_pg.yaml")
+
+	ctx := context.TODO()
+
+	assert.Nil(t, DeployNextcloud(ctx, svc))
+
+	pg := &vshnv1.XVSHNPostgreSQL{}
+	assert.Error(t, svc.GetDesiredComposedResourceByName(pg, comp.GetName()+pgInstanceNameSuffix))
+
+	release := &xhelmv1.Release{}
+	assert.NoError(t, svc.GetDesiredComposedResourceByName(release, comp.GetName()+"-release"))
+
+	values := map[string]any{}
+	assert.NoError(t, json.Unmarshal(release.Spec.ForProvider.Values.Raw, &values))
+	extDb := values["externalDatabase"].(map[string]any)
+	assert.Equal(t, map[string]any{}, extDb)
+	intDb := values["internalDatabase"].(map[string]any)
+	assert.Equal(t, true, intDb["enabled"])
+}
+
+func getNextcloudComp(t *testing.T, file string) (*runtime.ServiceRuntime, *vshnv1.VSHNNextcloud) {
+	svc := commontest.LoadRuntimeFromFile(t, file)
+
+	comp := &vshnv1.VSHNNextcloud{}
+	err := svc.GetObservedComposite(comp)
+	assert.NoError(t, err)
+
+	return svc, comp
 }

--- a/test/functions/vshnnextcloud/01_default.yaml
+++ b/test/functions/vshnnextcloud/01_default.yaml
@@ -16,7 +16,143 @@ input:
             "disk": "16Gi", "enabled": true, "memory": "8Gi"}}}'
     isOpenshift: "false"
 observed:
+  composite:
+    resource:
+      apiVersion: vshn.appcat.vshn.io/v1
+      kind: XVSHNNextcloud
+      metadata:
+        annotations: null
+        creationTimestamp: "2024-07-08T16:30:28Z"
+        finalizers:
+          - composite.apiextensions.crossplane.io
+        generateName: nextcloud-
+        generation: 1
+        labels:
+          crossplane.io/claim-name: nextcloud
+          crossplane.io/claim-namespace: unit-test
+          crossplane.io/composite: nextcloud-gc9x4
+        name: nextcloud-gc9x4
+      spec:
+        parameters:
+          service:
+            useExternalPostgreSQL: true
+            version: "29"
+        claimRef:
+          apiVersion: vshn.appcat.vshn.io/v1
+          kind: VSHNNextcloud
+          name: nextcloud
+          namespace: unit-test
+        compositionRef:
+          name: vshnnextcloud.vshn.appcat.vshn.io
+        compositionRevisionRef:
+          name: vshnnextcloud.vshn.appcat.vshn.io-ce52f13
+        compositionUpdatePolicy: Automatic
   resources:
-    mynextcloud-pg:
+    nextcloud-gc9x4-claim-ns-observer:
+      resource:
+        apiVersion: v1
+        kind: Object
+        metadata:
+          name: unit-test
+        spec:
+          forProvider:
+            manifest:
+              apiVersion: v1
+              kind: Namespace
+              metadata:
+                name: unit-test
+        status:
+          atProvider:
+            manifest:
+              apiVersion: v1
+              kind: Namespace
+              metadata:
+                name: unit-test
+                labels:
+                  appuio.io/organization: vshn
+    nextcloud-gc9x4-credentials-secret:
       connection_details:
-        foo: YmFyCg==
+        admin: czNjcjN0UGFzcwo=
+    nextcloud-gc9x4-pg:
+      resource:
+        apiVersion: v1
+        kind: Object
+        metadata:
+          name: "nextcloud-gc9x4-pg"
+        spec:
+          forProvider:
+            manifest:
+              apiVersion: vshn.appcat.vshn.io/v1
+              kind: VSHNNextcloud
+              metadata:
+                name: "nextcloud-gc9x4-pg"
+              spec:
+                parameters:
+                  service:
+                    repackEnabled: false
+                    vacuumEnabled: false
+                  backup:
+                    retention: 6
+                    deletionProtection: true
+                    deletionRetention: 7
+                  encryption:
+                    enabled: false
+                  instances: 1
+                  security:
+                    allowAllNamespaces: false
+        status:
+          atProvider:
+            manifest:
+              apiVersion: vshn.appcat.vshn.io/v1
+              kind: VSHNNextcloud
+              metadata:
+                annotations: null
+                creationTimestamp: "2024-07-08T16:30:28Z"
+                generation: 8
+                name: "nextcloud-gc9x4-pg"
+                namespace: vshn-postgresql-nextcloud-gc9x4
+                resourceVersion: "583272583"
+                uid: 44ead047-98de-4e73-9cc0-d99454090a36
+              spec:
+                parameters:
+                  service:
+                    repackEnabled: false
+                    vacuumEnabled: false
+                  backup:
+                    retention: 6
+                    deletionProtection: true
+                    deletionRetention: 7
+                  encryption:
+                    enabled: false
+                  instances: 1
+                  security:
+                    allowAllNamespaces: false
+              status:
+                conditions:
+                - lastTransitionTime: "2024-07-08T14:50:19Z"
+                  reason: Available
+                  status: "True"
+                  type: Ready
+                - lastTransitionTime: "2024-07-08T14:50:18Z"
+                  reason: ReconcileSuccess
+                  status: "True"
+                  type: Synced
+      connection_details:
+        POSTGRESQL_HOST: bmV4dGNsb3VkLWdjOXg0LnZzaG4tcG9zdGdyZXNxbC1uZXh0Y2xvdWQtZ2N4NC5zdmMuY2x1c3Rlci5sb2NhbAo=
+        POSTGRESQL_DB: cG9zdGdyZXMK
+        POSTGRESQL_URL: cG9zdGdyZXM6Ly9wb3N0Z3Jlczo0YTcwLWY2OTItNGE5YS1iMzBAbmV4dGNsb3VkLWdjOXg0LnZzaG4tcG9zdGdyZXNxbC1uZXh0Y2xvdWQtZ2N4NC5zdmMuY2x1c3Rlci5sb2NhbC9wb3N0Z3Jlcwo=
+        POSTGRESQL_USER: cG9zdGdyZXMK
+        POSTGRESQL_PORT: NTQzMgo=
+        POSTGRESQL_PASSWORD: NGE3MC1mNjkyLTRhOWEtYjMwCg==
+      status:
+        conditions:
+        - lastTransitionTime: "2024-07-08T14:50:19Z"
+          reason: Available
+          status: "True"
+          type: Ready
+        - lastTransitionTime: "2024-07-08T14:50:18Z"
+          reason: ReconcileSuccess
+          status: "True"
+          type: Synced
+
+

--- a/test/functions/vshnnextcloud/02_no_pg.yaml
+++ b/test/functions/vshnnextcloud/02_no_pg.yaml
@@ -1,0 +1,75 @@
+desired: {}
+input:
+  apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    annotations: {}
+    labels:
+      name: xfn-config
+    name: xfn-config
+  data:
+    defaultPlan: standard-2
+    controlNamespace: appcat-control
+    plans: '{"standard-2": {"size": {"cpu": "500m", "disk": "16Gi", "enabled":
+            true, "memory": "2Gi"}}, "standard-4": {"size": {"cpu": "1", "disk": "16Gi",
+            "enabled": true, "memory": "4Gi"}}, "standard-8": {"size": {"cpu": "2",
+            "disk": "16Gi", "enabled": true, "memory": "8Gi"}}}'
+    isOpenshift: "false"
+observed:
+  composite:
+    resource:
+      apiVersion: vshn.appcat.vshn.io/v1
+      kind: XVSHNNextcloud
+      metadata:
+        annotations: null
+        creationTimestamp: "2024-07-08T16:30:28Z"
+        finalizers:
+          - composite.apiextensions.crossplane.io
+        generateName: nextcloud-
+        generation: 1
+        labels:
+          crossplane.io/claim-name: nextcloud
+          crossplane.io/claim-namespace: unit-test
+          crossplane.io/composite: nextcloud-gc9x4
+        name: nextcloud-gc9x4
+      spec:
+        parameters:
+          service:
+            useExternalPostgreSQL: false
+            version: "29"
+        claimRef:
+          apiVersion: vshn.appcat.vshn.io/v1
+          kind: VSHNNextcloud
+          name: nextcloud
+          namespace: unit-test
+        compositionRef:
+          name: vshnnextcloud.vshn.appcat.vshn.io
+        compositionRevisionRef:
+          name: vshnnextcloud.vshn.appcat.vshn.io-ce52f13
+        compositionUpdatePolicy: Automatic
+  resources:
+    nextcloud-gc9x4-claim-ns-observer:
+      resource:
+        apiVersion: v1
+        kind: Object
+        metadata:
+          name: unit-test
+        spec:
+          forProvider:
+            manifest:
+              apiVersion: v1
+              kind: Namespace
+              metadata:
+                name: unit-test
+        status:
+          atProvider:
+            manifest:
+              apiVersion: v1
+              kind: Namespace
+              metadata:
+                name: unit-test
+                labels:
+                  appuio.io/organization: vshn
+    nextcloud-gc9x4-credentials-secret:
+      connection_details:
+        admin: czNjcjN0UGFzcwo=


### PR DESCRIPTION
## Summary

* This PR fixes a bug, where the `useExternalPostgreSQL` parameter operates exactly the wrong way. Instead of deploying a PostgreSQL instance when this is enabled, it will deploy one when this parameter is disabled.
* Added tests to catch this issue

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
