### PR TITLE
Set the FQDN for nextcloud as a required field

### DIFF
--- a/apis/vshn/v1/common_types.go
+++ b/apis/vshn/v1/common_types.go
@@ -192,7 +192,7 @@ type VSHNAccess struct {
 	// User specifies the username. If all other fields are left empty
 	// then a new database with the same name and all permissions will be created.
 	// +kubebuilder:validation:Required
-	User *string `json:"user,omitempty"`
+	User *string `json:"user"`
 
 	// Database is the name of the database to create, defaults to user.
 	Database *string `json:"database,omitempty"`

--- a/apis/vshn/v1/vshn_nextcloud.go
+++ b/apis/vshn/v1/vshn_nextcloud.go
@@ -12,7 +12,6 @@ import (
 // kubebuilder is unable to set a {} default
 //go:generate yq -i e ../../generated/vshn.appcat.vshn.io_vshnnextclouds.yaml --expression "with(.spec.versions[]; .schema.openAPIV3Schema.properties.spec.properties.parameters.default={})"
 //go:generate yq -i e ../../generated/vshn.appcat.vshn.io_vshnnextclouds.yaml --expression "with(.spec.versions[]; .schema.openAPIV3Schema.properties.spec.properties.parameters.properties.size.default={})"
-//go:generate yq -i e ../../generated/vshn.appcat.vshn.io_vshnnextclouds.yaml --expression "with(.spec.versions[]; .schema.openAPIV3Schema.properties.spec.properties.parameters.properties.service.default={})"
 //go:generate yq -i e ../../generated/vshn.appcat.vshn.io_vshnnextclouds.yaml --expression "with(.spec.versions[]; .schema.openAPIV3Schema.properties.spec.properties.parameters.properties.service.properties.postgreSQLParameters.default={})"
 //go:generate yq -i e ../../generated/vshn.appcat.vshn.io_vshnnextclouds.yaml --expression "with(.spec.versions[]; .schema.openAPIV3Schema.properties.spec.properties.parameters.properties.backup.default={})"
 
@@ -85,10 +84,12 @@ type VSHNNextcloudParameters struct {
 
 // VSHNNextcloudserviceSpec contains nextcloud DBaaS specific properties
 type VSHNNextcloudServiceSpec struct {
+	// +kubebuilder:validation:Required
+
 	// FQDN contains the FQDN which will be used for the ingress.
 	// If it's not set, no ingress will be deployed.
 	// This also enables strict hostname checking for this FQDN.
-	FQDN string `json:"fqdn,omitempty"`
+	FQDN string `json:"fqdn"`
 
 	// RelativePath on which Nextcloud will listen.
 	// +kubebuilder:default="/"

--- a/crds/vshn.appcat.vshn.io_vshnkeycloaks.yaml
+++ b/crds/vshn.appcat.vshn.io_vshnkeycloaks.yaml
@@ -8499,6 +8499,8 @@ spec:
                                           - name
                                           - namespace
                                         type: object
+                                    required:
+                                      - user
                                     type: object
                                   type: array
                                 extensions:

--- a/crds/vshn.appcat.vshn.io_vshnnextclouds.yaml
+++ b/crds/vshn.appcat.vshn.io_vshnnextclouds.yaml
@@ -8478,6 +8478,8 @@ spec:
                                           - name
                                           - namespace
                                         type: object
+                                    required:
+                                      - user
                                     type: object
                                   type: array
                                 extensions:
@@ -8616,8 +8618,9 @@ spec:
                             Version contains supported version of nextcloud.
                             Multiple versions are supported. The latest version 29 is the default version.
                           type: string
+                      required:
+                        - fqdn
                       type: object
-                      default: {}
                     size:
                       description: Size contains settings to control the sizing of a service.
                       properties:

--- a/crds/vshn.appcat.vshn.io_vshnpostgresqls.yaml
+++ b/crds/vshn.appcat.vshn.io_vshnpostgresqls.yaml
@@ -4351,6 +4351,8 @@ spec:
                                   - name
                                   - namespace
                                 type: object
+                            required:
+                              - user
                             type: object
                           type: array
                         extensions:

--- a/crds/vshn.appcat.vshn.io_xvshnkeycloaks.yaml
+++ b/crds/vshn.appcat.vshn.io_xvshnkeycloaks.yaml
@@ -10275,6 +10275,8 @@ spec:
                                       - name
                                       - namespace
                                       type: object
+                                  required:
+                                  - user
                                   type: object
                                 type: array
                               extensions:

--- a/crds/vshn.appcat.vshn.io_xvshnnextclouds.yaml
+++ b/crds/vshn.appcat.vshn.io_xvshnnextclouds.yaml
@@ -10252,6 +10252,8 @@ spec:
                                       - name
                                       - namespace
                                       type: object
+                                  required:
+                                  - user
                                   type: object
                                 type: array
                               extensions:
@@ -10407,6 +10409,8 @@ spec:
                           Version contains supported version of nextcloud.
                           Multiple versions are supported. The latest version 29 is the default version.
                         type: string
+                    required:
+                    - fqdn
                     type: object
                   size:
                     description: Size contains settings to control the sizing of a

--- a/crds/vshn.appcat.vshn.io_xvshnpostgresqls.yaml
+++ b/crds/vshn.appcat.vshn.io_xvshnpostgresqls.yaml
@@ -5032,6 +5032,8 @@ spec:
                               - name
                               - namespace
                               type: object
+                          required:
+                          - user
                           type: object
                         type: array
                       extensions:


### PR DESCRIPTION
## Summary

The FQDN needs to be always set, otherwise the lifeness and readiness probes will fail. Furthermore it doesn't make sense to run a nextcloud without a defined FQDN

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
