### PR TITLE
Fix dependency issue when using encrypted PVCs for VSHNPostgreSQL

### DIFF
--- a/pkg/comp-functions/functions/vshnkeycloak/deploy.go
+++ b/pkg/comp-functions/functions/vshnkeycloak/deploy.go
@@ -91,7 +91,7 @@ func DeployKeycloak(ctx context.Context, comp *vshnv1.VSHNKeycloak, svc *runtime
 		},
 	}
 
-	ready, err := svc.WaitForDependenciesWithConnectionDetails(comp.GetName(), resourceCDMap)
+	ready, err := svc.WaitForObservedDependenciesWithConnectionDetails(comp.GetName(), resourceCDMap)
 	if err != nil {
 		// We're returning a fatal here, so in case something is wrong we won't delete anything by mistake.
 		return runtime.NewFatalResult(err)

--- a/pkg/comp-functions/functions/vshnnextcloud/deploy.go
+++ b/pkg/comp-functions/functions/vshnnextcloud/deploy.go
@@ -87,7 +87,7 @@ func DeployNextcloud(ctx context.Context, comp *vshnv1.VSHNNextcloud, svc *runti
 			},
 		}
 
-		ready, err := svc.WaitForDependenciesWithConnectionDetails(comp.GetName(), resourceCDMap)
+		ready, err := svc.WaitForObservedDependenciesWithConnectionDetails(comp.GetName(), resourceCDMap)
 		if err != nil {
 			// We're returning a fatal here, so in case something is wrong we won't delete anything by mistake.
 			return runtime.NewFatalResult(err)

--- a/pkg/comp-functions/runtime/function_mgr.go
+++ b/pkg/comp-functions/runtime/function_mgr.go
@@ -995,11 +995,11 @@ func (s *ServiceRuntime) areResourcesReady(names []string) bool {
 	return true
 }
 
-// WaitForDependencies takes two arguments, the name of the main resource, which should be deployed after the dependencies.
+// WaitForObservedDependencies takes two arguments, the name of the main resource, which should be deployed after the dependencies.
 // It also takes a list of names for objects to depend on. It does NOT deploy any objects, but check for their existence.
 // If true is returned it is safe to continue with adding your main object to the desired resources.
 // If the main resource already exists in the observed state it will always return true.
-func (s *ServiceRuntime) WaitForDependencies(mainResource string, dependencies ...string) bool {
+func (s *ServiceRuntime) WaitForObservedDependencies(mainResource string, dependencies ...string) bool {
 	if _, ok := s.req.Observed.Resources[mainResource]; ok {
 		return true
 	}
@@ -1011,17 +1011,33 @@ func (s *ServiceRuntime) WaitForDependencies(mainResource string, dependencies .
 	return true
 }
 
-// WaitForDependenciesWithConnectionDetails does the same as WaitForDependencies but additionally also checks the given list of fields against the
+// WaitForDesiredDependencies takes two arguments, the name of the main resource, which should be deployed after the dependencies.
+// It also takes a list of names for objects to depend on. It does NOT deploy any objects, but check for their existence.
+// If true is returned it is safe to continue with adding your main object to the desired resources.
+// If the main resource already exists in the observed state it will always return true.
+func (s *ServiceRuntime) WaitForDesiredDependencies(mainResource string, dependencies ...string) bool {
+	if _, ok := s.req.Desired.Resources[mainResource]; ok {
+		return true
+	}
+
+	if !s.areResourcesReady(dependencies) {
+		return false
+	}
+
+	return true
+}
+
+// WaitForObservedDependenciesWithConnectionDetails does the same as WaitForDependencies but additionally also checks the given list of fields against the
 // available connection details.
 // objectCDMap should contain a map where the key is the name of the dependeny and the string slice the necessary connection detail fields.
-func (s *ServiceRuntime) WaitForDependenciesWithConnectionDetails(mainResource string, objectCDMap map[string][]string) (bool, error) {
+func (s *ServiceRuntime) WaitForObservedDependenciesWithConnectionDetails(mainResource string, objectCDMap map[string][]string) (bool, error) {
 	// If the main resource already exists we're done here
 	if _, ok := s.req.Observed.Resources[mainResource]; ok {
 		return true, nil
 	}
 
 	for dep, cds := range objectCDMap {
-		ready := s.WaitForDependencies(mainResource, dep)
+		ready := s.WaitForObservedDependencies(mainResource, dep)
 		if !ready {
 			return false, nil
 		}

--- a/test/functions/vshn-postgres/enc_pvc/03-GivenEncryptionParams.yaml
+++ b/test/functions/vshn-postgres/enc_pvc/03-GivenEncryptionParams.yaml
@@ -88,6 +88,7 @@ observed:
           name: vshnpostgres.vshn.appcat.vshn.io-ce52f13
         compositionUpdatePolicy: Automatic
         parameters:
+          instances: 1
           encryption:
             enabled: true
       status:

--- a/test/functions/vshn-postgres/enc_pvc/03-GivenEncryptionParamsExistingSecret.yaml
+++ b/test/functions/vshn-postgres/enc_pvc/03-GivenEncryptionParamsExistingSecret.yaml
@@ -88,12 +88,13 @@ observed:
           name: vshnpostgres.vshn.appcat.vshn.io-ce52f13
         compositionUpdatePolicy: Automatic
         parameters:
+          instances: 1
           encryption:
             enabled: true
       status:
         instanceNamespace: my-psql
   resources:
-    psql-luks-key:
+    psql-luks-key-0:
       resource:
         apiVersion: kubernetes.crossplane.io/v1alpha1
         kind: Object


### PR DESCRIPTION
## Summary

There was a dependency loop that prevented the creation of VSHNPostgreSQL instances that use encrypted PVCs:
* The SGCluster object can't be created before the luks secret for the PVC is generated
* The luks secret can't be created without getting the instance count of the cluster object

This has been resolved by relying on the instance count from the composite and also waiting for the luks secrets to be present before attempting to access the sgcluster object to be able to override the storageClass for the PVCs

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
