### PR TITLE
Fix operator upgrade restart instance

### DIFF
--- a/apis/stackgres/v1/sgcluster.go
+++ b/apis/stackgres/v1/sgcluster.go
@@ -5,10 +5,11 @@ import (
 )
 
 const SGClusterConditionTypePendingRestart = "PendingRestart"
+const SGClusterConditionTypePendingUpgrade = "PendingUpgrade"
 
 // +kubebuilder:object:root=true
 
-// VSHNPostgreSQL is the API for creating Postgresql clusters.
+// SGCluster is the API for creating Postgresql clusters.
 type SGCluster struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/comp-functions/functions/vshnpostgres/restart.go
+++ b/pkg/comp-functions/functions/vshnpostgres/restart.go
@@ -94,7 +94,7 @@ func getPendingRestart(ctx context.Context, svc *runtime.ServiceRuntime) (time.T
 	return time.Time{}, nil
 }
 
-// In case the operator was updated and the PostgreSQL clusters requires immediate restart we will postpone it during the maintenance
+// In case the operator was updated and the PostgreSQL clusters require a security maintenance, we ensure that it only happens during the maintenance window
 func hasPendingUpgrade(items []sgv1.SGClusterStatusConditionsItem) bool {
 	for _, i := range items {
 		if *i.Type == sgv1.SGClusterConditionTypePendingUpgrade && *i.Status == "True" {

--- a/pkg/comp-functions/functions/vshnpostgres/restart.go
+++ b/pkg/comp-functions/functions/vshnpostgres/restart.go
@@ -68,10 +68,15 @@ func getPendingRestart(ctx context.Context, svc *runtime.ServiceRuntime) (time.T
 		return time.Time{}, nil
 	}
 
+	if hasPendingUpgrade(*cluster.Status.Conditions) {
+		return time.Time{}, nil
+	}
+
 	for _, cond := range *cluster.Status.Conditions {
 		if cond.Type == nil || *cond.Type != sgv1.SGClusterConditionTypePendingRestart || cond.Status == nil || cond.LastTransitionTime == nil {
 			continue
 		}
+
 		status, err := strconv.ParseBool(*cond.Status)
 		if err != nil || !status {
 			continue
@@ -87,6 +92,16 @@ func getPendingRestart(ctx context.Context, svc *runtime.ServiceRuntime) (time.T
 	}
 
 	return time.Time{}, nil
+}
+
+// In case the operator was updated and the PostgreSQL clusters requires immediate restart we will postpone it during the maintenance
+func hasPendingUpgrade(items []sgv1.SGClusterStatusConditionsItem) bool {
+	for _, i := range items {
+		if *i.Type == sgv1.SGClusterConditionTypePendingUpgrade && *i.Status == "True" {
+			return true
+		}
+	}
+	return false
 }
 
 func scheduleRestart(ctx context.Context, svc *runtime.ServiceRuntime, compName string, restartTime time.Time) error {


### PR DESCRIPTION
## Summary

* This PR makes sure that whenever the Stackgres Operator is being updated, the postgres clusters will be upgraded only during the maintenance window and not right away.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
