### PR TITLE
Fix wrong probe path for keycloak for the sli exporter

### DIFF
--- a/pkg/sliexporter/vshnkeycloak_controller/vshnkeycloak_controller.go
+++ b/pkg/sliexporter/vshnkeycloak_controller/vshnkeycloak_controller.go
@@ -61,7 +61,7 @@ func (r *VSHNKeycloakReconciler) Reconcile(ctx context.Context, req ctrl.Request
 func (r VSHNKeycloakReconciler) getKeycloakProber(ctx context.Context, obj slireconciler.Service) (prober probes.Prober, err error) {
 	inst, ok := obj.(*vshnv1.XVSHNKeycloak)
 	if !ok {
-		return nil, fmt.Errorf("cannot start probe, object not a valid VSHNRedis")
+		return nil, fmt.Errorf("cannot start probe, object not a valid VSHKeycloak")
 	}
 
 	credentials := corev1.Secret{}
@@ -84,7 +84,7 @@ func (r VSHNKeycloakReconciler) getKeycloakProber(ctx context.Context, obj slire
 		return nil, fmt.Errorf("secret does not contain Keycloak url")
 	}
 
-	url := "https://" + string(host) + ":8443/health"
+	url := "https://" + string(host) + ":9000/health"
 
 	rawCACert, ok := credentials.Data["ca.crt"]
 	if !ok {


### PR DESCRIPTION
## Summary

* With Keycloak 25, the health enpdoint changed. We therefore also need to adjust our SLI prober accordingly

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [ ] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
