### PR TITLE
Clarify Repack and Vacuum API docs and fix wrong error message

### DIFF
--- a/apis/vshn/v1/dbaas_vshn_postgresql.go
+++ b/apis/vshn/v1/dbaas_vshn_postgresql.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"fmt"
+
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	sgv1 "github.com/vshn/appcat/v4/apis/stackgres/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -148,9 +149,11 @@ type VSHNPostgreSQLServiceSpec struct {
 	PgBouncerSettings *sgv1.SGPoolingConfigSpecPgBouncerPgbouncerIni `json:"pgBouncerSettings,omitempty"`
 
 	// +kubebuilder:default=true
-	// This is default option if neither repack or vacuum are selected
+	// RepackEnabled defines if `pg_repack` should be performed during the maintenance. Defaults to true.
 	RepackEnabled bool `json:"repackEnabled,omitempty"`
+
 	// +kubebuilder:default=false
+	// VacuumEnabled defines if `VACUUM` should be performed during the maintenace. Defaults to false.
 	VacuumEnabled bool `json:"vacuumEnabled,omitempty"`
 
 	// Access defines additional users and databases for this instance.

--- a/pkg/controller/webhooks/postgresql.go
+++ b/pkg/controller/webhooks/postgresql.go
@@ -312,7 +312,7 @@ func (p *PostgreSQLWebhookHandler) checkGuaranteedAvailability(pg *vshnv1.VSHNPo
 // validate vacuum and repack settings
 func validateVacuumRepack(vacuum, repack bool) error {
 	if !vacuum && !repack {
-		return fmt.Errorf("repack cannot be enabled without vacuum")
+		return fmt.Errorf("can't disable vacuum and repack at the same time")
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

* Clarify the Repack and Vaccum API docs and fix a wrong text in the error message of the repack and vacuum validation function.

## Checklist

- [ ] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [ ] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
