### PR TITLE
Fix wrong comment for kubebuilder

### DIFF
--- a/apis/vshn/v1/vshn_nextcloud.go
+++ b/apis/vshn/v1/vshn_nextcloud.go
@@ -106,9 +106,9 @@ type VSHNNextcloudServiceSpec struct {
 	// ServiceLevel defines the service level of this service. Either Best Effort or Guaranteed Availability is allowed.
 	ServiceLevel VSHNDBaaSServiceLevel `json:"serviceLevel,omitempty"`
 
-	// // +kubebuilder:default=true"
+	// +kubebuilder:default=true
 
-	//UseExternalPostgreSQL defines if the VSHNPostgreSQL database backend should be used. Defaults to true. If set to false,
+	// UseExternalPostgreSQL defines if the VSHNPostgreSQL database backend should be used. Defaults to true. If set to false,
 	// the build-in SQLite database is being used.
 	UseExternalPostgreSQL bool `json:"useExternalPostgreSQL,omitempty"`
 

--- a/crds/vshn.appcat.vshn.io_vshnnextclouds.yaml
+++ b/crds/vshn.appcat.vshn.io_vshnnextclouds.yaml
@@ -8605,6 +8605,7 @@ spec:
                             - guaranteed
                           type: string
                         useExternalPostgreSQL:
+                          default: true
                           description: |-
                             UseExternalPostgreSQL defines if the VSHNPostgreSQL database backend should be used. Defaults to true. If set to false,
                             the build-in SQLite database is being used.

--- a/crds/vshn.appcat.vshn.io_xvshnnextclouds.yaml
+++ b/crds/vshn.appcat.vshn.io_xvshnnextclouds.yaml
@@ -10396,6 +10396,7 @@ spec:
                         - guaranteed
                         type: string
                       useExternalPostgreSQL:
+                        default: true
                         description: |-
                           UseExternalPostgreSQL defines if the VSHNPostgreSQL database backend should be used. Defaults to true. If set to false,
                           the build-in SQLite database is being used.


### PR DESCRIPTION
## Summary

* This PR fixes a small bug in the kubebuilder instructions to set the correct default value for the `UseExternalPostgreSQL` parameter

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
