### PR TITLE
Add possibility to run MariaDB without TLS

### DIFF
--- a/pkg/comp-functions/functions/vshnmariadb/mariadb_deploy.go
+++ b/pkg/comp-functions/functions/vshnmariadb/mariadb_deploy.go
@@ -176,7 +176,7 @@ func newValues(ctx context.Context, svc *runtime.ServiceRuntime, comp *vshnv1.VS
 			"enabled": false,
 		},
 		"tls": map[string]interface{}{
-			"enabled":            true,
+			"enabled":            comp.Spec.Parameters.TLS.TLSEnabled,
 			"certificatesSecret": "tls-server-certificate",
 			"certFilename":       "tls.crt",
 			"certKeyFilename":    "tls.key",


### PR DESCRIPTION
## Summary

* Passing through parameter from claim to helm release

FYI: 
- SLI prober works with this change out of the box - tested in kind and lab