### PR TITLE
Fix connection detail name

### DIFF
--- a/pkg/comp-functions/functions/vshnnextcloud/deploy.go
+++ b/pkg/comp-functions/functions/vshnnextcloud/deploy.go
@@ -109,9 +109,14 @@ func DeployNextcloud(ctx context.Context, svc *runtime.ServiceRuntime) *xfnproto
 		return runtime.NewWarningResult(fmt.Sprintf("cannot get observed connection details for nextcloud admin: %s", err))
 	}
 
+	hostname := comp.GetName()
+	if !strings.Contains(hostname, serviceSuffix) {
+		hostname = hostname + "-" + serviceSuffix
+	}
+
 	svc.SetConnectionDetail(adminPWConnectionDetailsField, cd[adminPWSecretField])
 	svc.SetConnectionDetail(adminConnectionDetailsField, cd[adminUserSecretField])
-	svc.SetConnectionDetail(hostConnectionDetailsField, []byte(fmt.Sprintf("%s-%s.%s.svc.cluster.local", comp.GetName(), serviceSuffix, comp.GetInstanceNamespace())))
+	svc.SetConnectionDetail(hostConnectionDetailsField, []byte(fmt.Sprintf("%s.%s.svc.cluster.local", hostname, comp.GetInstanceNamespace())))
 
 	err = addApacheConfig(svc, comp)
 	if err != nil {


### PR DESCRIPTION
## Summary
If the claim-name contains `nextcloud` it will not append `nextcloud` to the `fullName` variable in the helm chart.

However if the claim-name doesn't contain `nextcloud`, then the `fullName` will get a `-nextcloud` appendix, resulting in broken service names.


## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
