### PR TITLE
Implement deletionProtection for claims

### DIFF
--- a/apis/vshn/v1/common_types.go
+++ b/apis/vshn/v1/common_types.go
@@ -1,9 +1,10 @@
 package v1
 
 import (
+	"time"
+
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	alertmanagerv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
-	"time"
 )
 
 type TimeOfDay string
@@ -190,6 +191,10 @@ type Security struct {
 	AllowAllNamespaces bool `json:"allowAllNamespaces,omitempty"`
 	// AllowedNamespaces defines a list of namespaces from where the service can be reached in the claim namespace
 	AllowedNamespaces []string `json:"allowedNamespaces,omitempty"`
+
+	// DeletionProtection blocks the deletion of the instance if it is enabled (enabled by default)
+	// +kubebuilder:default=true
+	DeletionProtection bool `json:"deletionProtection,omitempty"`
 }
 
 type VSHNAccess struct {

--- a/apis/vshn/v1/dbaas_vshn_keycloak.go
+++ b/apis/vshn/v1/dbaas_vshn_keycloak.go
@@ -17,6 +17,7 @@ import (
 //go:generate yq -i e ../../generated/vshn.appcat.vshn.io_vshnkeycloaks.yaml --expression "with(.spec.versions[]; .schema.openAPIV3Schema.properties.spec.properties.parameters.properties.service.properties.postgreSQLParameters.default={})"
 //go:generate yq -i e ../../generated/vshn.appcat.vshn.io_vshnkeycloaks.yaml --expression "with(.spec.versions[]; .schema.openAPIV3Schema.properties.spec.properties.parameters.properties.tls.default={})"
 //go:generate yq -i e ../../generated/vshn.appcat.vshn.io_vshnkeycloaks.yaml --expression "with(.spec.versions[]; .schema.openAPIV3Schema.properties.spec.properties.parameters.properties.backup.default={})"
+//go:generate yq -i e ../../generated/vshn.appcat.vshn.io_vshnkeycloaks.yaml --expression "with(.spec.versions[]; .schema.openAPIV3Schema.properties.spec.properties.parameters.properties.security.default={})"
 
 // +kubebuilder:object:root=true
 
@@ -329,4 +330,8 @@ func (v *VSHNKeycloak) GetPDBLabels() map[string]string {
 	return map[string]string{
 		"app.kubernetes.io/name": "keycloakx",
 	}
+}
+
+func (v *VSHNKeycloak) GetSecurity() *Security {
+	return &v.Spec.Parameters.Security
 }

--- a/apis/vshn/v1/dbaas_vshn_mariadb.go
+++ b/apis/vshn/v1/dbaas_vshn_mariadb.go
@@ -15,6 +15,7 @@ import (
 //go:generate yq -i e ../../generated/vshn.appcat.vshn.io_vshnmariadbs.yaml --expression "with(.spec.versions[]; .schema.openAPIV3Schema.properties.spec.properties.parameters.properties.service.default={})"
 //go:generate yq -i e ../../generated/vshn.appcat.vshn.io_vshnmariadbs.yaml --expression "with(.spec.versions[]; .schema.openAPIV3Schema.properties.spec.properties.parameters.properties.tls.default={})"
 //go:generate yq -i e ../../generated/vshn.appcat.vshn.io_vshnmariadbs.yaml --expression "with(.spec.versions[]; .schema.openAPIV3Schema.properties.spec.properties.parameters.properties.backup.default={})"
+//go:generate yq -i e ../../generated/vshn.appcat.vshn.io_vshnmariadbs.yaml --expression "with(.spec.versions[]; .schema.openAPIV3Schema.properties.spec.properties.parameters.properties.security.default={})"
 
 // +kubebuilder:object:root=true
 
@@ -268,4 +269,8 @@ func (v *VSHNMariaDB) GetPDBLabels() map[string]string {
 	return map[string]string{
 		"app.kubernetes.io/name:": "mariadb-galera",
 	}
+}
+
+func (v *VSHNMariaDB) GetSecurity() *Security {
+	return &v.Spec.Parameters.Security
 }

--- a/apis/vshn/v1/dbaas_vshn_postgresql.go
+++ b/apis/vshn/v1/dbaas_vshn_postgresql.go
@@ -17,6 +17,7 @@ import (
 //go:generate yq -i e ../../generated/vshn.appcat.vshn.io_vshnpostgresqls.yaml --expression "with(.spec.versions[]; .schema.openAPIV3Schema.properties.spec.properties.parameters.properties.service.default={})"
 //go:generate yq -i e ../../generated/vshn.appcat.vshn.io_vshnpostgresqls.yaml --expression "with(.spec.versions[]; .schema.openAPIV3Schema.properties.spec.properties.parameters.properties.backup.default={})"
 //go:generate yq -i e ../../generated/vshn.appcat.vshn.io_vshnpostgresqls.yaml --expression "with(.spec.versions[]; .schema.openAPIV3Schema.properties.spec.properties.parameters.properties.maintenance.default={})"
+//go:generate yq -i e ../../generated/vshn.appcat.vshn.io_vshnpostgresqls.yaml --expression "with(.spec.versions[]; .schema.openAPIV3Schema.properties.spec.properties.parameters.properties.security.default={})"
 
 // +kubebuilder:object:root=true
 
@@ -392,4 +393,8 @@ func (v *VSHNPostgreSQL) GetPDBLabels() map[string]string {
 	return map[string]string{
 		"app": "StackGresCluster",
 	}
+}
+
+func (v *VSHNPostgreSQL) GetSecurity() *Security {
+	return &v.Spec.Parameters.Security
 }

--- a/apis/vshn/v1/dbaas_vshn_redis.go
+++ b/apis/vshn/v1/dbaas_vshn_redis.go
@@ -15,6 +15,7 @@ import (
 //go:generate yq -i e ../../generated/vshn.appcat.vshn.io_vshnredis.yaml --expression "with(.spec.versions[]; .schema.openAPIV3Schema.properties.spec.properties.parameters.properties.service.default={})"
 //go:generate yq -i e ../../generated/vshn.appcat.vshn.io_vshnredis.yaml --expression "with(.spec.versions[]; .schema.openAPIV3Schema.properties.spec.properties.parameters.properties.tls.default={})"
 //go:generate yq -i e ../../generated/vshn.appcat.vshn.io_vshnredis.yaml --expression "with(.spec.versions[]; .schema.openAPIV3Schema.properties.spec.properties.parameters.properties.backup.default={})"
+//go:generate yq -i e ../../generated/vshn.appcat.vshn.io_vshnredis.yaml --expression "with(.spec.versions[]; .schema.openAPIV3Schema.properties.spec.properties.parameters.properties.security.default={})"
 
 // +kubebuilder:object:root=true
 
@@ -293,4 +294,8 @@ func (v *VSHNRedis) GetPDBLabels() map[string]string {
 	return map[string]string{
 		"app.kubernetes.io/name": "redis",
 	}
+}
+
+func (v *VSHNRedis) GetSecurity() *Security {
+	return &v.Spec.Parameters.Security
 }

--- a/apis/vshn/v1/vshn_minio.go
+++ b/apis/vshn/v1/vshn_minio.go
@@ -13,6 +13,7 @@ import (
 //go:generate yq -i e ../../generated/vshn.appcat.vshn.io_vshnminios.yaml --expression "with(.spec.versions[]; .schema.openAPIV3Schema.properties.spec.properties.parameters.default={})"
 //go:generate yq -i e ../../generated/vshn.appcat.vshn.io_vshnminios.yaml --expression "with(.spec.versions[]; .schema.openAPIV3Schema.properties.spec.properties.parameters.properties.size.default={})"
 //go:generate yq -i e ../../generated/vshn.appcat.vshn.io_vshnminios.yaml --expression "with(.spec.versions[]; .schema.openAPIV3Schema.properties.spec.properties.parameters.properties.backup.default={})"
+//go:generate yq -i e ../../generated/vshn.appcat.vshn.io_vshnminios.yaml --expression "with(.spec.versions[]; .schema.openAPIV3Schema.properties.spec.properties.parameters.properties.security.default={})"
 //go:generate yq -i e ../../generated/vshn.appcat.vshn.io_vshnminios.yaml --expression "with(.spec.versions[]; .schema.openAPIV3Schema.properties.spec.properties.parameters.properties.security.properties.allowAllNamespaces.default=true)"
 
 // +kubebuilder:object:root=true
@@ -242,4 +243,8 @@ func (v *VSHNMinio) GetPDBLabels() map[string]string {
 	return map[string]string{
 		"app": "minio",
 	}
+}
+
+func (v *VSHNMinio) GetSecurity() *Security {
+	return &v.Spec.Parameters.Security
 }

--- a/apis/vshn/v1/vshn_nextcloud.go
+++ b/apis/vshn/v1/vshn_nextcloud.go
@@ -14,6 +14,7 @@ import (
 //go:generate yq -i e ../../generated/vshn.appcat.vshn.io_vshnnextclouds.yaml --expression "with(.spec.versions[]; .schema.openAPIV3Schema.properties.spec.properties.parameters.properties.size.default={})"
 //go:generate yq -i e ../../generated/vshn.appcat.vshn.io_vshnnextclouds.yaml --expression "with(.spec.versions[]; .schema.openAPIV3Schema.properties.spec.properties.parameters.properties.service.properties.postgreSQLParameters.default={})"
 //go:generate yq -i e ../../generated/vshn.appcat.vshn.io_vshnnextclouds.yaml --expression "with(.spec.versions[]; .schema.openAPIV3Schema.properties.spec.properties.parameters.properties.backup.default={})"
+//go:generate yq -i e ../../generated/vshn.appcat.vshn.io_vshnnextclouds.yaml --expression "with(.spec.versions[]; .schema.openAPIV3Schema.properties.spec.properties.parameters.properties.security.default={})"
 
 // +kubebuilder:object:root=true
 
@@ -294,4 +295,8 @@ func (v *VSHNNextcloud) GetPDBLabels() map[string]string {
 	return map[string]string{
 		"app.kubernetes.io/name": "nextcloud",
 	}
+}
+
+func (v *VSHNNextcloud) GetSecurity() *Security {
+	return &v.Spec.Parameters.Security
 }

--- a/cmd/controller.go
+++ b/cmd/controller.go
@@ -126,6 +126,22 @@ func setupWebhooks(mgr manager.Manager, withQuota bool) error {
 	if err != nil {
 		return err
 	}
+	err = webhooks.SetupMariaDBWebhookHandlerWithManager(mgr, withQuota)
+	if err != nil {
+		return err
+	}
+	err = webhooks.SetupMinioWebhookHandlerWithManager(mgr, withQuota)
+	if err != nil {
+		return err
+	}
+	err = webhooks.SetupNextcloudWebhookHandlerWithManager(mgr, withQuota)
+	if err != nil {
+		return err
+	}
+	err = webhooks.SetupKeycloakWebhookHandlerWithManager(mgr, withQuota)
+	if err != nil {
+		return err
+	}
 	err = webhooks.SetupNamespaceDeletionProtectionHandlerWithManager(mgr)
 	if err != nil {
 		return err

--- a/config/controller/cluster-role.yaml
+++ b/config/controller/cluster-role.yaml
@@ -55,6 +55,86 @@ rules:
 - apiGroups:
   - vshn.appcat.vshn.io
   resources:
+  - xvshnkeycloaks
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - vshn.appcat.vshn.io
+  resources:
+  - xvshnkeycloaks/status
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - vshn.appcat.vshn.io
+  resources:
+  - xvshnmariadbs
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - vshn.appcat.vshn.io
+  resources:
+  - xvshnmariadbs/status
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - vshn.appcat.vshn.io
+  resources:
+  - xvshnminios
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - vshn.appcat.vshn.io
+  resources:
+  - xvshnminios/status
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - vshn.appcat.vshn.io
+  resources:
+  - xvshnnextclouds
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - vshn.appcat.vshn.io
+  resources:
+  - xvshnnextclouds/status
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - vshn.appcat.vshn.io
+  resources:
   - xvshnpostgresqls
   verbs:
   - get

--- a/config/controller/webhooks.yaml
+++ b/config/controller/webhooks.yaml
@@ -69,6 +69,90 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
+      path: /validate-vshn-appcat-vshn-io-v1-vshnkeycloak
+  failurePolicy: Fail
+  name: vshnkeycloak.vshn.appcat.vshn.io
+  rules:
+  - apiGroups:
+    - vshn.appcat.vshn.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+    resources:
+    - vshnkeycloaks
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-vshn-appcat-vshn-io-v1-vshnmariadb
+  failurePolicy: Fail
+  name: vshnmariadb.vshn.appcat.vshn.io
+  rules:
+  - apiGroups:
+    - vshn.appcat.vshn.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+    resources:
+    - vshnmariadbs
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-vshn-appcat-vshn-io-v1-vshnminio
+  failurePolicy: Fail
+  name: vshnminio.vshn.appcat.vshn.io
+  rules:
+  - apiGroups:
+    - vshn.appcat.vshn.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+    resources:
+    - vshnminios
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-vshn-appcat-vshn-io-v1-vshnnextcloud
+  failurePolicy: Fail
+  name: vshnnextcloud.vshn.appcat.vshn.io
+  rules:
+  - apiGroups:
+    - vshn.appcat.vshn.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+    resources:
+    - vshnnextclouds
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
       path: /validate-vshn-appcat-vshn-io-v1-vshnredis
   failurePolicy: Fail
   name: vshnredis.vshn.appcat.vshn.io
@@ -78,6 +162,8 @@ webhooks:
     apiVersions:
     - v1
     operations:
+    - CREATE
+    - UPDATE
     - DELETE
     resources:
     - vshnredis

--- a/crds/vshn.appcat.vshn.io_vshnkeycloaks.yaml
+++ b/crds/vshn.appcat.vshn.io_vshnkeycloaks.yaml
@@ -4832,7 +4832,12 @@ spec:
                           items:
                             type: string
                           type: array
+                        deletionProtection:
+                          default: true
+                          description: DeletionProtection blocks the deletion of the instance if it is enabled (enabled by default)
+                          type: boolean
                       type: object
+                      default: {}
                     service:
                       description: Service contains keycloak DBaaS specific properties
                       properties:
@@ -9742,6 +9747,10 @@ spec:
                                   items:
                                     type: string
                                   type: array
+                                deletionProtection:
+                                  default: true
+                                  description: DeletionProtection blocks the deletion of the instance if it is enabled (enabled by default)
+                                  type: boolean
                               type: object
                             service:
                               description: Service contains PostgreSQL DBaaS specific properties

--- a/crds/vshn.appcat.vshn.io_vshnmariadbs.yaml
+++ b/crds/vshn.appcat.vshn.io_vshnmariadbs.yaml
@@ -4824,7 +4824,12 @@ spec:
                           items:
                             type: string
                           type: array
+                        deletionProtection:
+                          default: true
+                          description: DeletionProtection blocks the deletion of the instance if it is enabled (enabled by default)
+                          type: boolean
                       type: object
+                      default: {}
                     service:
                       description: Service contains MariaDB DBaaS specific properties
                       properties:

--- a/crds/vshn.appcat.vshn.io_vshnminios.yaml
+++ b/crds/vshn.appcat.vshn.io_vshnminios.yaml
@@ -4822,7 +4822,12 @@ spec:
                           items:
                             type: string
                           type: array
+                        deletionProtection:
+                          default: true
+                          description: DeletionProtection blocks the deletion of the instance if it is enabled (enabled by default)
+                          type: boolean
                       type: object
+                      default: {}
                     service:
                       description: Service contains the Minio specific configurations
                       properties:

--- a/crds/vshn.appcat.vshn.io_vshnnextclouds.yaml
+++ b/crds/vshn.appcat.vshn.io_vshnnextclouds.yaml
@@ -4832,7 +4832,12 @@ spec:
                           items:
                             type: string
                           type: array
+                        deletionProtection:
+                          default: true
+                          description: DeletionProtection blocks the deletion of the instance if it is enabled (enabled by default)
+                          type: boolean
                       type: object
+                      default: {}
                     service:
                       description: Service contains nextcloud DBaaS specific properties
                       properties:
@@ -9708,6 +9713,10 @@ spec:
                                   items:
                                     type: string
                                   type: array
+                                deletionProtection:
+                                  default: true
+                                  description: DeletionProtection blocks the deletion of the instance if it is enabled (enabled by default)
+                                  type: boolean
                               type: object
                             service:
                               description: Service contains PostgreSQL DBaaS specific properties

--- a/crds/vshn.appcat.vshn.io_vshnpostgresqls.yaml
+++ b/crds/vshn.appcat.vshn.io_vshnpostgresqls.yaml
@@ -4946,7 +4946,12 @@ spec:
                           items:
                             type: string
                           type: array
+                        deletionProtection:
+                          default: true
+                          description: DeletionProtection blocks the deletion of the instance if it is enabled (enabled by default)
+                          type: boolean
                       type: object
+                      default: {}
                     service:
                       description: Service contains PostgreSQL DBaaS specific properties
                       properties:

--- a/crds/vshn.appcat.vshn.io_vshnredis.yaml
+++ b/crds/vshn.appcat.vshn.io_vshnredis.yaml
@@ -4824,7 +4824,12 @@ spec:
                           items:
                             type: string
                           type: array
+                        deletionProtection:
+                          default: true
+                          description: DeletionProtection blocks the deletion of the instance if it is enabled (enabled by default)
+                          type: boolean
                       type: object
+                      default: {}
                     service:
                       description: Service contains Redis DBaaS specific properties
                       properties:

--- a/crds/vshn.appcat.vshn.io_xvshnkeycloaks.yaml
+++ b/crds/vshn.appcat.vshn.io_xvshnkeycloaks.yaml
@@ -5554,6 +5554,11 @@ spec:
                         items:
                           type: string
                         type: array
+                      deletionProtection:
+                        default: true
+                        description: DeletionProtection blocks the deletion of the
+                          instance if it is enabled (enabled by default)
+                        type: boolean
                     type: object
                   service:
                     description: Service contains keycloak DBaaS specific properties
@@ -11516,6 +11521,11 @@ spec:
                                 items:
                                   type: string
                                 type: array
+                              deletionProtection:
+                                default: true
+                                description: DeletionProtection blocks the deletion
+                                  of the instance if it is enabled (enabled by default)
+                                type: boolean
                             type: object
                           service:
                             description: Service contains PostgreSQL DBaaS specific

--- a/crds/vshn.appcat.vshn.io_xvshnmariadbs.yaml
+++ b/crds/vshn.appcat.vshn.io_xvshnmariadbs.yaml
@@ -5546,6 +5546,11 @@ spec:
                         items:
                           type: string
                         type: array
+                      deletionProtection:
+                        default: true
+                        description: DeletionProtection blocks the deletion of the
+                          instance if it is enabled (enabled by default)
+                        type: boolean
                     type: object
                   service:
                     description: Service contains MariaDB DBaaS specific properties

--- a/crds/vshn.appcat.vshn.io_xvshnminios.yaml
+++ b/crds/vshn.appcat.vshn.io_xvshnminios.yaml
@@ -5542,6 +5542,11 @@ spec:
                         items:
                           type: string
                         type: array
+                      deletionProtection:
+                        default: true
+                        description: DeletionProtection blocks the deletion of the
+                          instance if it is enabled (enabled by default)
+                        type: boolean
                     type: object
                   service:
                     description: Service contains the Minio specific configurations

--- a/crds/vshn.appcat.vshn.io_xvshnnextclouds.yaml
+++ b/crds/vshn.appcat.vshn.io_xvshnnextclouds.yaml
@@ -5554,6 +5554,11 @@ spec:
                         items:
                           type: string
                         type: array
+                      deletionProtection:
+                        default: true
+                        description: DeletionProtection blocks the deletion of the
+                          instance if it is enabled (enabled by default)
+                        type: boolean
                     type: object
                   service:
                     description: Service contains nextcloud DBaaS specific properties
@@ -11480,6 +11485,11 @@ spec:
                                 items:
                                   type: string
                                 type: array
+                              deletionProtection:
+                                default: true
+                                description: DeletionProtection blocks the deletion
+                                  of the instance if it is enabled (enabled by default)
+                                type: boolean
                             type: object
                           service:
                             description: Service contains PostgreSQL DBaaS specific

--- a/crds/vshn.appcat.vshn.io_xvshnpostgresqls.yaml
+++ b/crds/vshn.appcat.vshn.io_xvshnpostgresqls.yaml
@@ -5626,6 +5626,11 @@ spec:
                         items:
                           type: string
                         type: array
+                      deletionProtection:
+                        default: true
+                        description: DeletionProtection blocks the deletion of the
+                          instance if it is enabled (enabled by default)
+                        type: boolean
                     type: object
                   service:
                     description: Service contains PostgreSQL DBaaS specific properties

--- a/crds/vshn.appcat.vshn.io_xvshnredis.yaml
+++ b/crds/vshn.appcat.vshn.io_xvshnredis.yaml
@@ -5546,6 +5546,11 @@ spec:
                         items:
                           type: string
                         type: array
+                      deletionProtection:
+                        default: true
+                        description: DeletionProtection blocks the deletion of the
+                          instance if it is enabled (enabled by default)
+                        type: boolean
                     type: object
                   service:
                     description: Service contains Redis DBaaS specific properties

--- a/hack/bootstrap/template/api.txt
+++ b/hack/bootstrap/template/api.txt
@@ -15,6 +15,8 @@ import (
 //go:generate yq -i e ../../generated/vshn.appcat.vshn.io_{{.NamePluralLower}}.yaml --expression "with(.spec.versions[]; .schema.openAPIV3Schema.properties.spec.properties.parameters.properties.service.default={})"
 //go:generate yq -i e ../../generated/vshn.appcat.vshn.io_{{.NamePluralLower}}.yaml --expression "with(.spec.versions[]; .schema.openAPIV3Schema.properties.spec.properties.parameters.properties.tls.default={})"
 //go:generate yq -i e ../../generated/vshn.appcat.vshn.io_{{.NamePluralLower}}.yaml --expression "with(.spec.versions[]; .schema.openAPIV3Schema.properties.spec.properties.parameters.properties.backup.default={})"
+//go:generate yq -i e ../../generated/vshn.appcat.vshn.io_{{.NamePluralLower}}.yaml --expression "with(.spec.versions[]; .schema.openAPIV3Schema.properties.spec.properties.parameters.properties.security.default={})"
+
 
 // +kubebuilder:object:root=true
 
@@ -262,4 +264,37 @@ func (v *{{.Name}}) GetFullMaintenanceSchedule() VSHNDBaaSMaintenanceScheduleSpe
 func (v *{{.Name}}) GetPDBLabels() map[string]string {
 	return map[string]string{
 	}
+}
+
+// GetAllowAllNamespaces returns the AllowAllNamespaces field of this service
+func (v *{{.Name}}) GetAllowAllNamespaces() bool {
+	return v.Spec.Parameters.Security.AllowAllNamespaces
+}
+
+// GetAllowedNamespaces returns the AllowedNamespaces array of this service
+func (v *{{.Name}}) GetAllowedNamespaces() []string {
+	if v.Spec.Parameters.Security.AllowedNamespaces == nil {
+		v.Spec.Parameters.Security.AllowedNamespaces = []string{}
+	}
+	return append(v.Spec.Parameters.Security.AllowedNamespaces, v.GetClaimNamespace())
+}
+
+func (v *{{.Name}}) GetVSHNMonitoring() VSHNMonitoring {
+	return v.Spec.Parameters.Monitoring
+}
+
+func (v *{{.Name}}) GetSize() VSHNSizeSpec {
+	return v.Spec.Parameters.Size
+}
+
+func (v *{{.Name}}) GetMonitoring() VSHNMonitoring {
+	return v.Spec.Parameters.Monitoring
+}
+
+func (v *{{.Name}}) GetInstances() int {
+	return v.Spec.Parameters.Instances
+}
+
+func (v *{{.Name}}) GetSecurity() *Security {
+	return &v.Spec.Parameters.Security
 }

--- a/hack/bootstrap/template/webhook.txt
+++ b/hack/bootstrap/template/webhook.txt
@@ -1,0 +1,44 @@
+package webhooks
+
+import (
+	vshnv1 "github.com/vshn/appcat/v4/apis/vshn/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+//+kubebuilder:webhook:verbs=create;update;delete,path=/validate-vshn-appcat-vshn-io-v1-vshn{{.NameShort}},mutating=false,failurePolicy=fail,groups=vshn.appcat.vshn.io,resources={{.NamePluralLower}},versions=v1,name=vshn{{.NameShort}}.vshn.appcat.vshn.io,sideEffects=None,admissionReviewVersions=v1
+
+//+kubebuilder:rbac:groups=vshn.appcat.vshn.io,resources=x{{.NamePluralLower}},verbs=get;list;watch;patch;update
+//+kubebuilder:rbac:groups=vshn.appcat.vshn.io,resources=x{{.NamePluralLower}}/status,verbs=get;list;watch;patch;update
+
+var (
+	{{.NameShort}}GK = schema.GroupKind{Group: "vshn.appcat.vshn.io", Kind: "{{.Name}}"}
+	{{.NameShort}}GR = schema.GroupResource{Group: {{.NameShort}}GK.Group, Resource: "vshn{{.NameShort}}"}
+)
+
+var _ webhook.CustomValidator = &{{.NameShortCapital}}WebhookHandler{}
+
+type {{.NameShortCapital}}WebhookHandler struct {
+	DefaultWebhookHandler
+}
+
+// Setup{{.NameShortCapital}}WebhookHandlerWithManager registers the validation webhook with the manager.
+func Setup{{.NameShortCapital}}WebhookHandlerWithManager(mgr ctrl.Manager, withQuota bool) error {
+
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(&vshnv1.{{.Name}}{}).
+		WithValidator(&{{.NameShortCapital}}WebhookHandler{
+			DefaultWebhookHandler: *New(
+				mgr.GetClient(),
+				mgr.GetLogger().WithName("webhook").WithName("{{.NameShort}}"),
+				withQuota,
+				&vshnv1.{{.Name}}{},
+				"{{.NameShort}}",
+				{{.NameShort}}GK,
+				{{.NameShort}}GR,
+				45, // TBD: Adjust this as necessary. prefix for the instance namespace is 11 postfix is 8 chars for the instance namespace (eg. "vshn-{{.NameShort}}-foo-kn7tx2r"). Max namespace length is 63. That leaves us with 42 chars
+			),
+		}).
+		Complete()
+}

--- a/pkg/comp-functions/functions/common/interfaces.go
+++ b/pkg/comp-functions/functions/common/interfaces.go
@@ -15,6 +15,7 @@ type InfoGetter interface {
 	GetInstances() int
 	GetFullMaintenanceSchedule() vshnv1.VSHNDBaaSMaintenanceScheduleSpec
 	GetMonitoring() vshnv1.VSHNMonitoring
+	GetSecurity() *vshnv1.Security
 	InstanceNamespaceInfo
 	GetPDBLabels() map[string]string
 }

--- a/pkg/comp-functions/runtime/naming.go
+++ b/pkg/comp-functions/runtime/naming.go
@@ -10,6 +10,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+const defaultDNSLabelLength = 63
+const jobDSNLabelLenth = 52
+
 // escapeK8sNames will figure out what naming scheme applies to the given object
 // and tries to find the correct naming scheme for it.
 // Then it will escape the name accordingly.
@@ -21,11 +24,9 @@ func escapeK8sNames(obj client.Object) {
 
 	switch kind[0].Kind {
 	case "Pod":
-		obj.SetName(EscapeDNS1123Label(obj.GetName()))
-	case "Namespace":
-		obj.SetName(EscapeDNS1123Label(obj.GetName()))
+		obj.SetName(EscapeDNS1123Label(obj.GetName(), defaultDNSLabelLength))
 	case "Service":
-		obj.SetName(EscapeDNS1123Label(obj.GetName()))
+		obj.SetName(EscapeDNS1123Label(obj.GetName(), defaultDNSLabelLength))
 	case "Role":
 		obj.SetName(EscapeDNS1123(obj.GetName(), true))
 	case "ClusterRole":
@@ -34,17 +35,19 @@ func escapeK8sNames(obj client.Object) {
 		obj.SetName(EscapeDNS1123(obj.GetName(), true))
 	case "ClusterRoleBinding":
 		obj.SetName(EscapeDNS1123(obj.GetName(), true))
+	case "CronJob":
+		obj.SetName(EscapeDNS1123Label(obj.GetName(), jobDSNLabelLenth))
 	default:
 		obj.SetName(EscapeDNS1123(obj.GetName(), false))
 	}
 }
 
 // EscapeDNS1123Label does the same as escapeDNS1123 but also limit to 63 chars
-func EscapeDNS1123Label(name string) string {
+func EscapeDNS1123Label(name string, length int) string {
 	name = EscapeDNS1123(name, false)
-	if len(name) > 63 {
+	if len(name) > length {
 		suffix := hashString(name)
-		name = name[:58] + suffix
+		name = name[:length-5] + suffix
 	}
 	return name
 }

--- a/pkg/controller/postgres/deletion_protection.go
+++ b/pkg/controller/postgres/deletion_protection.go
@@ -3,19 +3,14 @@ package postgres
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"sort"
 	"strconv"
-	"time"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	logging "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/go-logr/logr"
 	"github.com/vshn/appcat/v4/pkg/common/jsonpatch"
-	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -25,62 +20,18 @@ const (
 	finalizerName = "appcat.io/deletionProtection"
 )
 
-func handle(ctx context.Context, inst client.Object, enabled bool, retention int) (client.Patch, error) {
+func handle(ctx context.Context, inst client.Object) (client.Patch, error) {
 	log := logging.FromContext(ctx, "namespace", inst.GetNamespace(), "instance", inst.GetName())
 	op := jsonpatch.JSONopNone
 
-	if !enabled {
-		removed := controllerutil.RemoveFinalizer(inst, finalizerName)
+	removed := controllerutil.RemoveFinalizer(inst, finalizerName)
 
-		if removed {
-			log.Info("DeletionProtection is not enabled, ensuring no finalizer set", "objectName", inst.GetName())
-			op = jsonpatch.JSONopRemove
-		}
-
-		return getPatchObjectFinalizer(log, inst, op)
-	}
-
-	if !controllerutil.ContainsFinalizer(inst, finalizerName) && inst.GetDeletionTimestamp() == nil {
-		added := controllerutil.AddFinalizer(inst, finalizerName)
-		if added {
-			log.Info("Added finalizer to the object", "objectName", inst.GetName())
-			op = jsonpatch.JSONopAdd
-			return getPatchObjectFinalizer(log, inst, op)
-		}
-	}
-
-	if inst.GetDeletionTimestamp() != nil {
-		op = checkRetention(ctx, inst, retention)
+	if removed {
+		log.Info("Ensuring deprecated finalizer is not set", "objectName", inst.GetName())
+		op = jsonpatch.JSONopRemove
 	}
 
 	return getPatchObjectFinalizer(log, inst, op)
-}
-
-func checkRetention(ctx context.Context, inst client.Object, retention int) jsonpatch.JSONop {
-	log := logging.FromContext(ctx, "namespace", inst.GetNamespace(), "instance", inst.GetName())
-	timestamp := inst.GetDeletionTimestamp()
-	expireDate := timestamp.AddDate(0, 0, retention)
-	op := jsonpatch.JSONopNone
-	now := getCurrentTime()
-	if now.After(expireDate) {
-		log.Info("Retention expired, removing finalizer")
-		removed := controllerutil.RemoveFinalizer(inst, finalizerName)
-		if removed {
-			op = jsonpatch.JSONopRemove
-		}
-	}
-	return op
-}
-
-func getRequeueTime(ctx context.Context, inst client.Object, deletionTime *metav1.Time, retention int) time.Duration {
-	log := logging.FromContext(ctx, "namespace", inst.GetNamespace(), "instance", inst.GetName())
-	now := getCurrentTime()
-	if deletionTime != nil {
-		deletionIn := deletionTime.AddDate(0, 0, retention).Sub(now)
-		log.V(1).Info("Deletion in: " + deletionIn.String())
-		return deletionIn
-	}
-	return time.Second * 30
 }
 
 func getPatchObjectFinalizer(log logr.Logger, inst client.Object, op jsonpatch.JSONop) (client.Patch, error) {
@@ -143,66 +94,4 @@ func getPatchObjectFinalizer(log logr.Logger, inst client.Object, op jsonpatch.J
 	log.V(1).Info("Patching object", "patch", string(patch))
 
 	return client.RawPatch(types.JSONPatchType, patch), nil
-}
-
-func getCurrentTime() time.Time {
-	t := time.Now()
-	return time.Date(t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), 0, 0, t.Location())
-}
-
-func getPostgreSQLNamespace(inst client.Object) string {
-	return fmt.Sprintf("vshn-postgresql-%s", inst.GetName())
-}
-
-// instanceNamespaceDeleted handles the case, if the instance namespace gets deleted.
-// The customer can't delete the namespace by themselves, so this is usally when the customer as a whole gets deleted.
-// Or some other administrative action.
-// In those cases we should disable the deletionprotection.
-// If the namespace is deleted or not found it will return a patch to remove the finalizer.
-func instanceNamespaceDeleted(ctx context.Context, log logr.Logger, inst client.Object, enabled bool, c client.Client) (jsonpatch.JSONop, error) {
-	ns := &corev1.Namespace{}
-	err := c.Get(ctx, client.ObjectKey{Name: getPostgreSQLNamespace(inst)}, ns)
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			log.V(1).Info("Instance namespace was not found, ignoring")
-			return jsonpatch.JSONopNone, nil
-		}
-		return jsonpatch.JSONopNone, err
-	}
-
-	if ns.DeletionTimestamp != nil && controllerutil.RemoveFinalizer(ns, finalizerName) {
-		log.Info("Instance namespace was deleted, overriding deletionprotection")
-		return jsonpatch.JSONopRemove, c.Update(ctx, ns)
-	}
-
-	if enabled && controllerutil.AddFinalizer(ns, finalizerName) {
-		log.Info("Deletion protection enabled, protecting instance namespace")
-		err := controllerutil.SetControllerReference(inst, ns, c.Scheme())
-		if err != nil {
-			return jsonpatch.JSONopNone, err
-		}
-		return jsonpatch.JSONopNone, c.Update(ctx, ns)
-	}
-
-	if !enabled && controllerutil.RemoveFinalizer(ns, finalizerName) {
-		log.Info("Deletion protection disabled, removing protection from instance namespace")
-		return jsonpatch.JSONopRemove, c.Update(ctx, ns)
-	}
-
-	return jsonpatch.JSONopNone, nil
-}
-
-func getInstanceNamespaceOverride(ctx context.Context, inst client.Object, enabled bool, c client.Client) (client.Patch, error) {
-	log := logging.FromContext(ctx, "namespace", inst.GetNamespace(), "instance", inst.GetName())
-
-	overrideOp, err := instanceNamespaceDeleted(ctx, log, inst, enabled, c)
-	if err != nil {
-		return nil, errors.Wrap(err, "could not determine instance namespace status")
-	}
-
-	patch, err := getPatchObjectFinalizer(log, inst, overrideOp)
-	if err != nil {
-		return nil, errors.Wrap(err, "can't create namespace override patch")
-	}
-	return patch, nil
 }

--- a/pkg/controller/postgres/deletion_protection_test.go
+++ b/pkg/controller/postgres/deletion_protection_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"strconv"
 	"testing"
-	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
@@ -13,14 +12,8 @@ import (
 	vshnv1 "github.com/vshn/appcat/v4/apis/vshn/v1"
 	"github.com/vshn/appcat/v4/pkg/common/jsonpatch"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-)
-
-var (
-	currentTimeKey = "now"
 )
 
 func init() {
@@ -30,172 +23,37 @@ func init() {
 }
 
 func Test_Handle(t *testing.T) {
-	previousDay := getCurrentTime().AddDate(0, 0, -1)
 	tests := map[string]struct {
 		ctx           context.Context
 		obj           vshnv1.XVSHNPostgreSQL
-		enabled       bool
-		retention     int
 		expectedPatch client.Patch
 	}{
-		"WhenRetentionDisableAndNoFinalizer_ThenNilPatch": {
+
+		"WhenFinalizer_ThenRemoveOpPatch": {
 			ctx:           context.Background(),
-			obj:           getXVSHNPostgreSQL(0, nil),
-			enabled:       false,
-			retention:     0,
-			expectedPatch: nil,
-		},
-		"WhenRetentionDisableAndFinalizer_ThenRemoveOpPatch": {
-			ctx:           context.Background(),
-			obj:           getXVSHNPostgreSQL(1, nil),
-			enabled:       false,
-			retention:     0,
+			obj:           getXVSHNPostgreSQL(1),
 			expectedPatch: getPatch(jsonpatch.JSONopRemove),
-		},
-		"WhenRetentionEnabledAndNoFinalizerAndNotDeleted_ThenAddOpPatch": {
-			ctx:           context.Background(),
-			obj:           getXVSHNPostgreSQL(0, nil),
-			enabled:       true,
-			retention:     0,
-			expectedPatch: getPatch(jsonpatch.JSONopAdd),
-		},
-		"WhenRetentionEnabledAndFinalizerAndDeletedAndRetentionNonZero_ThenNilPatch": {
-			ctx:           context.WithValue(context.Background(), currentTimeKey, getCurrentTime()),
-			obj:           getXVSHNPostgreSQL(1, &previousDay),
-			enabled:       true,
-			retention:     1,
-			expectedPatch: nil,
-		},
-		"WhenRetentionEnabledAndFinalizerAndDeletedAndRetentionZero_ThenNilPatch": {
-			ctx:           context.WithValue(context.Background(), currentTimeKey, getCurrentTime()),
-			obj:           getXVSHNPostgreSQL(1, &previousDay),
-			enabled:       true,
-			retention:     0,
-			expectedPatch: getPatch(jsonpatch.JSONopRemove),
-		},
-		"WhenRetentionEnabledAndFinalizerAndNotDeleted_ThenNilPatch": {
-			ctx:           context.WithValue(context.Background(), currentTimeKey, getCurrentTime()),
-			obj:           getXVSHNPostgreSQL(1, nil),
-			enabled:       true,
-			retention:     0,
-			expectedPatch: nil,
 		},
 		"WhenMultipleFinalzers_ThenOnlyKeepOne": {
 			ctx:           context.Background(),
-			obj:           getXVSHNPostgreSQL(2, nil),
-			enabled:       true,
-			retention:     0,
-			expectedPatch: getRemovePatches(2),
+			obj:           getXVSHNPostgreSQL(2),
+			expectedPatch: getPatch(jsonpatch.JSONopRemove),
 		},
 		"WhenMoreFinalzers_ThenOnlyKeepOne": {
 			ctx:           context.Background(),
-			obj:           getXVSHNPostgreSQL(3, nil),
-			enabled:       true,
-			retention:     0,
-			expectedPatch: getRemovePatches(3),
+			obj:           getXVSHNPostgreSQL(3),
+			expectedPatch: getPatch(jsonpatch.JSONopRemove),
 		},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 
 			// WHEN
-			actualPatch, err := handle(tc.ctx, &tc.obj, tc.enabled, tc.retention)
+			actualPatch, err := handle(tc.ctx, &tc.obj)
 
 			// THEN
 			assert.NoError(t, err)
 			assert.Equal(t, tc.expectedPatch, actualPatch)
-		})
-	}
-}
-
-func Test_CheckRetention(t *testing.T) {
-	twoDaysBefore := getCurrentTime().AddDate(0, 0, -2)
-	previousDay := getCurrentTime().AddDate(0, 0, -1)
-	nextDay := getCurrentTime().AddDate(0, 0, 1)
-	tests := map[string]struct {
-		ctx        context.Context
-		obj        vshnv1.XVSHNPostgreSQL
-		retention  int
-		expectedOp jsonpatch.JSONop
-	}{
-		"WhenDeletionTimePlusRetentionTimeBeforeCurrentRuntime_ThenRemoveOp": {
-			ctx:        context.WithValue(context.Background(), currentTimeKey, getCurrentTime()),
-			obj:        getXVSHNPostgreSQL(1, &twoDaysBefore),
-			retention:  1,
-			expectedOp: jsonpatch.JSONopRemove,
-		},
-		"WhenDeletionTimeAndNoRetentionBeforeCurrentRuntime_ThenRemoveOp": {
-			ctx:        context.WithValue(context.Background(), currentTimeKey, getCurrentTime()),
-			obj:        getXVSHNPostgreSQL(1, &twoDaysBefore),
-			retention:  0,
-			expectedOp: jsonpatch.JSONopRemove,
-		},
-		"WhenDeletionTimePlusRetentionAfterCurrentRuntime_ThenNonOp": {
-			ctx:        context.WithValue(context.Background(), currentTimeKey, getCurrentTime()),
-			obj:        getXVSHNPostgreSQL(1, &twoDaysBefore),
-			retention:  5,
-			expectedOp: jsonpatch.JSONopNone,
-		},
-		"WhenDeletionTimeWithoutRetentionAfterCurrentRuntime_ThenNonOp": {
-			ctx:        context.WithValue(context.Background(), currentTimeKey, getCurrentTime()),
-			obj:        getXVSHNPostgreSQL(1, &nextDay),
-			retention:  5,
-			expectedOp: jsonpatch.JSONopNone,
-		},
-		"WhenDeletionTimeWithRetentionEqualsCurrentRuntime_ThenNonOp": {
-			ctx:        context.WithValue(context.Background(), currentTimeKey, getCurrentTime()),
-			obj:        getXVSHNPostgreSQL(1, &previousDay),
-			retention:  1,
-			expectedOp: jsonpatch.JSONopNone,
-		},
-	}
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
-
-			// WHEN
-			actualOp := checkRetention(tc.ctx, &tc.obj, tc.retention)
-
-			// THEN
-			assert.Equal(t, tc.expectedOp, actualOp)
-		})
-	}
-}
-
-func Test_GetRequeueTime(t *testing.T) {
-	previousDay := getCurrentTime().AddDate(0, 0, -1)
-	tests := map[string]struct {
-		ctx              context.Context
-		obj              vshnv1.XVSHNPostgreSQL
-		deletionTime     *time.Time
-		retention        int
-		expectedDuration time.Duration
-	}{
-		"WhenNoDeletion_ThenReturnIn30Seconds": {
-			ctx:              context.WithValue(context.Background(), currentTimeKey, getCurrentTime()),
-			obj:              getXVSHNPostgreSQL(1, nil),
-			deletionTime:     nil,
-			retention:        1,
-			expectedDuration: time.Second * 30,
-		},
-		"WhenDeletionTime_ThenCalculateDuration": {
-			ctx:              context.WithValue(context.Background(), currentTimeKey, getCurrentTime()),
-			obj:              getXVSHNPostgreSQL(1, &previousDay),
-			deletionTime:     &previousDay,
-			retention:        2,
-			expectedDuration: time.Hour * 24,
-		},
-	}
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
-
-			// GIVEN
-			delTime := transformToK8sTime(tc.deletionTime)
-
-			// WHEN
-			actualDuration := getRequeueTime(tc.ctx, &tc.obj, delTime, tc.retention)
-
-			// THEN
-			assert.Equal(t, tc.expectedDuration, actualDuration)
 		})
 	}
 }
@@ -206,25 +64,10 @@ func Test_GetPatchObjectFinalizer(t *testing.T) {
 		op            jsonpatch.JSONop
 		expectedPatch client.Patch
 	}{
-		"WhenOpNone_ThenNil": {
-			obj:           getXVSHNPostgreSQL(1, nil),
-			op:            jsonpatch.JSONopNone,
-			expectedPatch: nil,
-		},
 		"WhenOpRemove_ThenReturnPatch": {
-			obj:           getXVSHNPostgreSQL(1, nil),
+			obj:           getXVSHNPostgreSQL(1),
 			op:            jsonpatch.JSONopRemove,
 			expectedPatch: getPatch(jsonpatch.JSONopRemove),
-		},
-		"WhenOpAdd_ThenReturnPatch": {
-			obj:           getXVSHNPostgreSQL(1, nil),
-			op:            jsonpatch.JSONopAdd,
-			expectedPatch: getPatch(jsonpatch.JSONopAdd),
-		},
-		"WhenOpReplace_ThenReturnPatch": {
-			obj:           getXVSHNPostgreSQL(1, nil),
-			op:            jsonpatch.JSONopReplace,
-			expectedPatch: getPatch(jsonpatch.JSONopReplace),
 		},
 	}
 	for name, tc := range tests {
@@ -244,21 +87,10 @@ func Test_GetPatchObjectFinalizer(t *testing.T) {
 	}
 }
 
-func transformToK8sTime(t *time.Time) *metav1.Time {
-	if t != nil {
-		temp := metav1.NewTime(*t)
-		return &temp
-	}
-	return nil
-}
-
-func getXVSHNPostgreSQL(addFinalizer int, deletedTime *time.Time) vshnv1.XVSHNPostgreSQL {
+func getXVSHNPostgreSQL(addFinalizer int) vshnv1.XVSHNPostgreSQL {
 	obj := vshnv1.XVSHNPostgreSQL{}
 	for i := 0; i < addFinalizer; i++ {
 		obj.Finalizers = append(obj.Finalizers, finalizerName)
-	}
-	if deletedTime != nil {
-		obj.SetDeletionTimestamp(&metav1.Time{Time: *deletedTime})
 	}
 	return obj
 }
@@ -277,151 +109,4 @@ func getPatch(op jsonpatch.JSONop) client.Patch {
 	}
 	patch, _ := json.Marshal(patchOps)
 	return client.RawPatch(types.JSONPatchType, patch)
-}
-
-func getRemovePatches(count int) client.Patch {
-	patchOps := []jsonpatch.JSONpatch{}
-	for i := count; i > 0; i-- {
-		if i == count {
-			continue
-		}
-		patchOps = append(patchOps, jsonpatch.JSONpatch{
-			Op:   jsonpatch.JSONopRemove,
-			Path: "/metadata/finalizers/" + strconv.Itoa(i),
-		})
-	}
-	patch, _ := json.Marshal(patchOps)
-	return client.RawPatch(types.JSONPatchType, patch)
-}
-
-func Test_instanceNamespaceDeleted(t *testing.T) {
-	tests := []struct {
-		name          string
-		want          jsonpatch.JSONop
-		wantDeleted   bool
-		wantFinalizer bool
-		wantErr       bool
-		instance      vshnv1.XVSHNPostgreSQL
-		namespace     corev1.Namespace
-		enabled       bool
-	}{
-		{
-			name:          "GivenEnabledAndNotDeleted_ThenExpectNoOpAndFinalizer",
-			want:          jsonpatch.JSONopNone,
-			wantFinalizer: true,
-			enabled:       true,
-			instance: vshnv1.XVSHNPostgreSQL{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "instance-1",
-				},
-			},
-			namespace: corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "vshn-postgresql-instance-1",
-				},
-			},
-		},
-		{
-			name:          "GivenEnabledAndDeleted_ThenExpectRemoveOpAndNoObject",
-			want:          jsonpatch.JSONopRemove,
-			wantFinalizer: false,
-			wantDeleted:   true,
-			enabled:       true,
-			instance: vshnv1.XVSHNPostgreSQL{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "instance-1",
-				},
-			},
-			namespace: corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:              "vshn-postgresql-instance-1",
-					DeletionTimestamp: &metav1.Time{Time: time.Now()},
-					Finalizers:        []string{finalizerName},
-				},
-			},
-		},
-		{
-			name:          "GivenNotEnabledAndNotDeleted_ThenExpectNoOpAndNoFinalizer",
-			want:          jsonpatch.JSONopNone,
-			wantFinalizer: false,
-			enabled:       false,
-			instance: vshnv1.XVSHNPostgreSQL{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "instance-1",
-				},
-			},
-			namespace: corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "vshn-postgresql-instance-1",
-				},
-			},
-		},
-		{
-			name:          "GivenNotEnabledAndNotFound_ThenExpectNoOpAndNoObject",
-			want:          jsonpatch.JSONopNone,
-			wantFinalizer: false,
-			wantDeleted:   true,
-			enabled:       false,
-			instance: vshnv1.XVSHNPostgreSQL{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "instance-1",
-				},
-			},
-			namespace: corev1.Namespace{},
-		},
-		{
-			name:          "GivenNotEnabledAndFinalizer_ThenExpectRemoveOpAndNoFinalizer",
-			want:          jsonpatch.JSONopRemove,
-			wantFinalizer: false,
-			enabled:       false,
-			instance: vshnv1.XVSHNPostgreSQL{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "instance-1",
-				},
-			},
-			namespace: corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:       "vshn-postgresql-instance-1",
-					Finalizers: []string{finalizerName},
-				},
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-
-			// Given
-			fclient := fake.NewClientBuilder().
-				WithScheme(s).
-				WithRuntimeObjects(&tt.instance, &tt.namespace).
-				Build()
-			logger := logr.Discard()
-
-			// When
-			got, err := instanceNamespaceDeleted(context.TODO(), logger, &tt.instance, tt.enabled, fclient)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("instanceNamespaceDeleted() error = %v, wantErr %v", err, tt.wantErr)
-			}
-
-			// Then
-			if got != tt.want {
-				t.Errorf("instanceNamespaceDeleted() = %v, want %v", got, tt.want)
-			}
-
-			resultNs := &corev1.Namespace{}
-			err = fclient.Get(context.TODO(), client.ObjectKey{Name: "vshn-postgresql-" + tt.instance.Name}, resultNs)
-
-			if tt.wantDeleted {
-				assert.Error(t, err)
-			} else {
-				assert.NoError(t, err)
-			}
-
-			if tt.wantFinalizer {
-				assert.Contains(t, resultNs.GetFinalizers(), finalizerName)
-			} else {
-				assert.NotContains(t, resultNs.GetFinalizers(), finalizerName)
-			}
-		})
-	}
 }

--- a/pkg/controller/webhooks/claim_deletionprotection.go
+++ b/pkg/controller/webhooks/claim_deletionprotection.go
@@ -1,0 +1,17 @@
+package webhooks
+
+import (
+	vshnv1 "github.com/vshn/appcat/v4/apis/vshn/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+func GetClaimDeletionProtection(security *vshnv1.Security, allErrs field.ErrorList) field.ErrorList {
+	if security.DeletionProtection {
+		allErrs = append(allErrs, &field.Error{
+			Field:  "spec.parameters.security.deletionProtection",
+			Detail: "DeletionProtection is enabled. To delete the instance, disable the deletionProtection in spec.parameters.security.deletionProtection",
+			Type:   field.ErrorTypeForbidden,
+		})
+	}
+	return allErrs
+}

--- a/pkg/controller/webhooks/default_handler.go
+++ b/pkg/controller/webhooks/default_handler.go
@@ -1,0 +1,251 @@
+package webhooks
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	"github.com/vshn/appcat/v4/pkg/common/quotas"
+	"github.com/vshn/appcat/v4/pkg/common/utils"
+	"github.com/vshn/appcat/v4/pkg/comp-functions/functions/common"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+type DefaultWebhookHandler struct {
+	client    client.Client
+	log       logr.Logger
+	withQuota bool
+	obj       runtime.Object
+	name      string
+	gk        schema.GroupKind
+	gr        schema.GroupResource
+}
+
+var _ webhook.CustomValidator = &DefaultWebhookHandler{}
+
+// SetupWebhookHandlerWithManager registers the validation webhook with the manager.
+func New(mgrClient client.Client, logger logr.Logger, withQuota bool, obj runtime.Object, name string, gk schema.GroupKind, gr schema.GroupResource) *DefaultWebhookHandler {
+
+	return &DefaultWebhookHandler{
+		client:    mgrClient,
+		log:       logger,
+		withQuota: withQuota,
+		name:      name,
+		obj:       obj,
+		gk:        gk,
+		gr:        gr,
+	}
+}
+
+// ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type
+func (r *DefaultWebhookHandler) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	allErrs := field.ErrorList{}
+	comp, ok := obj.(common.Composite)
+	if !ok {
+		return nil, fmt.Errorf("provided manifest is not a valid " + r.gk.Kind + " object")
+	}
+
+	if r.withQuota {
+		quotaErrs := r.checkQuotas(ctx, comp, true)
+		if quotaErrs != nil {
+			allErrs = append(allErrs, &field.Error{
+				Field: "quota",
+				Detail: fmt.Sprintf("quota check failed: %s",
+					quotaErrs.Error()),
+				BadValue: "*your namespace quota*",
+				Type:     field.ErrorTypeForbidden,
+			})
+		}
+	}
+
+	// We aggregate and return all errors at the same time.
+	// So the user is aware of all broken parameters.
+	// But at the same time, if any of these fail we cannot do proper quota checks anymore.
+	if len(allErrs) != 0 {
+		return nil, apierrors.NewInvalid(
+			r.gk,
+			comp.GetName(),
+			allErrs,
+		)
+	}
+
+	return nil, nil
+}
+
+// ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type
+func (r *DefaultWebhookHandler) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
+	allErrs := field.ErrorList{}
+	comp, ok := newObj.(common.Composite)
+	if !ok {
+		return nil, fmt.Errorf("provided manifest is not a valid " + r.gk.Kind + " object")
+	}
+
+	if comp.GetDeletionTimestamp() != nil {
+		return nil, nil
+	}
+
+	if r.withQuota {
+		quotaErrs := r.checkQuotas(ctx, comp, true)
+		if quotaErrs != nil {
+			allErrs = append(allErrs, &field.Error{
+				Field: "quota",
+				Detail: fmt.Sprintf("quota check failed: %s",
+					quotaErrs.Error()),
+				BadValue: "*your namespace quota*",
+				Type:     field.ErrorTypeForbidden,
+			})
+		}
+	}
+
+	// We aggregate and return all errors at the same time.
+	// So the user is aware of all broken parameters.
+	// But at the same time, if any of these fail we cannot do proper quota checks anymore.
+	if len(allErrs) != 0 {
+		return nil, apierrors.NewInvalid(
+			r.gk,
+			comp.GetName(),
+			allErrs,
+		)
+	}
+
+	return nil, nil
+}
+
+// ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type
+func (r *DefaultWebhookHandler) ValidateDelete(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	allErrs := field.ErrorList{}
+
+	comp, ok := obj.(common.Composite)
+	if !ok {
+		return nil, fmt.Errorf("provided manifest is not a valid " + r.gk.Kind + " object")
+	}
+
+	allErrs = GetClaimDeletionProtection(comp.GetSecurity(), allErrs)
+
+	if len(allErrs) != 0 {
+		return nil, apierrors.NewInvalid(
+			r.gk,
+			comp.GetName(),
+			allErrs,
+		)
+	}
+	return nil, nil
+}
+
+// checkQuotas will read the plan if it's set and then check if any other size parameters are overwriten
+func (r *DefaultWebhookHandler) checkQuotas(ctx context.Context, comp common.Composite, checkNamespaceQuota bool) *apierrors.StatusError {
+
+	var fieldErr *field.Error
+	instances := int64(comp.GetInstances())
+	allErrs := field.ErrorList{}
+	resources := utils.Resources{}
+
+	if comp.GetSize().Plan != "" {
+		var err error
+		resources, err = utils.FetchPlansFromCluster(ctx, r.client, "vshn"+r.name+"plans", comp.GetSize().Plan)
+		if err != nil {
+			return apierrors.NewInternalError(err)
+		}
+	}
+
+	isLegacy := false
+	if r.name == "redis" {
+		isLegacy = true
+	}
+	r.addPathsToResources(&resources, isLegacy)
+
+	if comp.GetSize().CPU != "" {
+		resources.CPULimits, fieldErr = parseResource(resources.CPULimitsPath, comp.GetSize().CPU, "not a valid cpu size")
+		if fieldErr != nil {
+			allErrs = append(allErrs, fieldErr)
+		}
+	}
+
+	if comp.GetSize().Requests.CPU != "" {
+		resources.CPURequests, fieldErr = parseResource(resources.CPURequestsPath, comp.GetSize().Requests.CPU, "not a valid cpu size")
+		if fieldErr != nil {
+			allErrs = append(allErrs, fieldErr)
+		}
+	}
+
+	if comp.GetSize().Memory != "" {
+		resources.MemoryLimits, fieldErr = parseResource(resources.MemoryLimitsPath, comp.GetSize().Memory, "not a valid memory size")
+		if fieldErr != nil {
+			allErrs = append(allErrs, fieldErr)
+		}
+	}
+
+	if comp.GetSize().Requests.Memory != "" {
+		resources.MemoryRequests, fieldErr = parseResource(resources.MemoryRequestsPath, comp.GetSize().Requests.Memory, "not a valid memory size")
+		if fieldErr != nil {
+			allErrs = append(allErrs, fieldErr)
+		}
+	}
+
+	if comp.GetSize().Disk != "" {
+		resources.Disk, fieldErr = parseResource(resources.DiskPath, comp.GetSize().Disk, "not a valid cpu size")
+		if fieldErr != nil {
+			allErrs = append(allErrs, fieldErr)
+		}
+	}
+
+	// We aggregate and return all errors at the same time.
+	// So the user is aware of all broken parameters.
+	// But at the same time, if any of these fail we cannot do proper quota checks anymore.
+	if len(allErrs) != 0 {
+		return apierrors.NewInvalid(
+			r.gk,
+			comp.GetName(),
+			allErrs,
+		)
+	}
+
+	resources.MultiplyBy(instances)
+
+	checker := quotas.NewQuotaChecker(
+		r.client,
+		comp.GetName(),
+		comp.GetNamespace(),
+		comp.GetInstanceNamespace(),
+		resources,
+		r.gr,
+		r.gk,
+		checkNamespaceQuota,
+		instances,
+	)
+
+	return checker.CheckQuotas(ctx)
+}
+
+func (r *DefaultWebhookHandler) addPathsToResources(res *utils.Resources, isLegacy bool) {
+	basePath := field.NewPath("spec", "parameters", "size")
+
+	if isLegacy {
+		res.CPULimitsPath = basePath.Child("CPULimits")
+		res.CPURequestsPath = basePath.Child("CPURequests")
+		res.MemoryLimitsPath = basePath.Child("memoryLimits")
+		res.MemoryRequestsPath = basePath.Child("memoryLimits")
+	} else {
+		res.CPULimitsPath = basePath.Child("CPU")
+		res.CPURequestsPath = basePath.Child("Requests", "CPU")
+		res.MemoryLimitsPath = basePath.Child("Memory")
+		res.MemoryRequestsPath = basePath.Child("Requests", "Memory")
+	}
+	res.DiskPath = basePath.Child("disk")
+
+}
+
+// k8s limitation is 52 characters, our longest postfix we add is 15 character, therefore 37 chracters is the maximum length
+// https://kubernetes.io/docs/concepts/overview/working-with-objects/names/
+func (r *DefaultWebhookHandler) validateResourceNameLength(name string, lenght int) error {
+	if len(name) > lenght {
+		return fmt.Errorf("%d/%d chars.\n\tWe add various postfixes and CronJob name length has it's own limitations: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names", len(name), lenght)
+	}
+	return nil
+}

--- a/pkg/controller/webhooks/default_handler_test.go
+++ b/pkg/controller/webhooks/default_handler_test.go
@@ -1,0 +1,187 @@
+package webhooks
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	vshnv1 "github.com/vshn/appcat/v4/apis/vshn/v1"
+	"github.com/vshn/appcat/v4/pkg"
+	"github.com/vshn/appcat/v4/pkg/common/utils"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestSetupWebhookHandlerWithManager_ValidateCreate(t *testing.T) {
+	// Given
+	claimNS := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "claimns",
+			Labels: map[string]string{
+				utils.OrgLabelName: "myorg",
+			},
+		},
+	}
+
+	ctx := context.TODO()
+
+	fclient := fake.NewClientBuilder().
+		WithScheme(pkg.SetupScheme()).
+		WithObjects(claimNS).
+		Build()
+
+	handler := TestWebhookHandler{
+		DefaultWebhookHandler: DefaultWebhookHandler{
+			client:    fclient,
+			log:       logr.Discard(),
+			withQuota: true,
+			obj:       &vshnv1.VSHNNextcloud{},
+			name:      "nextcloud",
+		},
+	}
+
+	redisOrig := &vshnv1.VSHNNextcloud{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "myinstance",
+			Namespace: "claimns",
+		},
+		Spec: vshnv1.VSHNNextcloudSpec{
+			Parameters: vshnv1.VSHNNextcloudParameters{
+				Size: vshnv1.VSHNSizeSpec{
+					Requests: vshnv1.VSHNDBaaSSizeRequestsSpec{
+						CPU: "500m",
+					},
+				},
+			},
+		},
+	}
+
+	// When within quota
+	_, err := handler.ValidateCreate(ctx, redisOrig)
+
+	//Then no err
+	assert.NoError(t, err)
+
+	// When quota breached
+	// CPU Requests
+	nextcloudInvalid := redisOrig.DeepCopy()
+	nextcloudInvalid.Spec.Parameters.Size.Requests.CPU = "5000m"
+	_, err = handler.ValidateCreate(ctx, nextcloudInvalid)
+	assert.Error(t, err)
+
+	// CPU Limit
+	nextcloudInvalid = redisOrig.DeepCopy()
+	nextcloudInvalid.Spec.Parameters.Size.CPU = "5000m"
+	_, err = handler.ValidateCreate(ctx, nextcloudInvalid)
+	assert.Error(t, err)
+
+	// Memory Limit
+	nextcloudInvalid = redisOrig.DeepCopy()
+	nextcloudInvalid.Spec.Parameters.Size.Memory = "25Gi"
+	_, err = handler.ValidateCreate(ctx, nextcloudInvalid)
+	assert.Error(t, err)
+
+	// Memory Requests
+	nextcloudInvalid = redisOrig.DeepCopy()
+	nextcloudInvalid.Spec.Parameters.Size.Requests.Memory = "25Gi"
+	_, err = handler.ValidateCreate(ctx, nextcloudInvalid)
+	assert.Error(t, err)
+
+	// Disk
+	nextcloudInvalid = redisOrig.DeepCopy()
+	nextcloudInvalid.Spec.Parameters.Size.Disk = "25Ti"
+	_, err = handler.ValidateCreate(ctx, nextcloudInvalid)
+	assert.Error(t, err)
+
+	//When invalid size
+	// CPU Requests
+	nextcloudInvalid = redisOrig.DeepCopy()
+	nextcloudInvalid.Spec.Parameters.Size.Requests.CPU = "foo"
+	_, err = handler.ValidateCreate(ctx, nextcloudInvalid)
+	assert.Error(t, err)
+
+	// CPU Limit
+	nextcloudInvalid = redisOrig.DeepCopy()
+	nextcloudInvalid.Spec.Parameters.Size.CPU = "foo"
+	_, err = handler.ValidateCreate(ctx, nextcloudInvalid)
+	assert.Error(t, err)
+
+	// Memory Limit
+	nextcloudInvalid = redisOrig.DeepCopy()
+	nextcloudInvalid.Spec.Parameters.Size.Memory = "foo"
+	_, err = handler.ValidateCreate(ctx, nextcloudInvalid)
+	assert.Error(t, err)
+
+	// Memory Requests
+	nextcloudInvalid = redisOrig.DeepCopy()
+	nextcloudInvalid.Spec.Parameters.Size.Requests.Memory = "foo"
+	_, err = handler.ValidateCreate(ctx, nextcloudInvalid)
+	assert.Error(t, err)
+
+	// Disk
+	nextcloudInvalid = redisOrig.DeepCopy()
+	nextcloudInvalid.Spec.Parameters.Size.Disk = "foo"
+	_, err = handler.ValidateCreate(ctx, nextcloudInvalid)
+	assert.Error(t, err)
+
+}
+
+func TestSetupWebhookHandlerWithManager_ValidateDelete(t *testing.T) {
+	// Given
+	claimNS := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "claimns",
+			Labels: map[string]string{
+				utils.OrgLabelName: "myorg",
+			},
+		},
+	}
+
+	ctx := context.TODO()
+
+	fclient := fake.NewClientBuilder().
+		WithScheme(pkg.SetupScheme()).
+		WithObjects(claimNS).
+		Build()
+
+	handler := TestWebhookHandler{
+		DefaultWebhookHandler: DefaultWebhookHandler{
+			client:    fclient,
+			log:       logr.Discard(),
+			withQuota: true,
+			obj:       &vshnv1.VSHNNextcloud{},
+			name:      "nextcloud",
+		},
+	}
+
+	nextcloudOrig := &vshnv1.VSHNNextcloud{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "myinstance",
+			Namespace: "claimns",
+		},
+		Spec: vshnv1.VSHNNextcloudSpec{
+			Parameters: vshnv1.VSHNNextcloudParameters{
+				Security: vshnv1.Security{
+					DeletionProtection: true,
+				},
+			},
+		},
+	}
+
+	// When within quota
+	_, err := handler.ValidateDelete(ctx, nextcloudOrig)
+
+	//Then err
+	assert.Error(t, err)
+
+	//Instances
+	nextcloudDeletable := nextcloudOrig.DeepCopy()
+	nextcloudDeletable.Spec.Parameters.Security.DeletionProtection = false
+
+	_, err = handler.ValidateDelete(ctx, nextcloudDeletable)
+
+	//Then no err
+	assert.NoError(t, err)
+}

--- a/pkg/controller/webhooks/keycloak.go
+++ b/pkg/controller/webhooks/keycloak.go
@@ -1,0 +1,43 @@
+package webhooks
+
+import (
+	vshnv1 "github.com/vshn/appcat/v4/apis/vshn/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+//+kubebuilder:webhook:verbs=create;update;delete,path=/validate-vshn-appcat-vshn-io-v1-vshnkeycloak,mutating=false,failurePolicy=fail,groups=vshn.appcat.vshn.io,resources=vshnkeycloaks,versions=v1,name=vshnkeycloak.vshn.appcat.vshn.io,sideEffects=None,admissionReviewVersions=v1
+
+//+kubebuilder:rbac:groups=vshn.appcat.vshn.io,resources=xvshnkeycloaks,verbs=get;list;watch;patch;update
+//+kubebuilder:rbac:groups=vshn.appcat.vshn.io,resources=xvshnkeycloaks/status,verbs=get;list;watch;patch;update
+
+var (
+	keycloakGK = schema.GroupKind{Group: "vshn.appcat.vshn.io", Kind: "VSHNKeycloak"}
+	keycloakGR = schema.GroupResource{Group: keycloakGK.Group, Resource: "vshnkeycloak"}
+)
+
+var _ webhook.CustomValidator = &KeycloakWebhookHandler{}
+
+type KeycloakWebhookHandler struct {
+	DefaultWebhookHandler
+}
+
+// SetupKeycloakWebhookHandlerWithManager registers the validation webhook with the manager.
+func SetupKeycloakWebhookHandlerWithManager(mgr ctrl.Manager, withQuota bool) error {
+
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(&vshnv1.VSHNKeycloak{}).
+		WithValidator(&KeycloakWebhookHandler{
+			DefaultWebhookHandler: *New(
+				mgr.GetClient(),
+				mgr.GetLogger().WithName("webhook").WithName("keycloak"),
+				withQuota,
+				&vshnv1.VSHNKeycloak{},
+				"keycloak",
+				keycloakGK,
+				keycloakGR,
+			),
+		}).
+		Complete()
+}

--- a/pkg/controller/webhooks/mariadb.go
+++ b/pkg/controller/webhooks/mariadb.go
@@ -1,0 +1,43 @@
+package webhooks
+
+import (
+	vshnv1 "github.com/vshn/appcat/v4/apis/vshn/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+//+kubebuilder:webhook:verbs=create;update;delete,path=/validate-vshn-appcat-vshn-io-v1-vshnmariadb,mutating=false,failurePolicy=fail,groups=vshn.appcat.vshn.io,resources=vshnmariadbs,versions=v1,name=vshnmariadb.vshn.appcat.vshn.io,sideEffects=None,admissionReviewVersions=v1
+
+//+kubebuilder:rbac:groups=vshn.appcat.vshn.io,resources=xvshnmariadbs,verbs=get;list;watch;patch;update
+//+kubebuilder:rbac:groups=vshn.appcat.vshn.io,resources=xvshnmariadbs/status,verbs=get;list;watch;patch;update
+
+var (
+	mariadbGK = schema.GroupKind{Group: "vshn.appcat.vshn.io", Kind: "VSHNMariaDB"}
+	mariadbGR = schema.GroupResource{Group: mariadbGK.Group, Resource: "vshnmariadb"}
+)
+
+var _ webhook.CustomValidator = &MariaDBWebhookHandler{}
+
+type MariaDBWebhookHandler struct {
+	DefaultWebhookHandler
+}
+
+// SetupMariaDBWebhookHandlerWithManager registers the validation webhook with the manager.
+func SetupMariaDBWebhookHandlerWithManager(mgr ctrl.Manager, withQuota bool) error {
+
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(&vshnv1.VSHNMariaDB{}).
+		WithValidator(&MariaDBWebhookHandler{
+			DefaultWebhookHandler: *New(
+				mgr.GetClient(),
+				mgr.GetLogger().WithName("webhook").WithName("mariadb"),
+				withQuota,
+				&vshnv1.VSHNMariaDB{},
+				"mariadb",
+				mariadbGK,
+				mariadbGR,
+			),
+		}).
+		Complete()
+}

--- a/pkg/controller/webhooks/minio.go
+++ b/pkg/controller/webhooks/minio.go
@@ -1,0 +1,43 @@
+package webhooks
+
+import (
+	vshnv1 "github.com/vshn/appcat/v4/apis/vshn/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+//+kubebuilder:webhook:verbs=create;update;delete,path=/validate-vshn-appcat-vshn-io-v1-vshnminio,mutating=false,failurePolicy=fail,groups=vshn.appcat.vshn.io,resources=vshnminios,versions=v1,name=vshnminio.vshn.appcat.vshn.io,sideEffects=None,admissionReviewVersions=v1
+
+//+kubebuilder:rbac:groups=vshn.appcat.vshn.io,resources=xvshnminios,verbs=get;list;watch;patch;update
+//+kubebuilder:rbac:groups=vshn.appcat.vshn.io,resources=xvshnminios/status,verbs=get;list;watch;patch;update
+
+var (
+	minioGK = schema.GroupKind{Group: "vshn.appcat.vshn.io", Kind: "VSHNMinio"}
+	minioGR = schema.GroupResource{Group: minioGK.Group, Resource: "vshnminio"}
+)
+
+var _ webhook.CustomValidator = &MinioWebhookHandler{}
+
+type MinioWebhookHandler struct {
+	DefaultWebhookHandler
+}
+
+// SetupMinioWebhookHandlerWithManager registers the validation webhook with the manager.
+func SetupMinioWebhookHandlerWithManager(mgr ctrl.Manager, withQuota bool) error {
+
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(&vshnv1.VSHNMinio{}).
+		WithValidator(&MinioWebhookHandler{
+			DefaultWebhookHandler: *New(
+				mgr.GetClient(),
+				mgr.GetLogger().WithName("webhook").WithName("minio"),
+				withQuota,
+				&vshnv1.VSHNMinio{},
+				"minio",
+				minioGK,
+				minioGR,
+			),
+		}).
+		Complete()
+}

--- a/pkg/controller/webhooks/nextcloud.go
+++ b/pkg/controller/webhooks/nextcloud.go
@@ -1,0 +1,43 @@
+package webhooks
+
+import (
+	vshnv1 "github.com/vshn/appcat/v4/apis/vshn/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+//+kubebuilder:webhook:verbs=create;update;delete,path=/validate-vshn-appcat-vshn-io-v1-vshnnextcloud,mutating=false,failurePolicy=fail,groups=vshn.appcat.vshn.io,resources=vshnnextclouds,versions=v1,name=vshnnextcloud.vshn.appcat.vshn.io,sideEffects=None,admissionReviewVersions=v1
+
+//+kubebuilder:rbac:groups=vshn.appcat.vshn.io,resources=xvshnnextclouds,verbs=get;list;watch;patch;update
+//+kubebuilder:rbac:groups=vshn.appcat.vshn.io,resources=xvshnnextclouds/status,verbs=get;list;watch;patch;update
+
+var (
+	nextcloudGK = schema.GroupKind{Group: "vshn.appcat.vshn.io", Kind: "VSHNNextcloud"}
+	nextcloudGR = schema.GroupResource{Group: nextcloudGK.Group, Resource: "vshnnextcloud"}
+)
+
+var _ webhook.CustomValidator = &TestWebhookHandler{}
+
+type TestWebhookHandler struct {
+	DefaultWebhookHandler
+}
+
+// SetupNextcloudWebhookHandlerWithManager registers the validation webhook with the manager.
+func SetupNextcloudWebhookHandlerWithManager(mgr ctrl.Manager, withQuota bool) error {
+
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(&vshnv1.VSHNNextcloud{}).
+		WithValidator(&TestWebhookHandler{
+			DefaultWebhookHandler: *New(
+				mgr.GetClient(),
+				mgr.GetLogger().WithName("webhook").WithName("nextcloud"),
+				withQuota,
+				&vshnv1.VSHNNextcloud{},
+				"nextcloud",
+				nextcloudGK,
+				nextcloudGR,
+			),
+		}).
+		Complete()
+}

--- a/pkg/controller/webhooks/redis.go
+++ b/pkg/controller/webhooks/redis.go
@@ -4,21 +4,20 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/go-logr/logr"
 	vshnv1 "github.com/vshn/appcat/v4/apis/vshn/v1"
-	"github.com/vshn/appcat/v4/pkg/common/quotas"
-	"github.com/vshn/appcat/v4/pkg/common/utils"
+	"github.com/vshn/appcat/v4/pkg/comp-functions/functions/common"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
-//+kubebuilder:webhook:verbs=delete,path=/validate-vshn-appcat-vshn-io-v1-vshnredis,mutating=false,failurePolicy=fail,groups=vshn.appcat.vshn.io,resources=vshnredis,versions=v1,name=vshnredis.vshn.appcat.vshn.io,sideEffects=None,admissionReviewVersions=v1
+//+kubebuilder:webhook:verbs=create;update;	delete,path=/validate-vshn-appcat-vshn-io-v1-vshnredis,mutating=false,failurePolicy=fail,groups=vshn.appcat.vshn.io,resources=vshnredis,versions=v1,name=vshnredis.vshn.appcat.vshn.io,sideEffects=None,admissionReviewVersions=v1
 
 //+kubebuilder:rbac:groups=vshn.appcat.vshn.io,resources=xvshnredis,verbs=get;list;watch;patch;update
 //+kubebuilder:rbac:groups=vshn.appcat.vshn.io,resources=xvshnredis/status,verbs=get;list;watch;patch;update
@@ -32,9 +31,7 @@ var _ webhook.CustomValidator = &RedisWebhookHandler{}
 
 // RedisWebhookHandler handles all quota webhooks concerning redis by vshn.
 type RedisWebhookHandler struct {
-	client    client.Client
-	log       logr.Logger
-	withQuota bool
+	DefaultWebhookHandler
 }
 
 // SetupRedisWebhookHandlerWithManager registers the validation webhook with the manager.
@@ -43,9 +40,15 @@ func SetupRedisWebhookHandlerWithManager(mgr ctrl.Manager, withQuota bool) error
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(&vshnv1.VSHNRedis{}).
 		WithValidator(&RedisWebhookHandler{
-			client:    mgr.GetClient(),
-			log:       mgr.GetLogger().WithName("webhook").WithName("redis"),
-			withQuota: withQuota,
+			DefaultWebhookHandler: *New(
+				mgr.GetClient(),
+				mgr.GetLogger().WithName("webhook").WithName("redis"),
+				withQuota,
+				&vshnv1.VSHNRedis{},
+				"redis",
+				redisGK,
+				redisGR,
+			),
 		}).
 		Complete()
 }
@@ -53,13 +56,13 @@ func SetupRedisWebhookHandlerWithManager(mgr ctrl.Manager, withQuota bool) error
 // ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type
 func (r *RedisWebhookHandler) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
 	allErrs := field.ErrorList{}
-	redis, ok := obj.(*vshnv1.VSHNRedis)
+	comp, ok := obj.(common.Composite)
 	if !ok {
-		return nil, fmt.Errorf("provided manifest is not a valid VSHNRedis object")
+		return nil, fmt.Errorf("provided manifest is not a valid " + r.gk.Kind + " object")
 	}
 
 	if r.withQuota {
-		quotaErrs := r.checkQuotas(ctx, redis, true)
+		quotaErrs := r.checkQuotas(ctx, comp, true)
 		if quotaErrs != nil {
 			allErrs = append(allErrs, &field.Error{
 				Field: "quota",
@@ -70,13 +73,14 @@ func (r *RedisWebhookHandler) ValidateCreate(ctx context.Context, obj runtime.Ob
 			})
 		}
 	}
-	err := r.validateResourceNameLength(redis.GetName())
+	// k8s limitation is 52 characters, our longest postfix we add is 15 character, therefore 37 chracters is the maximum length
+	err := r.validateResourceNameLength(comp.GetName(), 37)
 	if err != nil {
 		allErrs = append(allErrs, &field.Error{
 			Field: ".metadata.name",
 			Detail: fmt.Sprintf("Please shorten Redis name, currently it is: %s",
 				err.Error()),
-			BadValue: redis.GetName(),
+			BadValue: comp.GetName(),
 			Type:     field.ErrorTypeTooLong,
 		})
 	}
@@ -86,8 +90,8 @@ func (r *RedisWebhookHandler) ValidateCreate(ctx context.Context, obj runtime.Ob
 	// But at the same time, if any of these fail we cannot do proper quota checks anymore.
 	if len(allErrs) != 0 {
 		return nil, apierrors.NewInvalid(
-			redisGK,
-			redis.GetName(),
+			r.gk,
+			comp.GetName(),
 			allErrs,
 		)
 	}
@@ -98,17 +102,17 @@ func (r *RedisWebhookHandler) ValidateCreate(ctx context.Context, obj runtime.Ob
 // ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type
 func (r *RedisWebhookHandler) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
 	allErrs := field.ErrorList{}
-	redis, ok := newObj.(*vshnv1.VSHNRedis)
+	comp, ok := newObj.(common.Composite)
 	if !ok {
-		return nil, fmt.Errorf("provided manifest is not a valid VSHNRedis object")
+		return nil, fmt.Errorf("provided manifest is not a valid " + r.gk.Kind + " object")
 	}
 
-	if redis.DeletionTimestamp != nil {
+	if comp.GetDeletionTimestamp() != nil {
 		return nil, nil
 	}
 
 	if r.withQuota {
-		quotaErrs := r.checkQuotas(ctx, redis, true)
+		quotaErrs := r.checkQuotas(ctx, comp, true)
 		if quotaErrs != nil {
 			allErrs = append(allErrs, &field.Error{
 				Field: "quota",
@@ -120,13 +124,14 @@ func (r *RedisWebhookHandler) ValidateUpdate(ctx context.Context, oldObj, newObj
 		}
 	}
 
-	err := r.validateResourceNameLength(redis.GetName())
+	// k8s limitation is 52 characters, our longest postfix we add is 15 character, therefore 37 chracters is the maximum length
+	err := r.validateResourceNameLength(comp.GetName(), 37)
 	if err != nil {
 		allErrs = append(allErrs, &field.Error{
 			Field: ".metadata.name",
-			Detail: fmt.Sprintf("Please shorten Redis name, currently it is: %s",
+			Detail: fmt.Sprintf("Please shorten "+cases.Title(language.English).String(r.name)+" name, currently it is: %s",
 				err.Error()),
-			BadValue: redis.GetName(),
+			BadValue: comp.GetName(),
 			Type:     field.ErrorTypeTooLong,
 		})
 	}
@@ -136,119 +141,11 @@ func (r *RedisWebhookHandler) ValidateUpdate(ctx context.Context, oldObj, newObj
 	// But at the same time, if any of these fail we cannot do proper quota checks anymore.
 	if len(allErrs) != 0 {
 		return nil, apierrors.NewInvalid(
-			redisGK,
-			redis.GetName(),
+			r.gk,
+			comp.GetName(),
 			allErrs,
 		)
 	}
 
 	return nil, nil
-}
-
-// ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type
-func (r *RedisWebhookHandler) ValidateDelete(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
-	// NOOP for now
-	return nil, nil
-}
-
-// checkQuotas will read the plan if it's set and then check if any other size parameters are overwriten
-func (r *RedisWebhookHandler) checkQuotas(ctx context.Context, redis *vshnv1.VSHNRedis, checkNamespaceQuota bool) *apierrors.StatusError {
-
-	var fieldErr *field.Error
-	// TODO: Fix once we support replicas
-	instances := int64(1)
-	allErrs := field.ErrorList{}
-	resources := utils.Resources{}
-
-	if redis.Spec.Parameters.Size.Plan != "" {
-		var err error
-		resources, err = utils.FetchPlansFromCluster(ctx, r.client, "vshnredisplans", redis.Spec.Parameters.Size.Plan)
-		if err != nil {
-			return apierrors.NewInternalError(err)
-		}
-	}
-
-	r.addPathsToResources(&resources)
-
-	if redis.Spec.Parameters.Size.CPULimits != "" {
-		resources.CPULimits, fieldErr = parseResource(resources.CPULimitsPath, redis.Spec.Parameters.Size.CPULimits, "not a valid cpu size")
-		if fieldErr != nil {
-			allErrs = append(allErrs, fieldErr)
-		}
-	}
-
-	if redis.Spec.Parameters.Size.CPURequests != "" {
-		resources.CPURequests, fieldErr = parseResource(resources.CPURequestsPath, redis.Spec.Parameters.Size.CPURequests, "not a valid cpu size")
-		if fieldErr != nil {
-			allErrs = append(allErrs, fieldErr)
-		}
-	}
-
-	if redis.Spec.Parameters.Size.MemoryLimits != "" {
-		resources.MemoryLimits, fieldErr = parseResource(resources.MemoryLimitsPath, redis.Spec.Parameters.Size.MemoryLimits, "not a valid memory size")
-		if fieldErr != nil {
-			allErrs = append(allErrs, fieldErr)
-		}
-	}
-
-	if redis.Spec.Parameters.Size.MemoryRequests != "" {
-		resources.MemoryRequests, fieldErr = parseResource(resources.MemoryRequestsPath, redis.Spec.Parameters.Size.MemoryRequests, "not a valid memory size")
-		if fieldErr != nil {
-			allErrs = append(allErrs, fieldErr)
-		}
-	}
-
-	if redis.Spec.Parameters.Size.Disk != "" {
-		resources.Disk, fieldErr = parseResource(resources.DiskPath, redis.Spec.Parameters.Size.Disk, "not a valid cpu size")
-		if fieldErr != nil {
-			allErrs = append(allErrs, fieldErr)
-		}
-	}
-
-	// We aggregate and return all errors at the same time.
-	// So the user is aware of all broken parameters.
-	// But at the same time, if any of these fail we cannot do proper quota checks anymore.
-	if len(allErrs) != 0 {
-		return apierrors.NewInvalid(
-			redisGK,
-			redis.GetName(),
-			allErrs,
-		)
-	}
-
-	// No support for replicas yet in redis
-	// resources.MultiplyBy(instances)
-
-	checker := quotas.NewQuotaChecker(
-		r.client,
-		redis.GetName(),
-		redis.GetNamespace(),
-		redis.Status.InstanceNamespace,
-		resources,
-		redisGR,
-		redisGK,
-		checkNamespaceQuota,
-		instances,
-	)
-
-	return checker.CheckQuotas(ctx)
-}
-
-func (r *RedisWebhookHandler) addPathsToResources(res *utils.Resources) {
-	basePath := field.NewPath("spec", "parameters", "size")
-
-	res.CPULimitsPath = basePath.Child("CPULimits")
-	res.CPURequestsPath = basePath.Child("CPURequests")
-	res.MemoryLimitsPath = basePath.Child("memoryLimits")
-	res.MemoryRequestsPath = basePath.Child("memoryLimits")
-	res.DiskPath = basePath.Child("disk")
-}
-
-// k8s limitation is 52 characters, our longest postfix we add is 15 character, therefore 37 chracters is the maximum length
-// https://kubernetes.io/docs/concepts/overview/working-with-objects/names/
-func (r *RedisWebhookHandler) validateResourceNameLength(name string) error {
-	if len(name) > 37 {
-		return fmt.Errorf("%d/37 chars.\n\tWe add various postfixes and CronJob name length has it's own limitations: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names", len(name))
-	}
-	return nil
 }


### PR DESCRIPTION
## Summary

* This PR adds a new field `spec.parameters.security.deletionProtection` which is enabled by default, that will prevent the deletion of a claim by accident.
* The deletion protection is handled via webhooks and a user must disable the `deletionProtection` in the claim before being able to delete it.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
