### PR TITLE
Add providerConfig management

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -216,9 +216,10 @@ install-proxy:
 	kubectl apply -f hack/functionproxy
 
 .PHONY: render-diff
+DEBUG=""
 render-diff: export IMG_TAG=$(shell git rev-parse --abbrev-ref HEAD | sed 's/\//_/g')
 render-diff: ## Render diff between the cluster in KUBECONF and the local branch
 	# We check if the image is pullable, if so we pull it, otherwise we build the image
 	# this will speed up the compare in CI/CD environments.
 	if ! docker pull $(IMG); then $(MAKE) docker-build-branchtag; fi
-	hack/diff/compare.sh
+	hack/diff/compare.sh $(DEBUG)

--- a/README.md
+++ b/README.md
@@ -218,8 +218,8 @@ This will:
 
 If you want to print the diff while using the debugger you can simply do this:
 
-* Star the local debugging session as described
-* Run `make render-diff -e DEBUG=Developmen`
+* Start the local debugging session as described
+* Run `make render-diff -e DEBUG=Development`
 
 NOTE: `crank render` has a 60s timeout, so you might run into it, if your debugging takes longer
 

--- a/README.md
+++ b/README.md
@@ -214,6 +214,15 @@ This will:
 * Run `crank` again with the state already downloaded, to avoid any unintended diffs
 * Use `dyff` to generate the diffs between both results
 
+### Generate diff against live version with debugger
+
+If you want to print the diff while using the debugger you can simply do this:
+
+* Star the local debugging session as described
+* Run `make render-diff -e DEBUG=Developmen`
+
+NOTE: `crank render` has a 60s timeout, so you might run into it, if your debugging takes longer
+
 # Run API Server locally
 To run the API server on your local machine you need to register the IDE running instance with kind cluster.
 This can be achieved with the following guide.

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -25,3 +25,4 @@
 * xref:explanations/disable-billing.adoc[]
 * xref:explanations/webhook-protection.adoc[]
 * xref:explanations/ordered-deletion.adoc[]
+* xref:explanations/providerconfig-management.adoc[]

--- a/docs/modules/ROOT/pages/explanations/providerconfig-management.adoc
+++ b/docs/modules/ROOT/pages/explanations/providerconfig-management.adoc
@@ -4,7 +4,7 @@ AppCat is able to inject a given `ProviderConfig` reference into all managed res
 
 That can be controlled by setting the `appcat.vshn.io/provider-config` label on any given claim or composite. The value of this label will be injected as the `ProviderConfig` name.
 
-There are managed resources that should have the `ProviderConfig` overwritten. In such cases it's possible to deploy them with the `appcat.vshn.io/ignore-config` and then no overwrite will happen.
+There are managed resources that should have the `ProviderConfig` overwritten. In such cases it's possible to deploy them with the `appcat.vshn.io/ignore-provider-config` and then no overwrite will happen.
 
 The `ProviderConfig` objects have to be provisioned beforehand, via `component-appcat` for example.
 

--- a/docs/modules/ROOT/pages/explanations/providerconfig-management.adoc
+++ b/docs/modules/ROOT/pages/explanations/providerconfig-management.adoc
@@ -1,0 +1,11 @@
+= ProviderConfig Management
+
+AppCat is able to inject a given `ProviderConfig` reference into all managed resources.
+
+That can be controlled by setting the `appcat.vshn.io/provider-config` label on any given claim or composite. The value of this label will be injected as the `ProviderConfig` name.
+
+There are managed resources that should have the `ProviderConfig` overwritten. In such cases it's possible to deploy them with the `appcat.vshn.io/ignore-config` and then no overwrite will happen.
+
+The `ProviderConfig` objects have to be provisioned beforehand, via `component-appcat` for example.
+
+If no labels are given, AppCat will use the hardcoded default `ProviderConfigs` for each provider. These also have to be provided by external means like `component-appcat`.

--- a/hack/diff/function.yaml.tmpl
+++ b/hack/diff/function.yaml.tmpl
@@ -4,6 +4,7 @@ metadata:
   name: function-appcat
   annotations:
     render.crossplane.io/runtime-docker-cleanup: Stop
+    render.crossplane.io/runtime: $DEBUG
 spec:
   package: ghcr.io/vshn/appcat:$APPCAT_VERSION
 ---

--- a/pkg/comp-functions/functions/common/backup/backup.go
+++ b/pkg/comp-functions/functions/common/backup/backup.go
@@ -56,6 +56,9 @@ func createObjectBucket(ctx context.Context, comp common.InfoGetter, svc *runtim
 	ob := &appcatv1.XObjectBucket{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: comp.GetName() + "-backup",
+			Labels: map[string]string{
+				runtime.ProviderConfigIgnoreLabel: "true",
+			},
 		},
 		Spec: appcatv1.XObjectBucketSpec{
 			Parameters: appcatv1.ObjectBucketParameters{

--- a/pkg/comp-functions/functions/vshnpostgres/postgresql_deploy.go
+++ b/pkg/comp-functions/functions/vshnpostgres/postgresql_deploy.go
@@ -454,6 +454,9 @@ func createObjectBucket(comp *vshnv1.VSHNPostgreSQL, svc *runtime.ServiceRuntime
 	xObjectBucket := &appcatv1.XObjectBucket{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: comp.GetName(),
+			Labels: map[string]string{
+				runtime.ProviderConfigIgnoreLabel: "true",
+			},
 		},
 		Spec: appcatv1.XObjectBucketSpec{
 			Parameters: appcatv1.ObjectBucketParameters{

--- a/pkg/comp-functions/functions/vshnpostgres/user_management.go
+++ b/pkg/comp-functions/functions/vshnpostgres/user_management.go
@@ -60,6 +60,9 @@ func addUser(comp *vshnv1.VSHNPostgreSQL, svc *runtime.ServiceRuntime, username 
 			Annotations: map[string]string{
 				"crossplane.io/external-name": username,
 			},
+			Labels: map[string]string{
+				runtime.ProviderConfigIgnoreLabel: "true",
+			},
 		},
 		Spec: pgv1alpha1.RoleSpec{
 			ForProvider: pgv1alpha1.RoleParameters{
@@ -209,6 +212,9 @@ func addDatabase(comp *vshnv1.VSHNPostgreSQL, svc *runtime.ServiceRuntime, name 
 			Annotations: map[string]string{
 				"crossplane.io/external-name": name,
 			},
+			Labels: map[string]string{
+				runtime.ProviderConfigIgnoreLabel: "true",
+			},
 		},
 		Spec: pgv1alpha1.DatabaseSpec{
 			ForProvider: pgv1alpha1.DatabaseParameters{},
@@ -241,6 +247,9 @@ func addGrants(comp *vshnv1.VSHNPostgreSQL, svc *runtime.ServiceRuntime, usernam
 	grant := &pgv1alpha1.Grant{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: fmt.Sprintf("%s-%s-%s-grants", comp.GetName(), username, dbname),
+			Labels: map[string]string{
+				runtime.ProviderConfigIgnoreLabel: "true",
+			},
 		},
 		Spec: pgv1alpha1.GrantSpec{
 			ForProvider: pgv1alpha1.GrantParameters{

--- a/pkg/comp-functions/runtime/function_mgr.go
+++ b/pkg/comp-functions/runtime/function_mgr.go
@@ -53,7 +53,7 @@ const (
 	ProtectsAnnotation        = "appcat.vshn.io/protects"
 	EventForwardAnnotation    = "appcat.vshn.io/forward-events-to"
 	providerConfigLabel       = "appcat.vshn.io/provider-config"
-	ProviderConfigIgnoreLabel = "appcat.vshn.io/ignore-config"
+	ProviderConfigIgnoreLabel = "appcat.vshn.io/ignore-provider-config"
 )
 
 // Step describes a single change within a service.

--- a/pkg/comp-functions/runtime/function_mgr_test.go
+++ b/pkg/comp-functions/runtime/function_mgr_test.go
@@ -1,0 +1,135 @@
+package runtime
+
+import (
+	"testing"
+
+	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
+	xpapi "github.com/crossplane/crossplane/apis/apiextensions/v1alpha1"
+	xfnproto "github.com/crossplane/function-sdk-go/proto/v1beta1"
+	"github.com/crossplane/function-sdk-go/resource"
+	"github.com/crossplane/function-sdk-go/resource/composed"
+	"github.com/stretchr/testify/assert"
+	xkube "github.com/vshn/appcat/v4/apis/kubernetes/v1alpha2"
+	"google.golang.org/protobuf/types/known/structpb"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestServiceRuntime_unwrapUsage(t *testing.T) {
+	tests := []struct {
+		name    string
+		resName string
+		objects []client.Object
+		want    bool
+		wantErr bool
+		desired bool
+	}{
+		{
+			name:    "GivenWrappedUsage_ThenUnwrap",
+			resName: "myusage",
+			objects: []client.Object{
+				&xpapi.Usage{},
+				&xkube.Object{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "myusage",
+					},
+					Status: xkube.ObjectStatus{
+						AtProvider: xkube.ObjectObservation{
+							Manifest: runtime.RawExtension{
+								Object: &xpapi.Usage{},
+							},
+						},
+					},
+				},
+			},
+			want:    false,
+			desired: true,
+		},
+		{
+			name:    "GivenWrappedUsageWithManagementPolicy_ThenUnwrap",
+			resName: "myusage",
+			objects: []client.Object{
+				&xpapi.Usage{},
+				&xkube.Object{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "myusage",
+					},
+					Spec: xkube.ObjectSpec{
+						ResourceSpec: xpv1.ResourceSpec{
+							ManagementPolicies: xpv1.ManagementPolicies{
+								xpv1.ManagementActionObserve,
+							},
+						},
+					},
+					Status: xkube.ObjectStatus{
+						AtProvider: xkube.ObjectObservation{
+							Manifest: runtime.RawExtension{
+								Object: &xpapi.Usage{},
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name:    "GivenUsage_ThenNoUnwrap",
+			resName: "myusage",
+			objects: []client.Object{
+				&xpapi.Usage{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "myusage",
+					},
+					Spec: xpapi.UsageSpec{
+						Of: xpapi.Resource{
+							Kind: "mykind",
+						},
+					},
+				},
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			req := &xfnproto.RunFunctionRequest{
+				Observed: &xfnproto.State{
+					Resources: map[string]*xfnproto.Resource{},
+				},
+			}
+
+			for _, obj := range tt.objects {
+				res, err := composed.From(obj)
+				assert.NoError(t, err)
+
+				protoRes, err := structpb.NewStruct(res.UnstructuredContent())
+				assert.NoError(t, err)
+
+				req.Observed.Resources[obj.GetName()] = &xfnproto.Resource{Resource: protoRes}
+			}
+
+			s := &ServiceRuntime{
+				req:              req,
+				desiredResources: map[resource.Name]*resource.DesiredComposed{},
+			}
+
+			res, err := s.unwrapUsage(tt.resName)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			assert.Equal(t, tt.want, res)
+
+			if tt.desired {
+				assert.NotEmpty(t, s.GetAllDesired())
+			} else {
+				assert.Empty(t, s.GetAllDesired())
+			}
+
+		})
+	}
+}


### PR DESCRIPTION
## Summary

* Each claim/composite pair can specific their own providerConfig name
* It will be injected into each managed resource
* The providerConfigs need to be correctly provisioned beforehand
* Not setting the label will result in the current defaults being used
* Usage will no longer be wrapped into Kube Objects to avoid deploying them to service clusters
  * Also it's best practices to NOT wrap them, it makes the deprovisioning process a lot smoother
* It's possible to set a label for managed resources that should not get the providerConf from the claim/composite
  * Some managed resources have already been labeled, but by all means not all of them. That should be in the scope of another story

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
