### PR TITLE
Fix backups if Redis TLS is disabled

### DIFF
--- a/pkg/comp-functions/functions/vshnredis/backup.go
+++ b/pkg/comp-functions/functions/vshnredis/backup.go
@@ -45,7 +45,7 @@ func AddBackup(ctx context.Context, comp *vshnv1.VSHNRedis, svc *runtime.Service
 	}
 
 	l.Info("Creating backup config map")
-	err = createScriptCM(ctx, comp, svc)
+	err = createScriptCM(comp, svc)
 	if err != nil {
 		return runtime.NewFatalResult(fmt.Errorf("cannot create backup config map: %w", err))
 	}
@@ -53,7 +53,7 @@ func AddBackup(ctx context.Context, comp *vshnv1.VSHNRedis, svc *runtime.Service
 	return nil
 }
 
-func createScriptCM(ctx context.Context, comp *vshnv1.VSHNRedis, svc *runtime.ServiceRuntime) error {
+func createScriptCM(comp *vshnv1.VSHNRedis, svc *runtime.ServiceRuntime) error {
 
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/comp-functions/functions/vshnredis/script/backup.sh
+++ b/pkg/comp-functions/functions/vshnredis/script/backup.sh
@@ -5,7 +5,11 @@
 # it will also backup that one.
 
 redis_cmd() {
-  redis-cli -a "${REDIS_PASSWORD}" --cacert "${REDIS_TLS_CA_FILE}" --cert "${REDIS_TLS_CERT_FILE}" --key "${REDIS_TLS_KEY_FILE}" --tls "$@"
+  if [ -z "$REDIS_TLS_CERT_FILE" ]; then 
+    redis-cli -a "${REDIS_PASSWORD}" "$@"
+  else
+    redis-cli -a "${REDIS_PASSWORD}" --cacert "${REDIS_TLS_CA_FILE}" --cert "${REDIS_TLS_CERT_FILE}" --key "${REDIS_TLS_KEY_FILE}" --tls "$@"
+  fi
 }
 
 rewrite_percentage=$(redis_cmd --raw CONFIG GET auto-aof-rewrite-percentage | tail -n 1) 1>&2


### PR DESCRIPTION
## Summary

* This PR fixes a bug, where the backups didn't work if Redis TLS is disabled.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [ ] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
