### PR TITLE
Fix hardcoded servicename

### DIFF
--- a/pkg/comp-functions/functions/common/instance_namespace.go
+++ b/pkg/comp-functions/functions/common/instance_namespace.go
@@ -100,12 +100,17 @@ func createInstanceNamespace(serviceName, compName, claimNamespace, instanceName
 		svc.AddResult(runtime.NewWarningResult("cannot get claim namespace"))
 	}
 
+	mode := "standalone"
+	if _, exists := svc.Config.Data["mode"]; exists {
+		mode = svc.Config.Data["mode"]
+	}
+
 	ns := &corev1.Namespace{
 
 		ObjectMeta: metav1.ObjectMeta{
 			Name: instanceNamespace,
 			Labels: map[string]string{
-				"appcat.vshn.io/servicename":     serviceName + "-standalone",
+				"appcat.vshn.io/servicename":     serviceName + "-" + mode,
 				"appcat.vshn.io/claim-namespace": claimNamespace,
 				"appcat.vshn.io/claim-name":      claimName,
 				"appuio.io/no-rbac-creation":     "true",


### PR DESCRIPTION
## Summary

* The servicename is currently hardcorded in the composition function.
* This PR fixes this issue and sets the correct label for the service type

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [ ] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
