### PR TITLE
Add MariaDB Scaling

### DIFF
--- a/crds/vshn.appcat.vshn.io_vshnmariadbs.yaml
+++ b/crds/vshn.appcat.vshn.io_vshnmariadbs.yaml
@@ -67,6 +67,18 @@ spec:
                           type: string
                       type: object
                       default: {}
+                    instances:
+                      default: 1
+                      description: |-
+                        Instances configures the number of MariaDB instances for the cluster.
+                        Each instance contains one MariaDB server.
+                        These serves will form a Galera cluster.
+                        An additional ProxySQL statefulset will be deployed to make failovers
+                        as seamless as possible.
+                      enum:
+                        - 1
+                        - 3
+                      type: integer
                     maintenance:
                       description: Maintenance contains settings to control the maintenance of an instance.
                       properties:
@@ -4895,7 +4907,7 @@ spec:
                             - guaranteed
                           type: string
                         version:
-                          default: "11.2"
+                          default: "11.5"
                           description: |-
                             Version contains supported version of MariaDB.
                             Multiple versions are supported. The latest version "11.2" is the default version.
@@ -4909,6 +4921,9 @@ spec:
                             - "11.0"
                             - "11.1"
                             - "11.2"
+                            - "11.3"
+                            - "11.4"
+                            - "11.5"
                           type: string
                       type: object
                       default: {}
@@ -5047,6 +5062,11 @@ spec:
                         type: string
                     type: object
                   type: array
+                currentInstances:
+                  description: |-
+                    CurrentInstances tracks the current amount of instances.
+                    Mainly used to detect if there was a change in instances
+                  type: integer
                 instanceNamespace:
                   description: InstanceNamespace contains the name of the namespace where the instance resides
                   type: string
@@ -5231,8 +5251,6 @@ spec:
                     type: object
                   type: array
               type: object
-          required:
-            - spec
           type: object
       served: true
       storage: true

--- a/crds/vshn.appcat.vshn.io_xvshnmariadbs.yaml
+++ b/crds/vshn.appcat.vshn.io_xvshnmariadbs.yaml
@@ -111,6 +111,18 @@ spec:
                           (\*|([1-9]|1[0-2])|\*\/([1-9]|1[0-2])) (\*|([0-6])|\*\/([0-6]))$
                         type: string
                     type: object
+                  instances:
+                    default: 1
+                    description: |-
+                      Instances configures the number of MariaDB instances for the cluster.
+                      Each instance contains one MariaDB server.
+                      These serves will form a Galera cluster.
+                      An additional ProxySQL statefulset will be deployed to make failovers
+                      as seamless as possible.
+                    enum:
+                    - 1
+                    - 3
+                    type: integer
                   maintenance:
                     description: Maintenance contains settings to control the maintenance
                       of an instance.
@@ -5623,7 +5635,7 @@ spec:
                         - guaranteed
                         type: string
                       version:
-                        default: "11.2"
+                        default: "11.5"
                         description: |-
                           Version contains supported version of MariaDB.
                           Multiple versions are supported. The latest version "11.2" is the default version.
@@ -5637,6 +5649,9 @@ spec:
                         - "11.0"
                         - "11.1"
                         - "11.2"
+                        - "11.3"
+                        - "11.4"
+                        - "11.5"
                         type: string
                     type: object
                   size:
@@ -5951,6 +5966,11 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              currentInstances:
+                description: |-
+                  CurrentInstances tracks the current amount of instances.
+                  Mainly used to detect if there was a change in instances
+                type: integer
               instanceNamespace:
                 description: InstanceNamespace contains the name of the namespace
                   where the instance resides

--- a/pkg/comp-functions/functions/common/resources.go
+++ b/pkg/comp-functions/functions/common/resources.go
@@ -133,3 +133,19 @@ func getHigherQuantity(a, b resource.Quantity) resource.Quantity {
 	}
 	return a
 }
+
+// GetBitnamiNano returns a "nano" bitnami resource termplate, but without the
+// ephemeral storage.
+// See for more details: https://github.com/bitnami/charts/blob/main/bitnami/common/templates/_resources.tpl#L15
+func GetBitnamiNano() map[string]any {
+	return map[string]any{
+		"requests": map[string]string{
+			"cpu":    "100m",
+			"memory": "128Mi",
+		},
+		"limits": map[string]string{
+			"cpu":    "150m",
+			"memory": "192Mi",
+		},
+	}
+}

--- a/pkg/comp-functions/functions/vshnkeycloak/deploy.go
+++ b/pkg/comp-functions/functions/vshnkeycloak/deploy.go
@@ -122,7 +122,7 @@ func DeployKeycloak(ctx context.Context, comp *vshnv1.VSHNKeycloak, svc *runtime
 
 	svc.Log.Info("Creating Keycloak TLS certs")
 	// The helm chart appends `-keycloakx-http` to the http service.
-	err = common.CreateTlsCerts(ctx, comp.GetInstanceNamespace(), comp.GetName()+"-keycloakx-http", svc)
+	_, err = common.CreateTLSCerts(ctx, comp.GetInstanceNamespace(), comp.GetName()+"-keycloakx-http", svc)
 	if err != nil {
 		return runtime.NewWarningResult(fmt.Sprintf("cannot add tls certificate: %s", err))
 	}

--- a/pkg/comp-functions/functions/vshnmariadb/files/proxysql.conf.tmpl
+++ b/pkg/comp-functions/functions/vshnmariadb/files/proxysql.conf.tmpl
@@ -1,0 +1,42 @@
+datadir="/var/lib/proxysql"
+
+admin_variables=
+{
+    admin_credentials="admin:{{ .RootPassword }};radmin:{{ .RootPassword }}"
+    mysql_ifaces="0.0.0.0:6032"
+    refresh_interval=2000
+    cluster_username="radmin"
+    cluster_password="{{ .RootPassword }}"
+}
+
+{{ if eq .TLS 1 }}
+mysql_variables = {
+    ssl_p2s_ca = "/var/lib/proxysql/proxysql-ca.pem"
+}
+{{ end }}
+
+mysql_servers =
+(
+    { address="{{ .CompName }}-0.{{ .CompName }}-headless.{{ .Namespace }}.svc" , port=3306 , hostgroup=2, weight=120, use_ssl={{ .TLS }} },
+    { address="{{ .CompName }}-1.{{ .CompName }}-headless.{{ .Namespace }}.svc" , port=3306 , hostgroup=2, weight=110, use_ssl={{ .TLS }} },
+    { address="{{ .CompName }}-2.{{ .CompName }}-headless.{{ .Namespace }}.svc" , port=3306 , hostgroup=2, weight=100, use_ssl={{ .TLS }} }
+)
+
+mysql_users =
+(
+    { username = "root", password = "{{ .RootPassword }}", default_hostgroup = 2 },
+    {{range $val := .Users}}
+    { username = "{{ $val.Name }}", password = "{{ $val.Password }}", default_hostgroup = 2 },
+    {{end}}
+)
+
+mysql_galera_hostgroups =
+(
+    {writer_hostgroup=2,backup_writer_hostgroup=4,reader_hostgroup=3,offline_hostgroup=1,active=1,max_writers=1,writer_is_also_reader=1,max_transactions_behind=100}
+)
+
+proxysql_servers =
+(
+    { hostname = "proxysql-0.proxysqlcluster.{{ .Namespace }}.svc", port = 6032, weight = 1 },
+    { hostname = "proxysql-1.proxysqlcluster.{{ .Namespace }}.svc", port = 6032, weight = 1 }
+)

--- a/pkg/comp-functions/functions/vshnmariadb/mariadb_deploy.go
+++ b/pkg/comp-functions/functions/vshnmariadb/mariadb_deploy.go
@@ -21,6 +21,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 )
 
@@ -53,8 +54,27 @@ func DeployMariadb(ctx context.Context, comp *vshnv1.VSHNMariaDB, svc *runtime.S
 		return runtime.NewWarningResult(fmt.Errorf("cannot bootstrap instance namespace: %w", err).Error())
 	}
 
+	svc.Log.Info("Creating main mariadb service")
+	err = createMainService(comp, svc, passwordSecret)
+	if err != nil {
+		return runtime.NewWarningResult(fmt.Sprintf("cannot create service: %s", err))
+	}
+
+	// To make scaling up and down as seamless as possible we create a cert that also includes the
+	// proxy dns names.
 	l.Info("Creating tls certificate for mariadb instance")
-	err = common.CreateTlsCerts(ctx, comp.GetInstanceNamespace(), comp.GetName(), svc)
+	_, err = common.CreateTLSCerts(ctx, comp.GetInstanceNamespace(), comp.GetName(), svc,
+		comp.GetName(),
+		fmt.Sprintf("*.%s-headless.%s.svc.cluster.local", comp.GetName(), comp.GetInstanceNamespace()),
+		fmt.Sprintf("*.%s.%s.svc.cluster.local", comp.GetName(), comp.GetInstanceNamespace()),
+		fmt.Sprintf("%s-headless.%s.svc.cluster.local", comp.GetName(), comp.GetInstanceNamespace()),
+		fmt.Sprintf("%s.%s.svc.cluster.local", comp.GetName(), comp.GetInstanceNamespace()),
+		fmt.Sprintf("mariadb.%s.svc.cluster.local", comp.GetInstanceNamespace()),
+		fmt.Sprintf("mariadb.%s.svc", comp.GetInstanceNamespace()),
+		fmt.Sprintf("proxysql-0.proxysqlcluster.%s.svc", comp.GetInstanceNamespace()),
+		fmt.Sprintf("proxysql-1.proxysqlcluster.%s.svc", comp.GetInstanceNamespace()),
+	)
+
 	if err != nil {
 		return runtime.NewWarningResult(fmt.Errorf("cannot create tls certificate: %w", err).Error())
 	}
@@ -112,25 +132,14 @@ func createObjectHelmRelease(ctx context.Context, comp *vshnv1.VSHNMariaDB, svc 
 }
 
 func getConnectionDetails(comp *vshnv1.VSHNMariaDB, svc *runtime.ServiceRuntime, secretName string) error {
-	secret := &corev1.Secret{}
 
-	err := svc.GetObservedKubeObject(secret, secretName)
-
+	mariadbRootPw, err := getMariaDBRootPassword(secretName, svc)
 	if err != nil {
-		if err == runtime.ErrNotFound {
-			return nil
-		}
 		return err
 	}
-	mariadbRootPw := secret.Data["mariadb-root-password"]
 
-	mariadbHost := comp.GetName() + ".vshn-mariadb-" + comp.GetName() + ".svc.cluster.local"
-	mariadbURL := fmt.Sprintf("mysql://%s:%s@%s:%s", mariadbUser, mariadbRootPw, mariadbHost, mariadbPort)
-
-	svc.SetConnectionDetail("MARIADB_HOST", []byte(mariadbHost))
 	svc.SetConnectionDetail("MARIADB_PORT", []byte(mariadbPort))
 	svc.SetConnectionDetail("MARIADB_USERNAME", []byte(mariadbUser))
-	svc.SetConnectionDetail("MARIADB_URL", []byte(mariadbURL))
 	svc.SetConnectionDetail("MARIADB_PASSWORD", mariadbRootPw)
 
 	return nil
@@ -161,7 +170,7 @@ func newValues(ctx context.Context, svc *runtime.ServiceRuntime, comp *vshnv1.VS
 	values = map[string]interface{}{
 		"existingSecret":   secretName,
 		"fullnameOverride": comp.GetName(),
-		"replicaCount":     1,
+		"replicaCount":     comp.GetInstances(),
 		"resources": map[string]interface{}{
 			"requests": map[string]interface{}{
 				"memory": res.ReqMem.String(),
@@ -186,8 +195,11 @@ func newValues(ctx context.Context, svc *runtime.ServiceRuntime, comp *vshnv1.VS
 			"size":         res.Disk.String(),
 			"storageClass": comp.Spec.Parameters.StorageClass,
 		},
+		// We don't need the startup probe for Galera clusters, as ProxySQL
+		// will check the state independetly and is usually faster than the probe.
+		// Also for single instances it unnecessarily slows downt he provisioning.
 		"startupProbe": map[string]interface{}{
-			"enabled": true,
+			"enabled": false,
 		},
 		"metrics": map[string]interface{}{
 			"enabled": true,
@@ -197,6 +209,7 @@ func newValues(ctx context.Context, svc *runtime.ServiceRuntime, comp *vshnv1.VS
 			"serviceMonitor": map[string]interface{}{
 				"enabled": true,
 			},
+			"resources": common.GetBitnamiNano(),
 		},
 		"securityContext": map[string]interface{}{
 			"enabled": !svc.GetBoolFromCompositionConfig("isOpenshift"),
@@ -208,6 +221,9 @@ func newValues(ctx context.Context, svc *runtime.ServiceRuntime, comp *vshnv1.VS
 			"enabled": !svc.GetBoolFromCompositionConfig("isOpenshift"),
 		},
 		"nodeSelector": nodeSelector,
+		"podLabels": map[string]string{
+			"app": "mariadb",
+		},
 	}
 
 	return values, nil
@@ -395,4 +411,65 @@ func getReleaseSecretValue(svc *runtime.ServiceRuntime, comp *vshnv1.VSHNMariaDB
 		return []byte{}
 	}
 	return m["release"]
+}
+
+// To make scaling as seamless as possible we create an additional service.
+// This service will either point to a single db instance, or to the proxysql cluster.
+func createMainService(comp *vshnv1.VSHNMariaDB, svc *runtime.ServiceRuntime, secretName string) error {
+	target := map[string]string{}
+	targetPort := 3306
+	serviceName := "mariadb"
+
+	if comp.GetInstances() == 1 {
+		target["app"] = "mariadb"
+	} else {
+		target["app"] = "proxysql"
+		targetPort = 6033
+	}
+
+	service := corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      serviceName,
+			Namespace: comp.GetInstanceNamespace(),
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: target,
+			Type:     corev1.ServiceTypeClusterIP,
+			Ports: []corev1.ServicePort{
+				{
+					Name:       serviceName,
+					Protocol:   corev1.ProtocolTCP,
+					TargetPort: intstr.FromInt(targetPort),
+					Port:       3306,
+				},
+			},
+		},
+	}
+
+	mariadbRootPw, err := getMariaDBRootPassword(secretName, svc)
+	if err != nil {
+		return err
+	}
+
+	mariadbHost := serviceName + ".vshn-mariadb-" + comp.GetName() + ".svc.cluster.local"
+	mariadbURL := fmt.Sprintf("mysql://%s:%s@%s:%s", mariadbUser, mariadbRootPw, mariadbHost, mariadbPort)
+
+	svc.SetConnectionDetail("MARIADB_HOST", []byte(mariadbHost))
+	svc.SetConnectionDetail("MARIADB_URL", []byte(mariadbURL))
+
+	return svc.SetDesiredKubeObject(&service, comp.GetName()+"-main-service")
+}
+
+func getMariaDBRootPassword(secretName string, svc *runtime.ServiceRuntime) ([]byte, error) {
+	secret := &corev1.Secret{}
+
+	err := svc.GetObservedKubeObject(secret, secretName)
+
+	if err != nil {
+		if err == runtime.ErrNotFound {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return secret.Data["mariadb-root-password"], nil
 }

--- a/pkg/comp-functions/functions/vshnmariadb/mariadb_deploy_test.go
+++ b/pkg/comp-functions/functions/vshnmariadb/mariadb_deploy_test.go
@@ -22,9 +22,9 @@ func TestMariadbDeploy(t *testing.T) {
 
 	rootUser := "root"
 	rootPassword := "mariadb123"
-	mariadbHost := "mariadb-gc9x4.vshn-mariadb-mariadb-gc9x4.svc.cluster.local"
+	mariadbHost := "mariadb.vshn-mariadb-mariadb-gc9x4.svc.cluster.local"
 	mariadbPort := "3306"
-	mariadbUrl := "mysql://root:mariadb123@mariadb-gc9x4.vshn-mariadb-mariadb-gc9x4.svc.cluster.local:3306"
+	mariadbUrl := "mysql://root:mariadb123@mariadb.vshn-mariadb-mariadb-gc9x4.svc.cluster.local:3306"
 
 	assert.Nil(t, DeployMariadb(ctx, &vshnv1.VSHNMariaDB{}, svc))
 

--- a/pkg/comp-functions/functions/vshnmariadb/proxysql.go
+++ b/pkg/comp-functions/functions/vshnmariadb/proxysql.go
@@ -1,0 +1,470 @@
+package vshnmariadb
+
+import (
+	"bytes"
+	"context"
+	"crypto/md5"
+	"encoding/hex"
+	"fmt"
+	"sort"
+	"text/template"
+
+	_ "embed"
+
+	xfnproto "github.com/crossplane/function-sdk-go/proto/v1beta1"
+	"github.com/vshn/appcat/v4/apis/kubernetes/v1alpha2"
+	vshnv1 "github.com/vshn/appcat/v4/apis/vshn/v1"
+	"github.com/vshn/appcat/v4/pkg/comp-functions/runtime"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	pdbv1 "k8s.io/api/policy/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
+)
+
+//go:embed files/proxysql.conf.tmpl
+var configTmpl string
+
+var (
+	labels = map[string]string{
+		"app": "proxysql",
+	}
+)
+
+type proxySQLConfigParams struct {
+	CompName     string
+	RootPassword string
+	Namespace    string
+	TLS          int
+	Users        []proxySQLUsers
+}
+
+type proxySQLUsers struct {
+	Name     string
+	Password string
+}
+
+// AddProxySQL will add a ProxySQL cluster to the service, if instances > 1.
+// This function also creates a main service, which should always be used to connect from the outside.
+// This service is necessary to seamlessly scale up and down without changing the IP address.
+func AddProxySQL(_ context.Context, comp *vshnv1.VSHNMariaDB, svc *runtime.ServiceRuntime) *xfnproto.Result {
+
+	err := svc.GetDesiredComposite(comp)
+	if err != nil {
+		return runtime.NewFatalResult(fmt.Errorf("cannot get mariadb composite: %s", err))
+	}
+
+	disableProtection := comp.Status.CurrentInstances != 0 && comp.GetInstances() != comp.Status.CurrentInstances
+
+	if comp.GetInstances() == 1 && !disableProtection {
+		// nothing else to do here
+		return nil
+	}
+
+	comp.Status.CurrentInstances = comp.GetInstances()
+
+	// ProxySQL expects the certificates to have specific names...
+	svc.Log.Info("Copying certificate secret")
+	err = copyCertificateSecret(comp, svc, "tls-server-certificate", disableProtection)
+	if err != nil {
+		return runtime.NewWarningResult(fmt.Sprintf("cannot rename secret fields: %s", err))
+	}
+
+	svc.Log.Info("Creating config for proxySQL")
+	configHash, err := createProxySQLConfig(comp, svc, disableProtection)
+	if err != nil {
+		return runtime.NewWarningResult(fmt.Sprintf("cannot create config: %s", err))
+	}
+
+	svc.Log.Info("Creating headless service for proxySQL")
+	err = createProxySQLHeadlessService(comp, svc, disableProtection)
+	if err != nil {
+		return runtime.NewWarningResult(fmt.Sprintf("cannot create headless service: %s", err))
+	}
+
+	svc.Log.Info("Creating statefulset for proxySQL")
+	err = createProxySQLStatefulset(comp, svc, configHash, disableProtection)
+	if err != nil {
+		return runtime.NewWarningResult(fmt.Sprintf("cannot create statefulset: %s", err))
+	}
+
+	svc.Log.Info("Creating pdb for proxysql")
+	err = createProxySQLPDB(comp, svc, disableProtection)
+	if err != nil {
+		return runtime.NewWarningResult(fmt.Sprintf("cannot create PDB for ProxySQL: %s", err))
+	}
+
+	svc.Log.Info("Updating composite status")
+	err = svc.SetDesiredCompositeStatus(comp)
+	if err != nil {
+		return runtime.NewWarningResult(fmt.Sprintf("cannot set mariadb composite status: %s", err))
+	}
+
+	return nil
+}
+
+func createProxySQLConfig(comp *vshnv1.VSHNMariaDB, svc *runtime.ServiceRuntime, disableProtection bool) (string, error) {
+
+	cd := svc.GetConnectionDetails()
+
+	userList, err := getUserList(comp, svc)
+	if err != nil {
+		return "", err
+	}
+
+	tls := 1
+	if !comp.Spec.Parameters.TLS.TLSEnabled {
+		tls = 0
+	}
+
+	confParams := proxySQLConfigParams{
+		CompName:     comp.GetName(),
+		RootPassword: string(cd["MARIADB_PASSWORD"]),
+		Namespace:    comp.GetInstanceNamespace(),
+		Users:        userList,
+		TLS:          tls,
+	}
+
+	var buf bytes.Buffer
+	tmpl, err := template.New("ProxySQLConfig").Parse(configTmpl)
+	if err != nil {
+		return "", err
+	}
+
+	err = tmpl.Execute(&buf, confParams)
+	if err != nil {
+		return "", err
+	}
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "proxysql-config",
+			Namespace: comp.GetInstanceNamespace(),
+		},
+		// We have to use stringdata here. For some reason, when using data, it
+		// won't update the value reliably...
+		StringData: map[string]string{
+			"proxysql.cnf": buf.String(),
+		},
+	}
+
+	hash := md5.Sum(buf.Bytes())
+
+	opts := []runtime.KubeObjectOption{}
+
+	if disableProtection {
+		opts = append(opts, runtime.KubeOptionAllowDeletion)
+	}
+
+	return hex.EncodeToString(hash[:]), svc.SetDesiredKubeObject(secret, comp.GetName()+"-proxySQL-config", opts...)
+}
+
+func getUserList(comp *vshnv1.VSHNMariaDB, svc *runtime.ServiceRuntime) ([]proxySQLUsers, error) {
+	users := []proxySQLUsers{}
+	userMap := map[string]string{}
+
+	for _, access := range comp.Spec.Parameters.Service.Access {
+		userCD, err := svc.GetObservedComposedResourceConnectionDetails(comp.GetName() + "-userpass-" + *access.User)
+		if err != nil {
+			if err == runtime.ErrNotFound {
+				return users, nil
+			}
+			return users, err
+		}
+		userMap[*access.User] = string(userCD["userpass"])
+	}
+
+	for k, v := range userMap {
+		users = append(users, proxySQLUsers{
+			Name:     k,
+			Password: v,
+		})
+	}
+
+	// Maps are not sorted and return a random order every time
+	// To avoid restarts on every reconcile due to order changes, we sort the slice
+	sort.Slice(users, func(i, j int) bool {
+		return users[i].Name < users[j].Name
+	})
+
+	return users, nil
+}
+
+func createProxySQLHeadlessService(comp *vshnv1.VSHNMariaDB, svc *runtime.ServiceRuntime, disableProtection bool) error {
+	service := corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "proxysqlcluster",
+			Namespace: comp.GetInstanceNamespace(),
+		},
+		Spec: corev1.ServiceSpec{
+			ClusterIP: "None",
+			Ports: []corev1.ServicePort{
+				{
+					Port: 6032,
+					Name: "proxysql-admin",
+				},
+			},
+			Selector: map[string]string{
+				"app": "proxysql",
+			},
+		},
+	}
+
+	opts := []runtime.KubeObjectOption{}
+
+	if disableProtection {
+		opts = append(opts, runtime.KubeOptionAllowDeletion)
+	}
+
+	return svc.SetDesiredKubeObject(&service, comp.GetName()+"-proxysql-headless-service", opts...)
+}
+
+func createProxySQLStatefulset(comp *vshnv1.VSHNMariaDB, svc *runtime.ServiceRuntime, configHash string, disableProtection bool) error {
+
+	cpuLimit := svc.Config.Data["proxysqlCPULimit"]
+	if cpuLimit == "" {
+		cpuLimit = "500m"
+	}
+
+	memoryLimit := svc.Config.Data["proxysqlMemoryLimit"]
+	if memoryLimit == "" {
+		memoryLimit = "256Mi"
+	}
+
+	cpuRequests := svc.Config.Data["proxysqlCPURequests"]
+	if cpuRequests == "" {
+		cpuRequests = "50m"
+	}
+
+	memoryRequests := svc.Config.Data["proxysqlMemoryRequests"]
+	if memoryRequests == "" {
+		memoryRequests = "64Mi"
+	}
+
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "proxysql",
+			Namespace: comp.GetInstanceNamespace(),
+			Labels:    labels,
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas:    ptr.To[int32](2),
+			ServiceName: "proxysqlcluster",
+			Selector: &metav1.LabelSelector{
+				MatchLabels: labels,
+			},
+			UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
+				Type: appsv1.RollingUpdateStatefulSetStrategyType,
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: labels,
+					Annotations: map[string]string{
+						"configHash": configHash,
+					},
+				},
+				Spec: corev1.PodSpec{
+					RestartPolicy: corev1.RestartPolicyAlways,
+					Affinity: &corev1.Affinity{
+						PodAntiAffinity: &corev1.PodAntiAffinity{
+							PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
+								{
+									PodAffinityTerm: corev1.PodAffinityTerm{
+										LabelSelector: &metav1.LabelSelector{
+											MatchLabels: labels,
+										},
+										TopologyKey: "kubernetes.io/hostname",
+									},
+									Weight: 1,
+								},
+							},
+						},
+					},
+					Containers: []corev1.Container{
+						{
+							Image: svc.Config.Data["proxysqlImage"],
+							Name:  "proxysql",
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse(cpuLimit),
+									corev1.ResourceMemory: resource.MustParse(memoryLimit),
+								},
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse(cpuRequests),
+									corev1.ResourceMemory: resource.MustParse(memoryRequests),
+								},
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "proxysql-config",
+									MountPath: "/etc/proxysql.cnf",
+									SubPath:   "proxysql.cnf",
+								},
+								{
+									Name:      "proxysql-emptydir",
+									MountPath: "/var/lib/proxysql",
+								},
+							},
+							Ports: []corev1.ContainerPort{
+								{
+									ContainerPort: 6033,
+									Name:          "proxysql-mysql",
+								},
+								{
+									ContainerPort: 6032,
+									Name:          "proxysql-admin",
+								},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "proxysql-config",
+							VolumeSource: corev1.VolumeSource{
+								Secret: &corev1.SecretVolumeSource{
+									SecretName: "proxysql-config",
+								},
+							},
+						},
+						{
+							Name: "proxysql-emptydir",
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if comp.Spec.Parameters.TLS.TLSEnabled {
+		sts.Spec.Template.Spec.Volumes = append(sts.Spec.Template.Spec.Volumes, corev1.Volume{
+			Name: "tls-config",
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: "proxysql-certs",
+				},
+			},
+		})
+
+		sts.Spec.Template.Spec.Containers[0].VolumeMounts = append(sts.Spec.Template.Spec.Containers[0].VolumeMounts,
+			corev1.VolumeMount{
+				Name:      "tls-config",
+				MountPath: "/var/lib/proxysql/proxysql-ca.pem",
+				SubPath:   "proxysql-ca.pem",
+			},
+			corev1.VolumeMount{
+				Name:      "tls-config",
+				MountPath: "/var/lib/proxysql/proxysql-cert.pem",
+				SubPath:   "proxysql-cert.pem",
+			},
+			corev1.VolumeMount{
+				Name:      "tls-config",
+				MountPath: "/var/lib/proxysql/proxysql-key.pem",
+				SubPath:   "proxysql-key.pem",
+			})
+	}
+
+	opts := []runtime.KubeObjectOption{}
+
+	if disableProtection {
+		opts = append(opts, runtime.KubeOptionAllowDeletion)
+	}
+
+	return svc.SetDesiredKubeObject(sts, comp.GetName()+"-proxysql-sts", opts...)
+}
+
+func copyCertificateSecret(comp *vshnv1.VSHNMariaDB, svc *runtime.ServiceRuntime, certSecretName string, disableProtection bool) error {
+	if !comp.Spec.Parameters.TLS.TLSEnabled {
+		return nil
+	}
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "proxysql-certs",
+			Namespace: comp.GetInstanceNamespace(),
+		},
+	}
+
+	refs := []v1alpha2.Reference{
+		{
+			PatchesFrom: &v1alpha2.PatchesFrom{
+				DependsOn: v1alpha2.DependsOn{
+					APIVersion: "v1",
+					Kind:       "Secret",
+					Name:       certSecretName,
+					Namespace:  comp.GetInstanceNamespace(),
+				},
+				FieldPath: ptr.To("data[ca.crt]"),
+			},
+			ToFieldPath: ptr.To("data[proxysql-ca.pem]"),
+		},
+		{
+			PatchesFrom: &v1alpha2.PatchesFrom{
+				DependsOn: v1alpha2.DependsOn{
+					APIVersion: "v1",
+					Kind:       "Secret",
+					Name:       certSecretName,
+					Namespace:  comp.GetInstanceNamespace(),
+				},
+				FieldPath: ptr.To("data[tls.crt]"),
+			},
+			ToFieldPath: ptr.To("data[proxysql-cert.pem]"),
+		},
+		{
+			PatchesFrom: &v1alpha2.PatchesFrom{
+				DependsOn: v1alpha2.DependsOn{
+					APIVersion: "v1",
+					Kind:       "Secret",
+					Name:       certSecretName,
+					Namespace:  comp.GetInstanceNamespace(),
+				},
+				FieldPath: ptr.To("data[tls.key]"),
+			},
+			ToFieldPath: ptr.To("data[proxysql-key.pem]"),
+		},
+	}
+
+	opts := []runtime.KubeObjectOption{
+		runtime.KubeOptionAddRefs(refs...),
+	}
+
+	if disableProtection {
+		opts = append(opts, runtime.KubeOptionAllowDeletion)
+	}
+
+	return svc.SetDesiredKubeObject(secret, comp.GetName()+"-proxysql-specific-certs", opts...)
+}
+
+func createProxySQLPDB(comp *vshnv1.VSHNMariaDB, svc *runtime.ServiceRuntime, disableProtection bool) error {
+	min := intstr.IntOrString{StrVal: "50%", Type: intstr.String}
+
+	pdb := &pdbv1.PodDisruptionBudget{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      comp.GetName() + "-proxysql-pdb",
+			Namespace: comp.GetInstanceNamespace(),
+		},
+		Spec: pdbv1.PodDisruptionBudgetSpec{
+			MinAvailable: &min,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: labels,
+			},
+		},
+	}
+
+	opts := []runtime.KubeObjectOption{}
+
+	if disableProtection {
+		opts = append(opts, runtime.KubeOptionAllowDeletion)
+	}
+
+	err := svc.SetDesiredKubeObject(pdb, comp.GetName()+"-proxysql-pdb", opts...)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/comp-functions/functions/vshnmariadb/proxysql_test.go
+++ b/pkg/comp-functions/functions/vshnmariadb/proxysql_test.go
@@ -1,0 +1,115 @@
+package vshnmariadb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	xkubev1 "github.com/vshn/appcat/v4/apis/kubernetes/v1alpha2"
+	vshnv1 "github.com/vshn/appcat/v4/apis/vshn/v1"
+	"github.com/vshn/appcat/v4/pkg/comp-functions/functions/commontest"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	pdbv1 "k8s.io/api/policy/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func getComp() *vshnv1.VSHNMariaDB {
+	return &vshnv1.VSHNMariaDB{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "myinstance",
+		},
+		Spec: vshnv1.VSHNMariaDBSpec{
+			Parameters: vshnv1.VSHNMariaDBParameters{
+				TLS: vshnv1.VSHNMariaDBTLSSpec{
+					TLSEnabled: true,
+				},
+			},
+		},
+	}
+}
+
+func Test_copyCertificateSecret(t *testing.T) {
+	svc := commontest.LoadRuntimeFromFile(t, "empty.yaml")
+
+	// Given TLS
+	comp := getComp()
+
+	// When applied
+	assert.NoError(t, copyCertificateSecret(comp, svc, "test", false))
+	obj := &xkubev1.Object{}
+	//Then expect secret
+	assert.NoError(t, svc.GetDesiredComposedResourceByName(obj, comp.GetName()+"-proxysql-specific-certs"))
+
+	svc = commontest.LoadRuntimeFromFile(t, "empty.yaml")
+	// Given no TLS
+	comp.Spec.Parameters.TLS.TLSEnabled = false
+	// When applied
+	assert.NoError(t, copyCertificateSecret(comp, svc, "test", false))
+	//Then expect no secret
+	assert.Error(t, svc.GetDesiredComposedResourceByName(obj, comp.GetName()+"-proxysql-specific-certs"))
+}
+
+func Test_createProxySQLConfig(t *testing.T) {
+	svc := commontest.LoadRuntimeFromFile(t, "empty.yaml")
+	comp := getComp()
+
+	expectedHash := "56e11403faab20eb54184eccef557c85"
+
+	hash, err := createProxySQLConfig(comp, svc, false)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedHash, hash)
+
+	comp.Spec.Parameters.TLS.TLSEnabled = false
+
+	hash, err = createProxySQLConfig(comp, svc, false)
+	assert.NoError(t, err)
+	assert.NotEqual(t, expectedHash, hash)
+}
+
+func Test_createProxySQLHeadlessService(t *testing.T) {
+	svc := commontest.LoadRuntimeFromFile(t, "empty.yaml")
+	comp := getComp()
+
+	assert.NoError(t, createProxySQLHeadlessService(comp, svc, false))
+
+	service := &corev1.Service{}
+	assert.NoError(t, svc.GetDesiredKubeObject(service, comp.GetName()+"-proxysql-headless-service"))
+}
+
+func Test_createProxySQLStatefulset(t *testing.T) {
+	svc := commontest.LoadRuntimeFromFile(t, "empty.yaml")
+	comp := getComp()
+
+	// given TLS enabled
+	assert.NoError(t, createProxySQLStatefulset(comp, svc, "1", false))
+
+	sts := &appsv1.StatefulSet{}
+	assert.NoError(t, svc.GetDesiredKubeObject(sts, comp.GetName()+"-proxysql-sts"))
+
+	// Then expect cert mounts
+	assert.Len(t, sts.Spec.Template.Spec.Containers[0].VolumeMounts, 5)
+	assert.Len(t, sts.Spec.Template.Spec.Volumes, 3)
+
+	comp.Spec.Parameters.TLS.TLSEnabled = false
+
+	// given TLS disabled
+	assert.NoError(t, createProxySQLStatefulset(comp, svc, "1", false))
+
+	sts = &appsv1.StatefulSet{}
+	assert.NoError(t, svc.GetDesiredKubeObject(sts, comp.GetName()+"-proxysql-sts"))
+
+	// Then expect no cert mounts
+	assert.Len(t, sts.Spec.Template.Spec.Containers[0].VolumeMounts, 2)
+	assert.Len(t, sts.Spec.Template.Spec.Volumes, 2)
+}
+
+func Test_createProxySQLPDB(t *testing.T) {
+	svc := commontest.LoadRuntimeFromFile(t, "empty.yaml")
+	comp := getComp()
+
+	assert.NoError(t, createProxySQLPDB(comp, svc, false))
+
+	pdb := &pdbv1.PodDisruptionBudget{}
+
+	assert.NoError(t, svc.GetDesiredKubeObject(pdb, comp.GetName()+"-proxysql-pdb"))
+}

--- a/pkg/comp-functions/functions/vshnmariadb/register.go
+++ b/pkg/comp-functions/functions/vshnmariadb/register.go
@@ -43,6 +43,10 @@ func init() {
 				Name:    "user-management",
 				Execute: UserManagement,
 			},
+			{
+				Name:    "proxySQL",
+				Execute: AddProxySQL,
+			},
 		},
 	})
 }

--- a/pkg/comp-functions/runtime/function_mgr.go
+++ b/pkg/comp-functions/runtime/function_mgr.go
@@ -482,6 +482,14 @@ func KubeOptionAddRefs(refs ...xkube.Reference) KubeObjectOption {
 	}
 }
 
+// KubeOptionAllowDeletion adds the allow deletion label to the object
+func KubeOptionAllowDeletion(obj *xkube.Object) {
+	if obj.ObjectMeta.Labels == nil {
+		obj.ObjectMeta.Labels = map[string]string{}
+	}
+	obj.ObjectMeta.Labels[WebhookAllowDeletionLabel] = "true"
+}
+
 // KubeOptionAddConnectionDetails adds the given connection details to the kube object.
 // DestNamespace speficies the namespace where the associated secret should be saved.
 // The associated secret will have the UID of the parent object as the name.
@@ -667,7 +675,8 @@ func (s *ServiceRuntime) SetDesiredCompositeStatus(obj client.Object) error {
 		return err
 	}
 
-	err = mergo.Merge(&s.desiredComposite.Unstructured, tmp.Unstructured)
+	// Mergo won't update fields without override
+	err = mergo.Merge(&s.desiredComposite.Unstructured, tmp.Unstructured, mergo.WithOverride)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/webhooks/mariadb.go
+++ b/pkg/controller/webhooks/mariadb.go
@@ -1,10 +1,15 @@
 package webhooks
 
 import (
+	"context"
+	"fmt"
+
 	vshnv1 "github.com/vshn/appcat/v4/apis/vshn/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
 //+kubebuilder:webhook:verbs=create;update;delete,path=/validate-vshn-appcat-vshn-io-v1-vshnmariadb,mutating=false,failurePolicy=fail,groups=vshn.appcat.vshn.io,resources=vshnmariadbs,versions=v1,name=vshnmariadb.vshn.appcat.vshn.io,sideEffects=None,admissionReviewVersions=v1
@@ -40,4 +45,24 @@ func SetupMariaDBWebhookHandlerWithManager(mgr ctrl.Manager, withQuota bool) err
 			),
 		}).
 		Complete()
+}
+
+// ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type
+func (p *MariaDBWebhookHandler) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
+	oldDb, ok := oldObj.(*vshnv1.VSHNMariaDB)
+	if !ok {
+		return nil, fmt.Errorf("not a valid vshnmariadb object")
+	}
+	newDb := newObj.(*vshnv1.VSHNMariaDB)
+	if !ok {
+		return nil, fmt.Errorf("not a valid vshnmariadb object")
+	}
+
+	if newDb.Spec.Parameters.Instances > 1 {
+		if oldDb.Spec.Parameters.TLS.TLSEnabled != newDb.Spec.Parameters.TLS.TLSEnabled {
+			return nil, fmt.Errorf("cannot change TLS if there are more than 1 instances. Please set .spec.parameters.instances to 1 to change the TLS settings")
+		}
+	}
+
+	return p.DefaultWebhookHandler.ValidateUpdate(ctx, oldObj, newObj)
 }


### PR DESCRIPTION
## Summary

With this MariaDB can scale to a 3 node Galera cluster.
    
* Added ProxySQl statefulset
* Updated default version of MariaDB
* Updated Galera helm chart
* Added sensible PDBs to ProxySQL
## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
