### PR TITLE
fixing PDB selector label

### DIFF
--- a/apis/vshn/v1/dbaas_vshn_postgresql.go
+++ b/apis/vshn/v1/dbaas_vshn_postgresql.go
@@ -391,7 +391,7 @@ func (v *VSHNPostgreSQL) GetInstances() int {
 
 func (v *VSHNPostgreSQL) GetPDBLabels() map[string]string {
 	return map[string]string{
-		"app": "StackGresCluster",
+		"stackgres.io/cluster": "true",
 	}
 }
 


### PR DESCRIPTION
## Summary

Our PDB Selector label for vSHNPOstgreSQL accidently matched also backups. This commit fixes it and takes unique label from PostgreSQL pods.

Test case:
- create new VSHNPostgreSQL (3 instances)
- run maintenance
- run backup
- run `k get pod -l stackgres.io/cluster="true"` in instance_namespace
- result - only cluster pods are selected
