### PR TITLE
Fix pointer leaks by using generics

### DIFF
--- a/pkg/comp-functions/functions/buckets/cloudscalebucket/cloudscalebucket.go
+++ b/pkg/comp-functions/functions/buckets/cloudscalebucket/cloudscalebucket.go
@@ -22,9 +22,7 @@ const (
 // ProvisionCloudscalebucket will create a bucket in cloudscale.
 // This function will leverage provider-cloudscale to deploy proper users
 // alongside the bucket.
-func ProvisionCloudscalebucket(_ context.Context, svc *runtime.ServiceRuntime) *xfnproto.Result {
-
-	bucket := &appcatv1.ObjectBucket{}
+func ProvisionCloudscalebucket(_ context.Context, bucket *appcatv1.ObjectBucket, svc *runtime.ServiceRuntime) *xfnproto.Result {
 
 	err := svc.GetObservedComposite(bucket)
 	if err != nil {

--- a/pkg/comp-functions/functions/buckets/cloudscalebucket/cloudscalebucket_test.go
+++ b/pkg/comp-functions/functions/buckets/cloudscalebucket/cloudscalebucket_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	v1 "github.com/vshn/appcat/v4/apis/v1"
 	"github.com/vshn/appcat/v4/pkg/comp-functions/functions/commontest"
 	cloudscalev1 "github.com/vshn/provider-cloudscale/apis/cloudscale/v1"
 )
@@ -16,7 +17,7 @@ func TestProvisionCloudscalebucket(t *testing.T) {
 
 	bucketName := "mytest"
 
-	res := ProvisionCloudscalebucket(ctx, svc)
+	res := ProvisionCloudscalebucket(ctx, &v1.ObjectBucket{}, svc)
 	assert.Nil(t, res)
 
 	bucket := &cloudscalev1.Bucket{}
@@ -35,7 +36,7 @@ func TestExistingBuckets(t *testing.T) {
 
 	ctx := context.TODO()
 
-	res := ProvisionCloudscalebucket(ctx, svc)
+	res := ProvisionCloudscalebucket(ctx, &v1.ObjectBucket{}, svc)
 	assert.Nil(t, res)
 
 	bucket := &cloudscalev1.Bucket{}

--- a/pkg/comp-functions/functions/buckets/cloudscalebucket/register.go
+++ b/pkg/comp-functions/functions/buckets/cloudscalebucket/register.go
@@ -1,10 +1,13 @@
 package cloudscalebucket
 
-import "github.com/vshn/appcat/v4/pkg/comp-functions/runtime"
+import (
+	appcatv1 "github.com/vshn/appcat/v4/apis/v1"
+	"github.com/vshn/appcat/v4/pkg/comp-functions/runtime"
+)
 
 func init() {
-	runtime.RegisterService("cloudscalebucket", runtime.Service{
-		Steps: []runtime.Step{
+	runtime.RegisterService[*appcatv1.ObjectBucket]("cloudscalebucket", runtime.Service[*appcatv1.ObjectBucket]{
+		Steps: []runtime.Step[*appcatv1.ObjectBucket]{
 			{
 				Name:    "provision-bucket",
 				Execute: ProvisionCloudscalebucket,

--- a/pkg/comp-functions/functions/buckets/exoscalebucket/exoscalebucket.go
+++ b/pkg/comp-functions/functions/buckets/exoscalebucket/exoscalebucket.go
@@ -21,9 +21,7 @@ const (
 // ProvisionExoscalebucket will create a bucket in cloudscale.
 // This function will leverage provider-cloudscale to deploy proper users
 // alongside the bucket.
-func ProvisionExoscalebucket(_ context.Context, svc *runtime.ServiceRuntime) *xfnproto.Result {
-
-	bucket := &appcatv1.ObjectBucket{}
+func ProvisionExoscalebucket(_ context.Context, bucket *appcatv1.ObjectBucket, svc *runtime.ServiceRuntime) *xfnproto.Result {
 
 	err := svc.GetObservedComposite(bucket)
 	if err != nil {

--- a/pkg/comp-functions/functions/buckets/exoscalebucket/exoscalebucket_test.go
+++ b/pkg/comp-functions/functions/buckets/exoscalebucket/exoscalebucket_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	v1 "github.com/vshn/appcat/v4/apis/v1"
 	"github.com/vshn/appcat/v4/pkg/comp-functions/functions/commontest"
 	cloudscalev1 "github.com/vshn/provider-cloudscale/apis/cloudscale/v1"
 	exoscalev1 "github.com/vshn/provider-exoscale/apis/exoscale/v1"
@@ -17,7 +18,7 @@ func TestProvisionCloudscalebucket(t *testing.T) {
 
 	bucketName := "mytest"
 
-	res := ProvisionExoscalebucket(ctx, svc)
+	res := ProvisionExoscalebucket(ctx, &v1.ObjectBucket{}, svc)
 	assert.Nil(t, res)
 
 	bucket := &exoscalev1.Bucket{}
@@ -36,7 +37,7 @@ func TestExistingBuckets(t *testing.T) {
 
 	ctx := context.TODO()
 
-	res := ProvisionExoscalebucket(ctx, svc)
+	res := ProvisionExoscalebucket(ctx, &v1.ObjectBucket{}, svc)
 	assert.Nil(t, res)
 
 	bucket := &cloudscalev1.Bucket{}

--- a/pkg/comp-functions/functions/buckets/exoscalebucket/register.go
+++ b/pkg/comp-functions/functions/buckets/exoscalebucket/register.go
@@ -1,10 +1,13 @@
 package exoscalebucket
 
-import "github.com/vshn/appcat/v4/pkg/comp-functions/runtime"
+import (
+	appcatv1 "github.com/vshn/appcat/v4/apis/v1"
+	"github.com/vshn/appcat/v4/pkg/comp-functions/runtime"
+)
 
 func init() {
-	runtime.RegisterService("exoscalebucket", runtime.Service{
-		Steps: []runtime.Step{
+	runtime.RegisterService[*appcatv1.ObjectBucket]("exoscalebucket", runtime.Service[*appcatv1.ObjectBucket]{
+		Steps: []runtime.Step[*appcatv1.ObjectBucket]{
 			{
 				Name:    "provision-bucket",
 				Execute: ProvisionExoscalebucket,

--- a/pkg/comp-functions/functions/buckets/miniobucket/miniobucket.go
+++ b/pkg/comp-functions/functions/buckets/miniobucket/miniobucket.go
@@ -15,9 +15,7 @@ import (
 // ProvisionMiniobucket will create a bucket in a pre-deployed minio instance.
 // This function will leverage provider-minio to deploy proper policies and users
 // alongside the bucket.
-func ProvisionMiniobucket(_ context.Context, svc *runtime.ServiceRuntime) *xfnproto.Result {
-
-	bucket := &appcatv1.ObjectBucket{}
+func ProvisionMiniobucket(_ context.Context, bucket *appcatv1.ObjectBucket, svc *runtime.ServiceRuntime) *xfnproto.Result {
 
 	err := svc.GetObservedComposite(bucket)
 	if err != nil {

--- a/pkg/comp-functions/functions/buckets/miniobucket/miniobucket_test.go
+++ b/pkg/comp-functions/functions/buckets/miniobucket/miniobucket_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	v1 "github.com/vshn/appcat/v4/apis/v1"
 	"github.com/vshn/appcat/v4/pkg/comp-functions/functions/commontest"
 	miniov1 "github.com/vshn/provider-minio/apis/minio/v1"
 )
@@ -16,7 +17,7 @@ func TestProvisionMiniobucket(t *testing.T) {
 
 	bucketName := "mytest"
 
-	res := ProvisionMiniobucket(ctx, svc)
+	res := ProvisionMiniobucket(ctx, &v1.ObjectBucket{}, svc)
 	assert.Nil(t, res)
 
 	bucket := &miniov1.Bucket{}

--- a/pkg/comp-functions/functions/buckets/miniobucket/register.go
+++ b/pkg/comp-functions/functions/buckets/miniobucket/register.go
@@ -1,10 +1,13 @@
 package miniobucket
 
-import "github.com/vshn/appcat/v4/pkg/comp-functions/runtime"
+import (
+	appcatv1 "github.com/vshn/appcat/v4/apis/v1"
+	"github.com/vshn/appcat/v4/pkg/comp-functions/runtime"
+)
 
 func init() {
-	runtime.RegisterService("miniobucket", runtime.Service{
-		Steps: []runtime.Step{
+	runtime.RegisterService[*appcatv1.ObjectBucket]("miniobucket", runtime.Service[*appcatv1.ObjectBucket]{
+		Steps: []runtime.Step[*appcatv1.ObjectBucket]{
 			{
 				Name:    "provision-bucket",
 				Execute: ProvisionMiniobucket,

--- a/pkg/comp-functions/functions/common/mailgun_alerting.go
+++ b/pkg/comp-functions/functions/common/mailgun_alerting.go
@@ -17,41 +17,40 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func MailgunAlerting(obj client.Object) func(ctx context.Context, svc *runtime.ServiceRuntime) *xfnproto.Result {
-	return func(ctx context.Context, svc *runtime.ServiceRuntime) *xfnproto.Result {
-		log := controllerruntime.LoggerFrom(ctx)
-		log.Info("Starting mailgun-alerting function")
+func MailgunAlerting[T client.Object](ctx context.Context, obj T, svc *runtime.ServiceRuntime) *xfnproto.Result {
+	log := controllerruntime.LoggerFrom(ctx)
+	log.Info("Starting mailgun-alerting function")
 
-		err := svc.GetObservedComposite(obj)
-		if err != nil {
-			return runtime.NewFatalResult(fmt.Errorf("Can't get composite: %w", err))
-		}
-		alertConfig, ok := obj.(Alerter)
-		if !ok {
-			return runtime.NewWarningResult(fmt.Sprintf("Type %s doesn't implement Alerter interface", reflect.TypeOf(obj).String()))
-		}
+	err := svc.GetObservedComposite(obj)
+	if err != nil {
+		return runtime.NewFatalResult(fmt.Errorf("Can't get composite: %w", err))
+	}
+	objCopy := obj.DeepCopyObject()
+	alertConfig, ok := objCopy.(Alerter)
+	if !ok {
+		return runtime.NewWarningResult(fmt.Sprintf("Type %s doesn't implement Alerter interface", reflect.TypeOf(obj).String()))
+	}
 
-		email := alertConfig.GetVSHNMonitoring().Email
-		instanceNamespace := alertConfig.GetInstanceNamespace()
-		name := obj.GetName()
+	email := alertConfig.GetVSHNMonitoring().Email
+	instanceNamespace := alertConfig.GetInstanceNamespace()
+	name := obj.GetName()
 
-		if email == "" {
-			return nil
-		}
-		if !mailAlertingEnabled(&svc.Config) {
-			return runtime.NewWarningResult("Email Alerting is not enabled")
-		}
-
-		log.Info("Deploying AlertmanagerConfig for mail alerting...")
-		err = deployAlertmanagerConfig(ctx, name, email, instanceNamespace, svc)
-		if err != nil {
-			return runtime.NewFatalResult(fmt.Errorf("Can't deploy AlertmanagerConfig "+name+"-alertmanagerconfig-mailgun for mail alerting: %w", err))
-		}
-
-		log.Info("Finishing mailgun-alerting function with NewNormal")
-
+	if email == "" {
 		return nil
 	}
+	if !mailAlertingEnabled(&svc.Config) {
+		return runtime.NewWarningResult("Email Alerting is not enabled")
+	}
+
+	log.Info("Deploying AlertmanagerConfig for mail alerting...")
+	err = deployAlertmanagerConfig(ctx, name, email, instanceNamespace, svc)
+	if err != nil {
+		return runtime.NewFatalResult(fmt.Errorf("Can't deploy AlertmanagerConfig "+name+"-alertmanagerconfig-mailgun for mail alerting: %w", err))
+	}
+
+	log.Info("Finishing mailgun-alerting function with NewNormal")
+
+	return nil
 }
 
 func deployAlertmanagerConfig(ctx context.Context, name, email, instanceNamespace string, svc *runtime.ServiceRuntime) error {

--- a/pkg/comp-functions/functions/common/mailgun_alerting_test.go
+++ b/pkg/comp-functions/functions/common/mailgun_alerting_test.go
@@ -72,12 +72,12 @@ func TestMailgunAlerting(t *testing.T) {
 }
 
 func runForGivenInputMailgun(t *testing.T, ctx context.Context, input *runtime.ServiceRuntime, res *xfnproto.Result) {
-	fnc := MailgunAlerting(&vshnv1.VSHNRedis{})
+	fnc := MailgunAlerting[*vshnv1.VSHNRedis](context.TODO(), &vshnv1.VSHNRedis{}, input)
 
-	assert.Equal(t, res, fnc(ctx, input))
+	assert.Equal(t, res, fnc)
 
-	fnc = MailgunAlerting(&vshnv1.VSHNPostgreSQL{})
+	fnc = MailgunAlerting[*vshnv1.VSHNPostgreSQL](context.TODO(), &vshnv1.VSHNPostgreSQL{}, input)
 
-	assert.Equal(t, res, fnc(ctx, input))
+	assert.Equal(t, res, fnc)
 
 }

--- a/pkg/comp-functions/functions/common/nonsla/non_sla_prom_rules.go
+++ b/pkg/comp-functions/functions/common/nonsla/non_sla_prom_rules.go
@@ -13,8 +13,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func GenerateNonSLAPromRules(obj client.Object, alerts Alerts) func(ctx context.Context, svc *runtime.ServiceRuntime) *fnproto.Result {
-	return func(ctx context.Context, svc *runtime.ServiceRuntime) *fnproto.Result {
+func GenerateNonSLAPromRules[T client.Object](alerts Alerts) func(ctx context.Context, obj T, svc *runtime.ServiceRuntime) *fnproto.Result {
+	return func(ctx context.Context, obj T, svc *runtime.ServiceRuntime) *fnproto.Result {
 		log := controllerruntime.LoggerFrom(ctx)
 		log.Info("Starting non SLA prometheus rules")
 
@@ -24,7 +24,8 @@ func GenerateNonSLAPromRules(obj client.Object, alerts Alerts) func(ctx context.
 		if err != nil {
 			return runtime.NewFatalResult(fmt.Errorf("can't get composite: %w", err))
 		}
-		elem, ok := obj.(common.InfoGetter)
+		objCopy := obj.DeepCopyObject()
+		elem, ok := objCopy.(common.InfoGetter)
 		if !ok {
 			return runtime.NewFatalResult(err)
 		}

--- a/pkg/comp-functions/functions/common/pdb.go
+++ b/pkg/comp-functions/functions/common/pdb.go
@@ -7,48 +7,49 @@ import (
 	pdbv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	fnproto "github.com/crossplane/function-sdk-go/proto/v1beta1"
 	"github.com/vshn/appcat/v4/pkg/comp-functions/runtime"
 )
 
-func AddPDBSettings(comp Composite) func(ctx context.Context, svc *runtime.ServiceRuntime) *fnproto.Result {
-	return func(ctx context.Context, svc *runtime.ServiceRuntime) *fnproto.Result {
+func AddPDBSettings[T client.Object](ctx context.Context, obj T, svc *runtime.ServiceRuntime) *fnproto.Result {
 
-		log := svc.Log
+	log := svc.Log
 
-		err := svc.GetObservedComposite(comp)
-		if err != nil {
-			return runtime.NewFatalResult(fmt.Errorf("can't get composite: %w", err))
-		}
-
-		log.Info("Checking if PDB is needed", "service", comp.GetName(), "instances", comp.GetInstances())
-
-		if comp.GetInstances() < 2 {
-			return runtime.NewNormalResult("Not HA, no pdb needed")
-		}
-		log.Info("HA detected, adding pdb", "service", comp.GetName())
-
-		min := intstr.IntOrString{StrVal: "50%", Type: intstr.String}
-
-		x := &pdbv1.PodDisruptionBudget{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      comp.GetName() + "-pdb",
-				Namespace: comp.GetInstanceNamespace(),
-			},
-			Spec: pdbv1.PodDisruptionBudgetSpec{
-				MinAvailable: &min,
-				Selector: &metav1.LabelSelector{
-					MatchLabels: comp.GetPDBLabels(),
-				},
-			},
-		}
-
-		err = svc.SetDesiredKubeObject(x, comp.GetName()+"-pdb")
-		if err != nil {
-			return runtime.NewFatalResult(fmt.Errorf("could not set desired kube compect: %w", err))
-		}
-
-		return runtime.NewNormalResult("PDB created")
+	err := svc.GetObservedComposite(obj)
+	if err != nil {
+		return runtime.NewFatalResult(fmt.Errorf("can't get composite: %w", err))
 	}
+
+	comp := obj.DeepCopyObject().(Composite)
+
+	log.Info("Checking if PDB is needed", "service", comp.GetName(), "instances", comp.GetInstances())
+
+	if comp.GetInstances() < 2 {
+		return runtime.NewNormalResult("Not HA, no pdb needed")
+	}
+	log.Info("HA detected, adding pdb", "service", comp.GetName())
+
+	min := intstr.IntOrString{StrVal: "50%", Type: intstr.String}
+
+	x := &pdbv1.PodDisruptionBudget{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      comp.GetName() + "-pdb",
+			Namespace: comp.GetInstanceNamespace(),
+		},
+		Spec: pdbv1.PodDisruptionBudgetSpec{
+			MinAvailable: &min,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: comp.GetPDBLabels(),
+			},
+		},
+	}
+
+	err = svc.SetDesiredKubeObject(x, comp.GetName()+"-pdb")
+	if err != nil {
+		return runtime.NewFatalResult(fmt.Errorf("could not set desired kube compect: %w", err))
+	}
+
+	return runtime.NewNormalResult("PDB created")
 }

--- a/pkg/comp-functions/functions/vshnkeycloak/deploy.go
+++ b/pkg/comp-functions/functions/vshnkeycloak/deploy.go
@@ -45,9 +45,8 @@ const (
 )
 
 // DeployKeycloak deploys a keycloak instance via the codecentric Helm Chart.
-func DeployKeycloak(ctx context.Context, svc *runtime.ServiceRuntime) *xfnproto.Result {
+func DeployKeycloak(ctx context.Context, comp *vshnv1.VSHNKeycloak, svc *runtime.ServiceRuntime) *xfnproto.Result {
 
-	comp := &vshnv1.VSHNKeycloak{}
 	err := svc.GetObservedComposite(comp)
 	if err != nil {
 		return runtime.NewFatalResult(fmt.Errorf("cannot get composite: %w", err))

--- a/pkg/comp-functions/functions/vshnkeycloak/ingress.go
+++ b/pkg/comp-functions/functions/vshnkeycloak/ingress.go
@@ -17,9 +17,7 @@ import (
 )
 
 // AddIngress adds an inrgess to the Keycloak instance.
-func AddIngress(_ context.Context, svc *runtime.ServiceRuntime) *xfnproto.Result {
-
-	comp := &vshnv1.VSHNKeycloak{}
+func AddIngress(_ context.Context, comp *vshnv1.VSHNKeycloak, svc *runtime.ServiceRuntime) *xfnproto.Result {
 
 	err := svc.GetObservedComposite(comp)
 	if err != nil {

--- a/pkg/comp-functions/functions/vshnkeycloak/ingress_test.go
+++ b/pkg/comp-functions/functions/vshnkeycloak/ingress_test.go
@@ -115,7 +115,7 @@ func TestAddIngress(t *testing.T) {
 	svc := commontest.LoadRuntimeFromFile(t, "vshnkeycloak/02_withFQDN.yaml")
 
 	// When
-	res := AddIngress(context.TODO(), svc)
+	res := AddIngress(context.TODO(), &vshnv1.VSHNKeycloak{}, svc)
 	assert.Nil(t, res)
 
 	// Then

--- a/pkg/comp-functions/functions/vshnkeycloak/maintenance.go
+++ b/pkg/comp-functions/functions/vshnkeycloak/maintenance.go
@@ -13,9 +13,8 @@ import (
 )
 
 // AddMaintenanceJob will add a job to do the maintenance for the instance
-func AddMaintenanceJob(ctx context.Context, svc *runtime.ServiceRuntime) *xfnproto.Result {
+func AddMaintenanceJob(ctx context.Context, comp *vshnv1.VSHNKeycloak, svc *runtime.ServiceRuntime) *xfnproto.Result {
 
-	comp := &vshnv1.VSHNKeycloak{}
 	err := svc.GetObservedComposite(comp)
 	if err != nil {
 		return runtime.NewFatalResult(fmt.Errorf("can't get composite: %w", err))

--- a/pkg/comp-functions/functions/vshnkeycloak/register.go
+++ b/pkg/comp-functions/functions/vshnkeycloak/register.go
@@ -8,8 +8,8 @@ import (
 )
 
 func init() {
-	runtime.RegisterService("keycloak", runtime.Service{
-		Steps: []runtime.Step{
+	runtime.RegisterService("keycloak", runtime.Service[*vshnv1.VSHNKeycloak]{
+		Steps: []runtime.Step[*vshnv1.VSHNKeycloak]{
 
 			{
 				Name:    "deploy",
@@ -25,19 +25,19 @@ func init() {
 			},
 			{
 				Name:    "mailgun-alerting",
-				Execute: common.MailgunAlerting(&vshnv1.VSHNKeycloak{}),
+				Execute: common.MailgunAlerting[*vshnv1.VSHNKeycloak],
 			},
 			{
 				Name:    "user-alerting",
-				Execute: common.AddUserAlerting(&vshnv1.VSHNKeycloak{}),
+				Execute: common.AddUserAlerting[*vshnv1.VSHNKeycloak],
 			},
 			{
 				Name:    "non-sla-prometheus-rules",
-				Execute: nonsla.GenerateNonSLAPromRules(&vshnv1.VSHNKeycloak{}, nonsla.NewAlertSetBuilder("keycloak", "keycloak").AddMemory().GetAlerts()),
+				Execute: nonsla.GenerateNonSLAPromRules[*vshnv1.VSHNKeycloak](nonsla.NewAlertSetBuilder("keycloak", "keycloak").AddMemory().GetAlerts()),
 			},
 			{
 				Name:    "pdb",
-				Execute: common.AddPDBSettings(&vshnv1.VSHNKeycloak{}),
+				Execute: common.AddPDBSettings[*vshnv1.VSHNKeycloak],
 			},
 		},
 	})

--- a/pkg/comp-functions/functions/vshnmariadb/backup.go
+++ b/pkg/comp-functions/functions/vshnmariadb/backup.go
@@ -19,10 +19,9 @@ import (
 var mariadbBackupScript string
 
 // AddBackupMariadb adds k8up backup to a MariaDB deployment.
-func AddBackupMariadb(ctx context.Context, svc *runtime.ServiceRuntime) *xfnproto.Result {
+func AddBackupMariadb(ctx context.Context, comp *vshnv1.VSHNMariaDB, svc *runtime.ServiceRuntime) *xfnproto.Result {
 	l := controllerruntime.LoggerFrom(ctx)
 
-	comp := &vshnv1.VSHNMariaDB{}
 	err := svc.GetObservedComposite(comp)
 	if err != nil {
 		return runtime.NewFatalResult(fmt.Errorf("failed to parse composite: %w", err))

--- a/pkg/comp-functions/functions/vshnmariadb/backup_test.go
+++ b/pkg/comp-functions/functions/vshnmariadb/backup_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	xhelmv1 "github.com/vshn/appcat/v4/apis/helm/release/v1beta1"
+	vshnv1 "github.com/vshn/appcat/v4/apis/vshn/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
@@ -15,7 +16,7 @@ import (
 func Test_AddBackupMariadb(t *testing.T) {
 	svc, comp := getMariadbComp(t)
 
-	assert.Nil(t, AddBackupMariadb(context.TODO(), svc))
+	assert.Nil(t, AddBackupMariadb(context.TODO(), &vshnv1.VSHNMariaDB{}, svc))
 
 	cm := &corev1.ConfigMap{}
 	assert.NoError(t, svc.GetDesiredKubeObject(cm, comp.GetName()+"-backup-script"))

--- a/pkg/comp-functions/functions/vshnmariadb/maintenance.go
+++ b/pkg/comp-functions/functions/vshnmariadb/maintenance.go
@@ -14,9 +14,8 @@ import (
 var service = "mariadb"
 
 // AddMaintenanceJob will add a job to do the maintenance for the instance
-func AddMaintenanceJob(ctx context.Context, svc *runtime.ServiceRuntime) *xfnproto.Result {
+func AddMaintenanceJob(ctx context.Context, comp *vshnv1.VSHNMariaDB, svc *runtime.ServiceRuntime) *xfnproto.Result {
 
-	comp := &vshnv1.VSHNMariaDB{}
 	err := svc.GetObservedComposite(comp)
 	if err != nil {
 		return runtime.NewFatalResult(fmt.Errorf("can't get composite: %w", err))

--- a/pkg/comp-functions/functions/vshnmariadb/mariadb_deploy.go
+++ b/pkg/comp-functions/functions/vshnmariadb/mariadb_deploy.go
@@ -31,11 +31,10 @@ const (
 )
 
 // DeployMariadb will deploy the objects to provision mariadb instance
-func DeployMariadb(ctx context.Context, svc *runtime.ServiceRuntime) *xfnproto.Result {
+func DeployMariadb(ctx context.Context, comp *vshnv1.VSHNMariaDB, svc *runtime.ServiceRuntime) *xfnproto.Result {
 
 	l := svc.Log
 
-	comp := &vshnv1.VSHNMariaDB{}
 	err := svc.GetObservedComposite(comp)
 	if err != nil {
 		return runtime.NewFatalResult(fmt.Errorf("cannot get observed composite: %w", err))

--- a/pkg/comp-functions/functions/vshnmariadb/mariadb_deploy_test.go
+++ b/pkg/comp-functions/functions/vshnmariadb/mariadb_deploy_test.go
@@ -26,7 +26,7 @@ func TestMariadbDeploy(t *testing.T) {
 	mariadbPort := "3306"
 	mariadbUrl := "mysql://root:mariadb123@mariadb-gc9x4.vshn-mariadb-mariadb-gc9x4.svc.cluster.local:3306"
 
-	assert.Nil(t, DeployMariadb(ctx, svc))
+	assert.Nil(t, DeployMariadb(ctx, &vshnv1.VSHNMariaDB{}, svc))
 
 	ns := &corev1.Namespace{}
 	assert.NoError(t, svc.GetDesiredKubeObject(ns, comp.GetName()+"-instanceNs"))

--- a/pkg/comp-functions/functions/vshnmariadb/register.go
+++ b/pkg/comp-functions/functions/vshnmariadb/register.go
@@ -8,8 +8,8 @@ import (
 )
 
 func init() {
-	runtime.RegisterService("mariadb", runtime.Service{
-		Steps: []runtime.Step{
+	runtime.RegisterService[*vshnv1.VSHNMariaDB]("mariadb", runtime.Service[*vshnv1.VSHNMariaDB]{
+		Steps: []runtime.Step[*vshnv1.VSHNMariaDB]{
 
 			{
 				Name:    "deploy",
@@ -25,15 +25,15 @@ func init() {
 			},
 			{
 				Name:    "mailgun-alerting",
-				Execute: common.MailgunAlerting(&vshnv1.VSHNMariaDB{}),
+				Execute: common.MailgunAlerting[*vshnv1.VSHNMariaDB],
 			},
 			{
 				Name:    "user-alerting",
-				Execute: common.AddUserAlerting(&vshnv1.VSHNMariaDB{}),
+				Execute: common.AddUserAlerting[*vshnv1.VSHNMariaDB],
 			},
 			{
 				Name:    "non-sla-prometheus-rules",
-				Execute: nonsla.GenerateNonSLAPromRules(&vshnv1.VSHNMariaDB{}, nonsla.NewAlertSetBuilder("mariadb", "mariadb").AddAll().GetAlerts()),
+				Execute: nonsla.GenerateNonSLAPromRules[*vshnv1.VSHNMariaDB](nonsla.NewAlertSetBuilder("mariadb", "mariadb").AddAll().GetAlerts()),
 			},
 		},
 	})

--- a/pkg/comp-functions/functions/vshnminio/maintenance.go
+++ b/pkg/comp-functions/functions/vshnminio/maintenance.go
@@ -14,9 +14,8 @@ import (
 var service = "minio"
 
 // AddMaintenanceJob will add a job to do the maintenance for the instance
-func AddMaintenanceJob(ctx context.Context, svc *runtime.ServiceRuntime) *xfnproto.Result {
+func AddMaintenanceJob(ctx context.Context, comp *vshnv1.VSHNMinio, svc *runtime.ServiceRuntime) *xfnproto.Result {
 
-	comp := &vshnv1.VSHNMinio{}
 	err := svc.GetObservedComposite(comp)
 	if err != nil {
 		err = fmt.Errorf("cannot get observed composite: %w", err)

--- a/pkg/comp-functions/functions/vshnminio/minio_deploy.go
+++ b/pkg/comp-functions/functions/vshnminio/minio_deploy.go
@@ -27,9 +27,8 @@ const (
 )
 
 // DeployMinio will add deploy the objects to deploy minio
-func DeployMinio(ctx context.Context, svc *runtime.ServiceRuntime) *xfnproto.Result {
+func DeployMinio(ctx context.Context, comp *vshnv1.VSHNMinio, svc *runtime.ServiceRuntime) *xfnproto.Result {
 
-	comp := &vshnv1.VSHNMinio{}
 	serviceName := comp.GetServiceName()
 	err := svc.GetObservedComposite(comp)
 	if err != nil {

--- a/pkg/comp-functions/functions/vshnminio/minio_deploy_test.go
+++ b/pkg/comp-functions/functions/vshnminio/minio_deploy_test.go
@@ -25,7 +25,7 @@ func TestMinioDeploy(t *testing.T) {
 	rootPassword := "minio123"
 	minioHost := "http://10.0.0.1:9000"
 
-	assert.Nil(t, DeployMinio(ctx, svc))
+	assert.Nil(t, DeployMinio(ctx, &vshnv1.VSHNMinio{}, svc))
 
 	ns := &corev1.Namespace{}
 	assert.NoError(t, svc.GetObservedKubeObject(ns, comp.Name+"-ns"))

--- a/pkg/comp-functions/functions/vshnminio/providerconfig.go
+++ b/pkg/comp-functions/functions/vshnminio/providerconfig.go
@@ -13,13 +13,11 @@ import (
 )
 
 // DeployMinioProviderConfig will deploy a providerconfig with the claim's name
-func DeployMinioProviderConfig(_ context.Context, svc *runtime.ServiceRuntime) *xfnproto.Result {
+func DeployMinioProviderConfig(_ context.Context, comp *vshnv1.VSHNMinio, svc *runtime.ServiceRuntime) *xfnproto.Result {
 
 	if !svc.GetBoolFromCompositionConfig("providerEnabled") {
 		return nil
 	}
-
-	comp := &vshnv1.VSHNMinio{}
 
 	err := svc.GetObservedComposite(comp)
 	if err != nil {

--- a/pkg/comp-functions/functions/vshnminio/providerconfig_test.go
+++ b/pkg/comp-functions/functions/vshnminio/providerconfig_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	vshnv1 "github.com/vshn/appcat/v4/apis/vshn/v1"
 	minioproviderv1 "github.com/vshn/provider-minio/apis/provider/v1"
 )
 
@@ -13,7 +14,7 @@ func TestDeployMinioProviderConfig(t *testing.T) {
 
 	ctx := context.TODO()
 
-	assert.Nil(t, DeployMinioProviderConfig(ctx, svc))
+	assert.Nil(t, DeployMinioProviderConfig(ctx, &vshnv1.VSHNMinio{}, svc))
 
 	config := &minioproviderv1.ProviderConfig{}
 

--- a/pkg/comp-functions/functions/vshnminio/register.go
+++ b/pkg/comp-functions/functions/vshnminio/register.go
@@ -8,8 +8,8 @@ import (
 )
 
 func init() {
-	runtime.RegisterService("minio", runtime.Service{
-		Steps: []runtime.Step{
+	runtime.RegisterService[*vshnv1.VSHNMinio]("minio", runtime.Service[*vshnv1.VSHNMinio]{
+		Steps: []runtime.Step[*vshnv1.VSHNMinio]{
 
 			{
 				Name:    "deploy",
@@ -25,7 +25,7 @@ func init() {
 			},
 			{
 				Name:    "non-sla-prometheus-rules",
-				Execute: nonsla.GenerateNonSLAPromRules(&vshnv1.VSHNMinio{}, nonsla.NewAlertSetBuilder("minio", "minio").AddAll().GetAlerts()),
+				Execute: nonsla.GenerateNonSLAPromRules[*vshnv1.VSHNMinio](nonsla.NewAlertSetBuilder("minio", "minio").AddAll().GetAlerts()),
 			},
 			{
 				Name:    "securitycontext",
@@ -33,15 +33,15 @@ func init() {
 			},
 			{
 				Name:    "mailgun-alerting",
-				Execute: common.MailgunAlerting(&vshnv1.VSHNMinio{}),
+				Execute: common.MailgunAlerting[*vshnv1.VSHNMinio],
 			},
 			{
 				Name:    "user-alerting",
-				Execute: common.AddUserAlerting(&vshnv1.VSHNMinio{}),
+				Execute: common.AddUserAlerting[*vshnv1.VSHNMinio],
 			},
 			{
 				Name:    "pdb",
-				Execute: common.AddPDBSettings(&vshnv1.VSHNMinio{}),
+				Execute: common.AddPDBSettings[*vshnv1.VSHNMinio],
 			},
 		},
 	})

--- a/pkg/comp-functions/functions/vshnminio/securitycontext.go
+++ b/pkg/comp-functions/functions/vshnminio/securitycontext.go
@@ -14,9 +14,8 @@ import (
 
 // SetSecurityContext patches the Minio statefulset to contain the correct securityContext.
 // Unfortunately the helm chart does not expose this value.
-func SetSecurityContext(_ context.Context, svc *runtime.ServiceRuntime) *xfnproto.Result {
+func SetSecurityContext(_ context.Context, comp *vshnv1.VSHNMinio, svc *runtime.ServiceRuntime) *xfnproto.Result {
 
-	comp := &vshnv1.VSHNMinio{}
 	err := svc.GetObservedComposite(comp)
 	if err != nil {
 		err = fmt.Errorf("cannot get observed composite: %w", err)

--- a/pkg/comp-functions/functions/vshnnextcloud/backup.go
+++ b/pkg/comp-functions/functions/vshnnextcloud/backup.go
@@ -18,8 +18,7 @@ import (
 //go:embed files/backup.sh
 var nextcloudBackupScript string
 
-func AddBackup(ctx context.Context, svc *runtime.ServiceRuntime) *xfnproto.Result {
-	comp := &vshnv1.VSHNNextcloud{}
+func AddBackup(ctx context.Context, comp *vshnv1.VSHNNextcloud, svc *runtime.ServiceRuntime) *xfnproto.Result {
 	err := svc.GetDesiredComposite(comp)
 	if err != nil {
 		return runtime.NewFatalResult(fmt.Errorf("can't get composite: %w", err))

--- a/pkg/comp-functions/functions/vshnnextcloud/deploy.go
+++ b/pkg/comp-functions/functions/vshnnextcloud/deploy.go
@@ -52,9 +52,8 @@ var nextcloudPostInstallation string
 var nextcloudPostUpgrade string
 
 // DeployNextcloud deploys a nexctloud instance via the codecentric Helm Chart.
-func DeployNextcloud(ctx context.Context, svc *runtime.ServiceRuntime) *xfnproto.Result {
+func DeployNextcloud(ctx context.Context, comp *vshnv1.VSHNNextcloud, svc *runtime.ServiceRuntime) *xfnproto.Result {
 
-	comp := &vshnv1.VSHNNextcloud{}
 	err := svc.GetObservedComposite(comp)
 	if err != nil {
 		return runtime.NewFatalResult(fmt.Errorf("cannot get composite: %w", err))

--- a/pkg/comp-functions/functions/vshnnextcloud/deploy_test.go
+++ b/pkg/comp-functions/functions/vshnnextcloud/deploy_test.go
@@ -19,7 +19,7 @@ func Test_addNextcloud(t *testing.T) {
 
 	ctx := context.TODO()
 
-	assert.Nil(t, DeployNextcloud(ctx, svc))
+	assert.Nil(t, DeployNextcloud(ctx, &vshnv1.VSHNNextcloud{}, svc))
 
 	pg := &vshnv1.XVSHNPostgreSQL{}
 	assert.NoError(t, svc.GetDesiredComposedResourceByName(pg, comp.GetName()+pgInstanceNameSuffix))
@@ -41,7 +41,7 @@ func Test_addReleaseInternalDB(t *testing.T) {
 
 	ctx := context.TODO()
 
-	assert.Nil(t, DeployNextcloud(ctx, svc))
+	assert.Nil(t, DeployNextcloud(ctx, &vshnv1.VSHNNextcloud{}, svc))
 
 	pg := &vshnv1.XVSHNPostgreSQL{}
 	assert.Error(t, svc.GetDesiredComposedResourceByName(pg, comp.GetName()+pgInstanceNameSuffix))

--- a/pkg/comp-functions/functions/vshnnextcloud/ingress.go
+++ b/pkg/comp-functions/functions/vshnnextcloud/ingress.go
@@ -15,9 +15,7 @@ import (
 )
 
 // AddIngress adds an inrgess to the Nextcloud instance.
-func AddIngress(_ context.Context, svc *runtime.ServiceRuntime) *xfnproto.Result {
-
-	comp := &vshnv1.VSHNNextcloud{}
+func AddIngress(_ context.Context, comp *vshnv1.VSHNNextcloud, svc *runtime.ServiceRuntime) *xfnproto.Result {
 
 	err := svc.GetObservedComposite(comp)
 	if err != nil {

--- a/pkg/comp-functions/functions/vshnnextcloud/maintenance.go
+++ b/pkg/comp-functions/functions/vshnnextcloud/maintenance.go
@@ -12,9 +12,8 @@ import (
 )
 
 // AddMaintenanceJob will add a job to do the maintenance for the instance
-func AddMaintenanceJob(ctx context.Context, svc *runtime.ServiceRuntime) *xfnproto.Result {
+func AddMaintenanceJob(ctx context.Context, comp *vshnv1.VSHNNextcloud, svc *runtime.ServiceRuntime) *xfnproto.Result {
 
-	comp := &vshnv1.VSHNNextcloud{}
 	err := svc.GetObservedComposite(comp)
 	if err != nil {
 		return runtime.NewFatalResult(fmt.Errorf("can't get composite: %w", err))

--- a/pkg/comp-functions/functions/vshnnextcloud/register.go
+++ b/pkg/comp-functions/functions/vshnnextcloud/register.go
@@ -1,12 +1,13 @@
 package vshnnextcloud
 
 import (
+	vshnv1 "github.com/vshn/appcat/v4/apis/vshn/v1"
 	"github.com/vshn/appcat/v4/pkg/comp-functions/runtime"
 )
 
 func init() {
-	runtime.RegisterService("nextcloud", runtime.Service{
-		Steps: []runtime.Step{
+	runtime.RegisterService[*vshnv1.VSHNNextcloud]("nextcloud", runtime.Service[*vshnv1.VSHNNextcloud]{
+		Steps: []runtime.Step[*vshnv1.VSHNNextcloud]{
 
 			{
 				Name:    "deploy",

--- a/pkg/comp-functions/functions/vshnpostgres/connection_details.go
+++ b/pkg/comp-functions/functions/vshnpostgres/connection_details.go
@@ -33,10 +33,9 @@ const (
 )
 
 // AddConnectionDetails changes the desired state of a FunctionIO
-func AddConnectionDetails(ctx context.Context, svc *runtime.ServiceRuntime) *v1beta1.Result {
+func AddConnectionDetails(ctx context.Context, comp *vshnv1.VSHNPostgreSQL, svc *runtime.ServiceRuntime) *v1beta1.Result {
 	log := controllerruntime.LoggerFrom(ctx)
 
-	comp := &vshnv1.VSHNPostgreSQL{}
 	err := svc.GetObservedComposite(comp)
 	if err != nil {
 		return runtime.NewFatalResult(fmt.Errorf("cannot get composite: %w", err))

--- a/pkg/comp-functions/functions/vshnpostgres/connection_details_test.go
+++ b/pkg/comp-functions/functions/vshnpostgres/connection_details_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	vshnv1 "github.com/vshn/appcat/v4/apis/vshn/v1"
 	"github.com/vshn/appcat/v4/pkg/comp-functions/functions/commontest"
 
 	"github.com/vshn/appcat/v4/pkg/comp-functions/runtime"
@@ -22,7 +23,7 @@ func TestTransform_NoInstanceNamespace(t *testing.T) {
 		svc := commontest.LoadRuntimeFromFile(t, "vshn-postgres/secrets/01_input_no-instance-namespace.yaml")
 
 		// When
-		result := AddConnectionDetails(ctx, svc)
+		result := AddConnectionDetails(ctx, &vshnv1.VSHNPostgreSQL{}, svc)
 
 		// Then
 		assert.Equal(t, expectResult, result)
@@ -41,7 +42,7 @@ func TestTransform(t *testing.T) {
 		svc := commontest.LoadRuntimeFromFile(t, "vshn-postgres/secrets/02_input_function-io.yaml")
 
 		// When
-		result := AddConnectionDetails(ctx, svc)
+		result := AddConnectionDetails(ctx, &vshnv1.VSHNPostgreSQL{}, svc)
 
 		// Then
 		assert.Nil(t, result)

--- a/pkg/comp-functions/functions/vshnpostgres/delay_cluster.go
+++ b/pkg/comp-functions/functions/vshnpostgres/delay_cluster.go
@@ -15,9 +15,8 @@ import (
 
 // DelayClusterDeployment adds the dependencies on the sgcluster object, so that the provider-kubernetes doesn't loop anymore.
 // The actual cluster object will only be deployed once the dependencies are deployed, synced and ready.
-func DelayClusterDeployment(_ context.Context, svc *runtime.ServiceRuntime) *xfnproto.Result {
+func DelayClusterDeployment(_ context.Context, comp *vshnv1.VSHNPostgreSQL, svc *runtime.ServiceRuntime) *xfnproto.Result {
 
-	comp := &vshnv1.VSHNPostgreSQL{}
 	err := svc.GetObservedComposite(comp)
 
 	if err != nil {

--- a/pkg/comp-functions/functions/vshnpostgres/delay_cluster_test.go
+++ b/pkg/comp-functions/functions/vshnpostgres/delay_cluster_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	stackgresv1 "github.com/vshn/appcat/v4/apis/stackgres/v1"
+	vshnv1 "github.com/vshn/appcat/v4/apis/vshn/v1"
 	"github.com/vshn/appcat/v4/pkg/comp-functions/functions/commontest"
 	"github.com/vshn/appcat/v4/pkg/comp-functions/runtime"
 )
@@ -13,7 +14,7 @@ import (
 func TestDelayClusterDeployment(t *testing.T) {
 	svc := commontest.LoadRuntimeFromFile(t, "vshn-postgres/delay_cluster/01_GivenNoDependency.yaml")
 
-	res := DelayClusterDeployment(context.TODO(), svc)
+	res := DelayClusterDeployment(context.TODO(), &vshnv1.VSHNPostgreSQL{}, svc)
 	assert.Equal(t, runtime.NewWarningResult("sgProfile is not yet ready, skipping creation of cluster"), res)
 
 	cluster := &stackgresv1.SGCluster{}
@@ -22,7 +23,7 @@ func TestDelayClusterDeployment(t *testing.T) {
 
 	svc = commontest.LoadRuntimeFromFile(t, "vshn-postgres/delay_cluster/01_GivenAllDependencies.yaml")
 
-	res = DelayClusterDeployment(context.TODO(), svc)
+	res = DelayClusterDeployment(context.TODO(), &vshnv1.VSHNPostgreSQL{}, svc)
 	assert.Nil(t, res)
 
 	err = svc.GetDesiredKubeObject(cluster, "cluster")

--- a/pkg/comp-functions/functions/vshnpostgres/encrypted_pvc.go
+++ b/pkg/comp-functions/functions/vshnpostgres/encrypted_pvc.go
@@ -19,11 +19,10 @@ import (
 )
 
 // AddPvcSecret adds a secret for the encrypted PVC for the  PostgreSQL instance.
-func AddPvcSecret(ctx context.Context, svc *runtime.ServiceRuntime) *xfnproto.Result {
+func AddPvcSecret(ctx context.Context, comp *vshnv1.VSHNPostgreSQL, svc *runtime.ServiceRuntime) *xfnproto.Result {
 
 	log := controllerruntime.LoggerFrom(ctx)
 
-	comp := &vshnv1.VSHNPostgreSQL{}
 	err := svc.GetObservedComposite(comp)
 
 	if err != nil {

--- a/pkg/comp-functions/functions/vshnpostgres/encrypted_pvc_test.go
+++ b/pkg/comp-functions/functions/vshnpostgres/encrypted_pvc_test.go
@@ -52,7 +52,7 @@ func TestNoEncryptedPVC(t *testing.T) {
 			svc := commontest.LoadRuntimeFromFile(t, tt.args.inputFuncIO)
 			expSvc := commontest.LoadRuntimeFromFile(t, tt.args.expectedFuncIO)
 
-			r := AddPvcSecret(ctx, svc)
+			r := AddPvcSecret(ctx, &vshnv1.VSHNPostgreSQL{}, svc)
 
 			assert.Equal(t, tt.expResult, r)
 			assert.Equal(t, expSvc, svc)
@@ -68,7 +68,7 @@ func TestGivenEncrypedPvcThenExpectOutput(t *testing.T) {
 
 		svc := commontest.LoadRuntimeFromFile(t, "vshn-postgres/enc_pvc/03-GivenEncryptionParams.yaml")
 
-		r := AddPvcSecret(ctx, svc)
+		r := AddPvcSecret(ctx, &vshnv1.VSHNPostgreSQL{}, svc)
 
 		assert.Nil(t, r)
 
@@ -93,7 +93,7 @@ func TestGivenEncrypedPvcThenExpectOutput(t *testing.T) {
 
 		iof := commontest.LoadRuntimeFromFile(t, "vshn-postgres/enc_pvc/03-GivenEncryptionParamsExistingSecret.yaml")
 
-		r := AddPvcSecret(ctx, iof)
+		r := AddPvcSecret(ctx, &vshnv1.VSHNPostgreSQL{}, iof)
 
 		assert.Nil(t, r)
 

--- a/pkg/comp-functions/functions/vshnpostgres/extensions.go
+++ b/pkg/comp-functions/functions/vshnpostgres/extensions.go
@@ -21,12 +21,11 @@ const (
 )
 
 // AddExtensions adds the user specified extensions to the SGCluster.
-func AddExtensions(ctx context.Context, svc *runtime.ServiceRuntime) *xfnproto.Result {
+func AddExtensions(ctx context.Context, comp *vshnv1.VSHNPostgreSQL, svc *runtime.ServiceRuntime) *xfnproto.Result {
 
 	log := controllerruntime.LoggerFrom(ctx)
 	log.Info("Starting extensions function")
 
-	comp := &vshnv1.VSHNPostgreSQL{}
 	err := svc.GetObservedComposite(comp)
 	if err != nil {
 		return runtime.NewFatalResult(fmt.Errorf("Cannot get composite from function io: %w", err))

--- a/pkg/comp-functions/functions/vshnpostgres/extensions_test.go
+++ b/pkg/comp-functions/functions/vshnpostgres/extensions_test.go
@@ -7,6 +7,7 @@ import (
 	xfnproto "github.com/crossplane/function-sdk-go/proto/v1beta1"
 	"github.com/stretchr/testify/assert"
 	stackgresv1 "github.com/vshn/appcat/v4/apis/stackgres/v1"
+	vshnv1 "github.com/vshn/appcat/v4/apis/vshn/v1"
 	"github.com/vshn/appcat/v4/pkg/comp-functions/functions/commontest"
 	"k8s.io/utils/ptr"
 )
@@ -124,7 +125,7 @@ func TestAddExtensions(t *testing.T) {
 		iof := commontest.LoadRuntimeFromFile(t, tt.iofFile)
 
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, AddExtensions(ctx, iof))
+			assert.Equal(t, tt.want, AddExtensions(ctx, &vshnv1.VSHNPostgreSQL{}, iof))
 
 			cluster := &stackgresv1.SGCluster{}
 

--- a/pkg/comp-functions/functions/vshnpostgres/loadBalancer.go
+++ b/pkg/comp-functions/functions/vshnpostgres/loadBalancer.go
@@ -17,7 +17,7 @@ import (
 
 var serviceName = "primary-service"
 
-func AddPrimaryService(ctx context.Context, svc *runtime.ServiceRuntime) *xfnproto.Result {
+func AddPrimaryService(ctx context.Context, comp *vshnv1.VSHNPostgreSQL, svc *runtime.ServiceRuntime) *xfnproto.Result {
 
 	comp, err := getVSHNPostgreSQL(ctx, svc)
 

--- a/pkg/comp-functions/functions/vshnpostgres/loadBalancer_test.go
+++ b/pkg/comp-functions/functions/vshnpostgres/loadBalancer_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	vshnv1 "github.com/vshn/appcat/v4/apis/vshn/v1"
 	"github.com/vshn/appcat/v4/pkg/comp-functions/functions/commontest"
 )
 
@@ -18,7 +19,7 @@ func TestNothingToDo(t *testing.T) {
 		svc.Config.Data["externalDatabaseConnectionsEnabled"] = "true"
 
 		// When
-		result := AddPrimaryService(ctx, svc)
+		result := AddPrimaryService(ctx, &vshnv1.VSHNPostgreSQL{}, svc)
 
 		desired := svc.GetAllDesired()
 
@@ -40,7 +41,7 @@ func TestLoadBalancerParameterSet(t *testing.T) {
 		svc.Config.Data["externalDatabaseConnectionsEnabled"] = "true"
 
 		// When
-		result := AddPrimaryService(ctx, svc)
+		result := AddPrimaryService(ctx, &vshnv1.VSHNPostgreSQL{}, svc)
 
 		// Then
 		assert.NotNil(t, result)
@@ -57,7 +58,7 @@ func TestLoadBalancerServiceObserverCreated(t *testing.T) {
 		svc.Config.Data["externalDatabaseConnectionsEnabled"] = "true"
 
 		// When
-		result := AddPrimaryService(ctx, svc)
+		result := AddPrimaryService(ctx, &vshnv1.VSHNPostgreSQL{}, svc)
 
 		// Then
 		assert.Nil(t, result)
@@ -76,7 +77,7 @@ func TestLoadBalancerNotEnabled(t *testing.T) {
 		svc.Config.Data["externalDatabaseConnectionsEnabled"] = "false"
 
 		// When
-		result := AddPrimaryService(ctx, svc)
+		result := AddPrimaryService(ctx, &vshnv1.VSHNPostgreSQL{}, svc)
 
 		// Then
 		assert.Nil(t, result)

--- a/pkg/comp-functions/functions/vshnpostgres/maintenance.go
+++ b/pkg/comp-functions/functions/vshnpostgres/maintenance.go
@@ -102,8 +102,7 @@ var (
 )
 
 // addSchedules will add a job to do the maintenance in for the instance
-func addSchedules(ctx context.Context, svc *runtime.ServiceRuntime) *xfnproto.Result {
-	comp := &vshnv1.VSHNPostgreSQL{}
+func addSchedules(ctx context.Context, comp *vshnv1.VSHNPostgreSQL, svc *runtime.ServiceRuntime) *xfnproto.Result {
 	err := svc.GetObservedComposite(comp)
 	if err != nil {
 		return runtime.NewFatalResult(fmt.Errorf("can't get composite: %w", err))

--- a/pkg/comp-functions/functions/vshnpostgres/objectbucket.go
+++ b/pkg/comp-functions/functions/vshnpostgres/objectbucket.go
@@ -12,9 +12,8 @@ import (
 
 // EnsureObjectBucketLabels just gets the bucket present from the PnT part and adds it again to the
 // desired state. This ensures that the correct labels are injected.
-func EnsureObjectBucketLabels(ctx context.Context, svc *runtime.ServiceRuntime) *xfnproto.Result {
+func EnsureObjectBucketLabels(ctx context.Context, comp *vshnv1.VSHNPostgreSQL, svc *runtime.ServiceRuntime) *xfnproto.Result {
 
-	comp := &vshnv1.VSHNPostgreSQL{}
 	err := svc.GetObservedComposite(comp)
 	if err != nil {
 		return runtime.NewFatalResult(fmt.Errorf("Cannot get composite from function io: %w", err))

--- a/pkg/comp-functions/functions/vshnpostgres/pg_bouncer_settings.go
+++ b/pkg/comp-functions/functions/vshnpostgres/pg_bouncer_settings.go
@@ -6,6 +6,7 @@ import (
 
 	xfnproto "github.com/crossplane/function-sdk-go/proto/v1beta1"
 	sgv1 "github.com/vshn/appcat/v4/apis/stackgres/v1"
+	vshnv1 "github.com/vshn/appcat/v4/apis/vshn/v1"
 	"github.com/vshn/appcat/v4/pkg/comp-functions/runtime"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
@@ -13,7 +14,7 @@ import (
 
 const pgBouncerSettingName = "pgbouncer-settings"
 
-func addPGBouncerSettings(ctx context.Context, svc *runtime.ServiceRuntime) *xfnproto.Result {
+func addPGBouncerSettings(ctx context.Context, comp *vshnv1.VSHNPostgreSQL, svc *runtime.ServiceRuntime) *xfnproto.Result {
 	comp, err := getVSHNPostgreSQL(ctx, svc)
 	if err != nil {
 		return runtime.NewFatalResult(fmt.Errorf("Cannot get composite from function io: %w", err))

--- a/pkg/comp-functions/functions/vshnpostgres/pgqexporter_config.go
+++ b/pkg/comp-functions/functions/vshnpostgres/pgqexporter_config.go
@@ -21,9 +21,8 @@ import (
 //go:embed files/queries.yml
 var queries string
 
-func PgExporterConfig(ctx context.Context, svc *runtime.ServiceRuntime) *v1beta1.Result {
+func PgExporterConfig(ctx context.Context, comp *vshnv1.VSHNPostgreSQL, svc *runtime.ServiceRuntime) *v1beta1.Result {
 
-	comp := &vshnv1.VSHNPostgreSQL{}
 	err := svc.GetObservedComposite(comp)
 	if err != nil {
 		return runtime.NewFatalResult(fmt.Errorf("cannot get composite: %w", err))

--- a/pkg/comp-functions/functions/vshnpostgres/postgresql_deploy.go
+++ b/pkg/comp-functions/functions/vshnpostgres/postgresql_deploy.go
@@ -37,10 +37,9 @@ const (
 //go:embed scripts/copy-pg-backup.sh
 var postgresqlCopyJobScript string
 
-func DeployPostgreSQL(ctx context.Context, svc *runtime.ServiceRuntime) *xfnproto.Result {
+func DeployPostgreSQL(ctx context.Context, comp *vshnv1.VSHNPostgreSQL, svc *runtime.ServiceRuntime) *xfnproto.Result {
 	l := svc.Log
 
-	comp := &vshnv1.VSHNPostgreSQL{}
 	err := svc.GetObservedComposite(comp)
 	if err != nil {
 		return runtime.NewFatalResult(fmt.Errorf("cannot get observed composite: %w", err))

--- a/pkg/comp-functions/functions/vshnpostgres/postgresql_deploy_test.go
+++ b/pkg/comp-functions/functions/vshnpostgres/postgresql_deploy_test.go
@@ -25,8 +25,8 @@ func TestPostgreSqlDeploy(t *testing.T) {
 
 	ctx := context.TODO()
 
-	assert.Nil(t, DeployPostgreSQL(ctx, svc))
-	assert.Nil(t, addSchedules(ctx, svc))
+	assert.Nil(t, DeployPostgreSQL(ctx, &vshnv1.VSHNPostgreSQL{}, svc))
+	assert.Nil(t, addSchedules(ctx, &vshnv1.VSHNPostgreSQL{}, svc))
 
 	ns := &corev1.Namespace{}
 	assert.NoError(t, svc.GetDesiredKubeObject(ns, "namespace-conditions"))
@@ -102,7 +102,7 @@ func TestPostgreSqlDeployWithPgConfig(t *testing.T) {
 
 	ctx := context.TODO()
 
-	assert.Nil(t, DeployPostgreSQL(ctx, svc))
+	assert.Nil(t, DeployPostgreSQL(ctx, &vshnv1.VSHNPostgreSQL{}, svc))
 
 	ns := &corev1.Namespace{}
 	assert.NoError(t, svc.GetDesiredKubeObject(ns, "namespace-conditions"))
@@ -126,7 +126,7 @@ func TestPostgreSqlDeployWithRestore(t *testing.T) {
 
 	ctx := context.TODO()
 
-	assert.Nil(t, DeployPostgreSQL(ctx, svc))
+	assert.Nil(t, DeployPostgreSQL(ctx, &vshnv1.VSHNPostgreSQL{}, svc))
 
 	ns := &corev1.Namespace{}
 	assert.NoError(t, svc.GetDesiredKubeObject(ns, "namespace-conditions"))

--- a/pkg/comp-functions/functions/vshnpostgres/register.go
+++ b/pkg/comp-functions/functions/vshnpostgres/register.go
@@ -11,8 +11,8 @@ import (
 var pgAlerts = nonsla.NewAlertSetBuilder("patroni", "postgresql").AddAll().AddCustom([]promv1.Rule{maxConnectionsAlert}).GetAlerts()
 
 func init() {
-	runtime.RegisterService("postgresql", runtime.Service{
-		Steps: []runtime.Step{
+	runtime.RegisterService[*vshnv1.VSHNPostgreSQL]("postgresql", runtime.Service[*vshnv1.VSHNPostgreSQL]{
+		Steps: []runtime.Step[*vshnv1.VSHNPostgreSQL]{
 			{
 				Name:    "deploy",
 				Execute: DeployPostgreSQL,
@@ -23,7 +23,7 @@ func init() {
 			},
 			{
 				Name:    "user-alerting",
-				Execute: common.AddUserAlerting(&vshnv1.VSHNPostgreSQL{}),
+				Execute: common.AddUserAlerting[*vshnv1.VSHNPostgreSQL],
 			},
 			{
 				Name:    "restart",
@@ -43,7 +43,7 @@ func init() {
 			},
 			{
 				Name:    "mailgun-alerting",
-				Execute: common.MailgunAlerting(&vshnv1.VSHNPostgreSQL{}),
+				Execute: common.MailgunAlerting[*vshnv1.VSHNPostgreSQL],
 			},
 			{
 				Name:    "extensions",
@@ -59,7 +59,7 @@ func init() {
 			},
 			{
 				Name:    "non-sla-prometheus-rules",
-				Execute: nonsla.GenerateNonSLAPromRules(&vshnv1.VSHNPostgreSQL{}, pgAlerts),
+				Execute: nonsla.GenerateNonSLAPromRules[*vshnv1.VSHNPostgreSQL](pgAlerts),
 			},
 			{
 				Name:    "pgbouncer-settings",
@@ -79,7 +79,7 @@ func init() {
 			},
 			{
 				Name:    "pdb",
-				Execute: common.AddPDBSettings(&vshnv1.VSHNPostgreSQL{}),
+				Execute: common.AddPDBSettings[*vshnv1.VSHNPostgreSQL],
 			},
 		},
 	})

--- a/pkg/comp-functions/functions/vshnpostgres/restart.go
+++ b/pkg/comp-functions/functions/vshnpostgres/restart.go
@@ -19,7 +19,7 @@ import (
 var sgDbOpsRestartRetention time.Duration = 30 * 24 * time.Hour
 
 // TransformRestart triggers a restart of the postgreqsql instance if there is a pending restart and the composite is configured to restart on update.
-func TransformRestart(ctx context.Context, svc *runtime.ServiceRuntime) *xfnproto.Result {
+func TransformRestart(ctx context.Context, comp *vshnv1.VSHNPostgreSQL, svc *runtime.ServiceRuntime) *xfnproto.Result {
 	return transformRestart(ctx, svc, time.Now)
 }
 

--- a/pkg/comp-functions/functions/vshnpostgres/restart_test.go
+++ b/pkg/comp-functions/functions/vshnpostgres/restart_test.go
@@ -16,7 +16,7 @@ import (
 func TestTransformRestart_NoopNoPending(t *testing.T) {
 	svc := commontest.LoadRuntimeFromFile(t, "vshn-postgres/restart/01-NoPendingReboot.yaml")
 
-	res := TransformRestart(context.TODO(), svc)
+	res := TransformRestart(context.TODO(), &vshnv1.VSHNPostgreSQL{}, svc)
 	assert.Nil(t, res)
 
 	comp := &vshnv1.XVSHNPostgreSQL{}
@@ -29,7 +29,7 @@ func TestTransformRestart_NoopNoPending(t *testing.T) {
 func TestTransformRestart_NoopPendingOnRestart(t *testing.T) {
 	svc := commontest.LoadRuntimeFromFile(t, "vshn-postgres/restart/02-PendingRebootNoRestart.yaml")
 
-	res := TransformRestart(context.TODO(), svc)
+	res := TransformRestart(context.TODO(), &vshnv1.VSHNPostgreSQL{}, svc)
 	assert.Nil(t, res)
 
 	comp := &vshnv1.XVSHNPostgreSQL{}
@@ -43,7 +43,7 @@ func TestTransformRestart_NoopPendingOnRestart(t *testing.T) {
 func TestTransformRestart_RestartPending(t *testing.T) {
 	svc := commontest.LoadRuntimeFromFile(t, "vshn-postgres/restart/02-PendingReboot.yaml")
 
-	res := TransformRestart(context.TODO(), svc)
+	res := TransformRestart(context.TODO(), &vshnv1.VSHNPostgreSQL{}, svc)
 	assert.Nil(t, res)
 
 	comp := &vshnv1.XVSHNPostgreSQL{}

--- a/pkg/comp-functions/functions/vshnpostgres/schedule.go
+++ b/pkg/comp-functions/functions/vshnpostgres/schedule.go
@@ -11,17 +11,16 @@ import (
 )
 
 // TransformSchedule initializes the backup and maintenance schedules  if the user did not explicitly provide a schedule.
-func TransformSchedule(ctx context.Context, svc *runtime.ServiceRuntime) *xfnproto.Result {
+func TransformSchedule(ctx context.Context, comp *vshnv1.VSHNPostgreSQL, svc *runtime.ServiceRuntime) *xfnproto.Result {
 
-	comp := vshnv1.VSHNPostgreSQL{}
-	err := svc.GetObservedComposite(&comp)
+	err := svc.GetObservedComposite(comp)
 	if err != nil {
 		return runtime.NewFatalResult(fmt.Errorf("failed to parse composite: %w", err))
 	}
 
-	common.SetRandomSchedules(&comp, &comp)
+	common.SetRandomSchedules(comp, comp)
 
-	err = svc.SetDesiredCompositeStatus(&comp)
+	err = svc.SetDesiredCompositeStatus(comp)
 	if err != nil {
 		return runtime.NewFatalResult(fmt.Errorf("failed to set composite: %w", err))
 	}

--- a/pkg/comp-functions/functions/vshnpostgres/schedule_test.go
+++ b/pkg/comp-functions/functions/vshnpostgres/schedule_test.go
@@ -21,7 +21,7 @@ func TestTransformSchedule_SetRandomSchedule(t *testing.T) {
 		t.Run(fmt.Sprintf("Round %d", i), func(t *testing.T) {
 			svc := commontest.LoadRuntimeFromFile(t, "vshn-postgres/base.yaml")
 
-			res := TransformSchedule(context.TODO(), svc)
+			res := TransformSchedule(context.TODO(), &vshnv1.VSHNPostgreSQL{}, svc)
 			assert.Nil(t, res)
 
 			out := &vshnv1.VSHNPostgreSQL{}
@@ -51,7 +51,7 @@ func TestTransformSchedule_DontOverwriteBackup(t *testing.T) {
 	err = svc.GetDesiredComposite(comp)
 	assert.NoError(t, err)
 
-	res := TransformSchedule(context.TODO(), svc)
+	res := TransformSchedule(context.TODO(), &vshnv1.VSHNPostgreSQL{}, svc)
 	assert.Nil(t, res)
 
 	err = svc.GetDesiredComposite(comp)
@@ -72,7 +72,7 @@ func TestTransformSchedule_DontOverwriteMaintenance(t *testing.T) {
 	err = svc.SetDesiredCompositeStatus(comp)
 	assert.NoError(t, err)
 
-	res := TransformSchedule(context.TODO(), svc)
+	res := TransformSchedule(context.TODO(), &vshnv1.VSHNPostgreSQL{}, svc)
 	assert.Nil(t, res)
 
 	err = svc.GetDesiredComposite(comp)
@@ -95,7 +95,7 @@ func TestTransformSchedule_DontOverwriteBackupOrMaintenance(t *testing.T) {
 	err = iof.SetDesiredCompositeStatus(comp)
 	assert.NoError(t, err)
 
-	res := TransformSchedule(context.TODO(), iof)
+	res := TransformSchedule(context.TODO(), &vshnv1.VSHNPostgreSQL{}, iof)
 	assert.Nil(t, res)
 
 	err = iof.GetDesiredComposite(comp)

--- a/pkg/comp-functions/functions/vshnpostgres/user_management.go
+++ b/pkg/comp-functions/functions/vshnpostgres/user_management.go
@@ -15,8 +15,7 @@ import (
 	"k8s.io/utils/ptr"
 )
 
-func UserManagement(ctx context.Context, svc *runtime.ServiceRuntime) *xfnproto.Result {
-	comp := &vshnv1.VSHNPostgreSQL{}
+func UserManagement(ctx context.Context, comp *vshnv1.VSHNPostgreSQL, svc *runtime.ServiceRuntime) *xfnproto.Result {
 	err := svc.GetDesiredComposite(comp)
 	if err != nil {
 		return runtime.NewFatalResult(fmt.Errorf("Cannot get composite from function io: %w", err))

--- a/pkg/comp-functions/functions/vshnpostgres/user_management_test.go
+++ b/pkg/comp-functions/functions/vshnpostgres/user_management_test.go
@@ -85,7 +85,7 @@ func TestUserManagement(t *testing.T) {
 	svc := commontest.LoadRuntimeFromFile(t, "vshn-postgres/usermanagement/01-emptyaccess.yaml")
 
 	// when applied
-	assert.Nil(t, UserManagement(context.TODO(), svc))
+	assert.Nil(t, UserManagement(context.TODO(), &vshnv1.VSHNPostgreSQL{}, svc))
 
 	// then expect no database
 	comp := &vshnv1.VSHNPostgreSQL{}
@@ -102,7 +102,7 @@ func TestUserManagement(t *testing.T) {
 	}
 
 	assert.NoError(t, svc.SetDesiredCompositeStatus(comp))
-	assert.Nil(t, UserManagement(context.TODO(), svc))
+	assert.Nil(t, UserManagement(context.TODO(), &vshnv1.VSHNPostgreSQL{}, svc))
 
 	// then expect database
 	db = &pgv1alpha1.Database{}
@@ -115,7 +115,7 @@ func TestUserManagement(t *testing.T) {
 	})
 
 	assert.NoError(t, svc.SetDesiredCompositeStatus(comp))
-	assert.Nil(t, UserManagement(context.TODO(), svc))
+	assert.Nil(t, UserManagement(context.TODO(), &vshnv1.VSHNPostgreSQL{}, svc))
 
 	// then expect database
 	db = &pgv1alpha1.Database{}

--- a/pkg/comp-functions/functions/vshnredis/backup.go
+++ b/pkg/comp-functions/functions/vshnredis/backup.go
@@ -23,11 +23,10 @@ const (
 var redisBackupScript string
 
 // AddBackup creates an object bucket and a K8up schedule to do the actual backup.
-func AddBackup(ctx context.Context, svc *runtime.ServiceRuntime) *xfnproto.Result {
+func AddBackup(ctx context.Context, comp *vshnv1.VSHNRedis, svc *runtime.ServiceRuntime) *xfnproto.Result {
 
 	l := controllerruntime.LoggerFrom(ctx)
 
-	comp := &vshnv1.VSHNRedis{}
 	err := svc.GetObservedComposite(comp)
 	if err != nil {
 		return runtime.NewFatalResult(fmt.Errorf("failed to parse composite: %w", err))

--- a/pkg/comp-functions/functions/vshnredis/backup_test.go
+++ b/pkg/comp-functions/functions/vshnredis/backup_test.go
@@ -18,7 +18,7 @@ func TestAddBackupObjectCreation(t *testing.T) {
 
 	ctx := context.TODO()
 
-	assert.Nil(t, AddBackup(ctx, svc))
+	assert.Nil(t, AddBackup(ctx, &vshnv1.VSHNRedis{}, svc))
 
 	bucket := &appcatv1.XObjectBucket{}
 	assert.NoError(t, svc.GetDesiredComposedResourceByName(bucket, comp.Name+"-backup"))

--- a/pkg/comp-functions/functions/vshnredis/maintenance.go
+++ b/pkg/comp-functions/functions/vshnredis/maintenance.go
@@ -14,9 +14,8 @@ import (
 var service = "redis"
 
 // AddMaintenanceJob will add a job to do the maintenance for the instance
-func AddMaintenanceJob(ctx context.Context, svc *runtime.ServiceRuntime) *xfnproto.Result {
+func AddMaintenanceJob(ctx context.Context, comp *vshnv1.VSHNRedis, svc *runtime.ServiceRuntime) *xfnproto.Result {
 
-	comp := &vshnv1.VSHNRedis{}
 	err := svc.GetObservedComposite(comp)
 	if err != nil {
 		return runtime.NewFatalResult(fmt.Errorf("can't get composite: %w", err))

--- a/pkg/comp-functions/functions/vshnredis/pvcresize.go
+++ b/pkg/comp-functions/functions/vshnredis/pvcresize.go
@@ -24,9 +24,8 @@ import (
 var stsRecreateScript string
 
 // ResizePVCs will add a job to do the pvc resize for the instance
-func ResizePVCs(ctx context.Context, svc *runtime.ServiceRuntime) *xfnproto.Result {
+func ResizePVCs(ctx context.Context, comp *vshnv1.VSHNRedis, svc *runtime.ServiceRuntime) *xfnproto.Result {
 
-	comp := &vshnv1.VSHNRedis{}
 	err := svc.GetObservedComposite(comp)
 	if err != nil {
 		return runtime.NewFatalResult(fmt.Errorf("failed to parse composite: %w", err))

--- a/pkg/comp-functions/functions/vshnredis/pvcresize_test.go
+++ b/pkg/comp-functions/functions/vshnredis/pvcresize_test.go
@@ -23,7 +23,7 @@ func TestPVCResize(t *testing.T) {
 
 	ctx := context.TODO()
 
-	assert.Nil(t, ResizePVCs(ctx, svc))
+	assert.Nil(t, ResizePVCs(ctx, &vshnv1.VSHNRedis{}, svc))
 
 	job := &batchv1.Job{}
 	assert.NoError(t, svc.GetDesiredKubeObject(job, "redis-gc9x4-sts-deleter"))
@@ -33,7 +33,7 @@ func TestPVCResize(t *testing.T) {
 
 	// Second reconcile, check for removed job
 	svc = commontest.LoadRuntimeFromFile(t, "vshnredis/pvcresize/01_job.yaml")
-	assert.Nil(t, ResizePVCs(ctx, svc))
+	assert.Nil(t, ResizePVCs(ctx, &vshnv1.VSHNRedis{}, svc))
 	assert.Error(t, svc.GetDesiredKubeObject(job, "redis-gc9x4-sts-deleter"))
 
 }

--- a/pkg/comp-functions/functions/vshnredis/redis_deploy.go
+++ b/pkg/comp-functions/functions/vshnredis/redis_deploy.go
@@ -10,10 +10,9 @@ import (
 	"github.com/vshn/appcat/v4/pkg/comp-functions/runtime"
 )
 
-func DeployRedis(ctx context.Context, svc *runtime.ServiceRuntime) *xfnproto.Result {
+func DeployRedis(ctx context.Context, comp *vshnv1.VSHNRedis, svc *runtime.ServiceRuntime) *xfnproto.Result {
 	l := svc.Log
 
-	comp := &vshnv1.VSHNRedis{}
 	err := svc.GetObservedComposite(comp)
 	if err != nil {
 		err = fmt.Errorf("cannot get observed composite: %w", err)

--- a/pkg/comp-functions/functions/vshnredis/redis_url.go
+++ b/pkg/comp-functions/functions/vshnredis/redis_url.go
@@ -24,10 +24,9 @@ const (
 )
 
 // AddUrlToConnectionDetails changes the desired state of a FunctionIO
-func AddUrlToConnectionDetails(ctx context.Context, svc *runtime.ServiceRuntime) *xfnproto.Result {
+func AddUrlToConnectionDetails(ctx context.Context, comp *vshnv1.VSHNRedis, svc *runtime.ServiceRuntime) *xfnproto.Result {
 	log := controllerruntime.LoggerFrom(ctx)
 
-	comp := &vshnv1.VSHNRedis{}
 	err := svc.GetObservedComposite(comp)
 	if err != nil {
 		return runtime.NewFatalResult(fmt.Errorf("Cannot get composite from function io: %w", err))

--- a/pkg/comp-functions/functions/vshnredis/register.go
+++ b/pkg/comp-functions/functions/vshnredis/register.go
@@ -8,8 +8,8 @@ import (
 )
 
 func init() {
-	runtime.RegisterService("redis", runtime.Service{
-		Steps: []runtime.Step{
+	runtime.RegisterService[*vshnv1.VSHNRedis]("redis", runtime.Service[*vshnv1.VSHNRedis]{
+		Steps: []runtime.Step[*vshnv1.VSHNRedis]{
 			{
 				Name:    "deploy",
 				Execute: DeployRedis,
@@ -40,15 +40,15 @@ func init() {
 			},
 			{
 				Name:    "mailgun-alerting",
-				Execute: common.MailgunAlerting(&vshnv1.VSHNRedis{}),
+				Execute: common.MailgunAlerting[*vshnv1.VSHNRedis],
 			},
 			{
 				Name:    "user-alerting",
-				Execute: common.AddUserAlerting(&vshnv1.VSHNRedis{}),
+				Execute: common.AddUserAlerting[*vshnv1.VSHNRedis],
 			},
 			{
 				Name:    "non-sla-prometheus-rules",
-				Execute: nonsla.GenerateNonSLAPromRules(&vshnv1.VSHNRedis{}, nonsla.NewAlertSetBuilder("redis", "redis").AddAll().GetAlerts()),
+				Execute: nonsla.GenerateNonSLAPromRules[*vshnv1.VSHNRedis](nonsla.NewAlertSetBuilder("redis", "redis").AddAll().GetAlerts()),
 			},
 		},
 	})

--- a/pkg/comp-functions/functions/vshnredis/release.go
+++ b/pkg/comp-functions/functions/vshnredis/release.go
@@ -22,11 +22,10 @@ import (
 var redisRelease = "release"
 
 // ManageRelease will update the release in line with other composition functions
-func ManageRelease(ctx context.Context, svc *runtime.ServiceRuntime) *xfnproto.Result {
+func ManageRelease(ctx context.Context, comp *vshnv1.VSHNRedis, svc *runtime.ServiceRuntime) *xfnproto.Result {
 
 	l := controllerruntime.LoggerFrom(ctx)
 
-	comp := &vshnv1.VSHNRedis{}
 	err := svc.GetObservedComposite(comp)
 	if err != nil {
 		return runtime.NewFatalResult(fmt.Errorf("can't get composite: %w", err))

--- a/pkg/comp-functions/functions/vshnredis/release_test.go
+++ b/pkg/comp-functions/functions/vshnredis/release_test.go
@@ -28,7 +28,7 @@ func TestHelmValueUpdate(t *testing.T) {
 	svc, _ := getRedisReleaseComp(t, "01_default")
 	ctx := context.TODO()
 
-	assert.Nil(t, ManageRelease(ctx, svc))
+	assert.Nil(t, ManageRelease(ctx, &vshnv1.VSHNRedis{}, svc))
 
 	release := &xhelm.Release{}
 	// IMPORTANT: this resource name must not change! Or crossplane will delete the release.
@@ -62,7 +62,7 @@ func TestHelmValueUpdate_noObservered(t *testing.T) {
 	iof, _ := getRedisReleaseComp(t, "02_no_observed")
 	ctx := context.TODO()
 
-	assert.Nil(t, ManageRelease(ctx, iof))
+	assert.Nil(t, ManageRelease(ctx, &vshnv1.VSHNRedis{}, iof))
 
 	release := &xhelm.Release{}
 	// IMPORTANT: this resource name must not change! Or crossplane will delete the release.
@@ -161,7 +161,7 @@ func TestAllowVersionUpgrade(t *testing.T) {
 			ctx := context.TODO()
 			iof := loadRuntimeFromTemplate(t, "vshnredis/release/03_version_update.yaml.tmpl", tc)
 
-			res := ManageRelease(ctx, iof)
+			res := ManageRelease(ctx, &vshnv1.VSHNRedis{}, iof)
 			if tc.Fail {
 				return
 			}

--- a/pkg/comp-functions/functions/vshnredis/restore.go
+++ b/pkg/comp-functions/functions/vshnredis/restore.go
@@ -24,11 +24,10 @@ var restoreScript string
 //go:embed script/cleanupRestore.sh
 var cleanupRestoreScript string
 
-func RestoreBackup(ctx context.Context, svc *runtime.ServiceRuntime) *xfnproto.Result {
+func RestoreBackup(ctx context.Context, comp *vshnv1.VSHNRedis, svc *runtime.ServiceRuntime) *xfnproto.Result {
 	log := controllerruntime.LoggerFrom(ctx)
 	log.Info("Starting RestoreBackup function")
 
-	comp := &vshnv1.VSHNRedis{}
 	err := svc.GetObservedComposite(comp)
 	if err != nil {
 		return runtime.NewFatalResult(fmt.Errorf("Cannot get composite from function io: %w", err))

--- a/pkg/comp-functions/functions/vshnredis/restore_test.go
+++ b/pkg/comp-functions/functions/vshnredis/restore_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	xkube "github.com/vshn/appcat/v4/apis/kubernetes/v1alpha2"
+	vshnv1 "github.com/vshn/appcat/v4/apis/vshn/v1"
 	"github.com/vshn/appcat/v4/pkg/comp-functions/functions/commontest"
 	"github.com/vshn/appcat/v4/pkg/comp-functions/runtime"
 	batchv1 "k8s.io/api/batch/v1"
@@ -26,7 +27,7 @@ func TestRestoreBackup_NoConfig(t *testing.T) {
 		io := commontest.LoadRuntimeFromFile(t, "vshnredis/restore/01-GivenNoRestoreConfig.yaml")
 
 		// When
-		result := RestoreBackup(ctx, io)
+		result := RestoreBackup(ctx, &vshnv1.VSHNRedis{}, io)
 
 		// Then
 		assert.Equal(t, expectResult, result)
@@ -43,7 +44,7 @@ func TestRestoreBackup_IncompleteConfig(t *testing.T) {
 		// Given
 		io := commontest.LoadRuntimeFromFile(t, "vshnredis/restore/01-GivenRestoreConfigNoCN.yaml")
 		// When
-		resultCN := RestoreBackup(ctx, io)
+		resultCN := RestoreBackup(ctx, &vshnv1.VSHNRedis{}, io)
 
 		// Then
 		assert.Equal(t, expectResultCN, resultCN)
@@ -52,7 +53,7 @@ func TestRestoreBackup_IncompleteConfig(t *testing.T) {
 		io = commontest.LoadRuntimeFromFile(t, "vshnredis/restore/01-GivenRestoreConfigNoBN.yaml")
 
 		// When
-		resultBN := RestoreBackup(ctx, io)
+		resultBN := RestoreBackup(ctx, &vshnv1.VSHNRedis{}, io)
 
 		// Then
 		assert.Equal(t, expectResultCN, resultBN)
@@ -65,7 +66,7 @@ func TestRestoreBackup(t *testing.T) {
 	// return Normal and new job resources in Desired
 	io := commontest.LoadRuntimeFromFile(t, "vshnredis/restore/01-GivenRestoreConfig.yaml")
 
-	result := RestoreBackup(ctx, io)
+	result := RestoreBackup(ctx, &vshnv1.VSHNRedis{}, io)
 	assert.Nil(t, result)
 
 	resNamePrepJob := "redis-gc9x4-bar-prepare-job"


### PR DESCRIPTION
## Summary

We re-used the same pointer for every single reconcile of any given service type. This could lead to leaking settings between the instances. Resulting in instances enabling features that aren't actually enabled in the claim belonging to the instance.

This change gets rid of the pointer by leveraging generics and reflect.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
