### PR TITLE
Fix a bug, where you can't edit an existing VSHNPostgreSQL instance

### DIFF
--- a/pkg/comp-functions/functions/vshnpostgres/connection_details.go
+++ b/pkg/comp-functions/functions/vshnpostgres/connection_details.go
@@ -44,7 +44,7 @@ func AddConnectionDetails(ctx context.Context, svc *runtime.ServiceRuntime) *v1b
 
 	log.Info("Making sure the cluster exposed connection details")
 	obj := &xkubev1.Object{}
-	err = svc.GetObservedComposedResource(obj, "cluster")
+	err = svc.GetDesiredComposedResourceByName(obj, "cluster")
 	if err != nil {
 		return runtime.NewWarningResult(fmt.Sprintf("cannot get the sgcluster object: %s", err))
 	}

--- a/test/functions/vshn-postgres/secrets/02_input_function-io.yaml
+++ b/test/functions/vshn-postgres/secrets/02_input_function-io.yaml
@@ -93,6 +93,12 @@ desired:
           writeConnectionSecretToRef:
             name: final-test
             namespace: test
+    cluster:
+      resource:
+        apiVersion: kubernetes.crossplane.io/v1alpha2
+        kind: Object
+        metadata:
+          name: pgsql-gc9x4-cluster
 observed:
   composite:
     resource:


### PR DESCRIPTION
## Summary

There is currently a bug in the AddConnectionDetails function that takes the SGcluster from the `observed` rather then the `desired` state. Since this function is run *after* the `DeployPostgreSQL` function and takes the cluster configuration from the `observed` state and at the end writes it to the `desired` state, it will effectively override every change done to the `SGCluster` object in the `DeployPostgreSQL` function.

The function should rather get the `SGCluster` object from the desired stage to avoid this issue.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
