### PR TITLE
Add support for PostgreSQL 15 and 16 on Exoscale

### DIFF
--- a/apis/exoscale/v1/dbaas_exoscale_postgresql.go
+++ b/apis/exoscale/v1/dbaas_exoscale_postgresql.go
@@ -58,11 +58,11 @@ type ExoscalePostgreSQLParameters struct {
 type ExoscalePostgreSQLServiceSpec struct {
 	ExoscaleDBaaSServiceSpec `json:",inline"`
 
-	// +kubebuilder:validation:Enum="14"
-	// +kubebuilder:default="14"
+	// +kubebuilder:validation:Enum="14";"15";"16"
+	// +kubebuilder:default="16"
 
 	// MajorVersion contains the major version for PostgreSQL.
-	// Currently only "14" is supported. Leave it empty to always get the latest supported version.
+	// Leave it empty to always get the latest supported version.
 	MajorVersion string `json:"majorVersion,omitempty"`
 
 	// PGSettings contains additional PostgreSQL settings.

--- a/crds/exoscale.appcat.vshn.io_exoscalepostgresqls.yaml
+++ b/crds/exoscale.appcat.vshn.io_exoscalepostgresqls.yaml
@@ -107,12 +107,14 @@ spec:
                       description: Service contains Exoscale PostgreSQL DBaaS specific properties
                       properties:
                         majorVersion:
-                          default: "14"
+                          default: "16"
                           description: |-
                             MajorVersion contains the major version for PostgreSQL.
-                            Currently only "14" is supported. Leave it empty to always get the latest supported version.
+                            Leave it empty to always get the latest supported version.
                           enum:
                             - "14"
+                            - "15"
+                            - "16"
                           type: string
                         pgSettings:
                           description: PGSettings contains additional PostgreSQL settings.


### PR DESCRIPTION
## Summary

* This PR adds support for PostgreSQL 15 and 16 on Exoscale.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [ ] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
