### PR TITLE
Fix pg config

### DIFF
--- a/pkg/comp-functions/functions/vshnkeycloak/billing.go
+++ b/pkg/comp-functions/functions/vshnkeycloak/billing.go
@@ -9,8 +9,8 @@ import (
 	"github.com/vshn/appcat/v4/pkg/comp-functions/runtime"
 )
 
-// AddServiceBillingLabel adds billingLabel to all the objects of a services that must be billed
-func AddServiceBillingLabel(ctx context.Context, comp *v1.VSHNKeycloak, svc *runtime.ServiceRuntime) *xfnproto.Result {
+// AddBilling enables billing for this service
+func AddBilling(ctx context.Context, comp *v1.VSHNKeycloak, svc *runtime.ServiceRuntime) *xfnproto.Result {
 	err := svc.GetObservedComposite(comp)
 	if err != nil {
 		return runtime.NewFatalResult(fmt.Errorf("can't get composite: %w", err))

--- a/pkg/comp-functions/functions/vshnkeycloak/register.go
+++ b/pkg/comp-functions/functions/vshnkeycloak/register.go
@@ -41,7 +41,7 @@ func init() {
 			},
 			{
 				Name:    "billing",
-				Execute: AddServiceBillingLabel,
+				Execute: AddBilling,
 			},
 		},
 	})

--- a/pkg/comp-functions/functions/vshnmariadb/billing.go
+++ b/pkg/comp-functions/functions/vshnmariadb/billing.go
@@ -9,8 +9,8 @@ import (
 	"github.com/vshn/appcat/v4/pkg/comp-functions/runtime"
 )
 
-// AddServiceBillingLabel adds billingLabel to all the objects of a services that must be billed
-func AddServiceBillingLabel(ctx context.Context, comp *v1.VSHNMariaDB, svc *runtime.ServiceRuntime) *xfnproto.Result {
+// AddBilling enables billing for this service
+func AddBilling(ctx context.Context, comp *v1.VSHNMariaDB, svc *runtime.ServiceRuntime) *xfnproto.Result {
 	err := svc.GetObservedComposite(comp)
 	if err != nil {
 		return runtime.NewFatalResult(fmt.Errorf("can't get composite: %w", err))

--- a/pkg/comp-functions/functions/vshnmariadb/register.go
+++ b/pkg/comp-functions/functions/vshnmariadb/register.go
@@ -37,7 +37,7 @@ func init() {
 			},
 			{
 				Name:    "billing",
-				Execute: AddServiceBillingLabel,
+				Execute: AddBilling,
 			},
 			{
 				Name:    "user-management",

--- a/pkg/comp-functions/functions/vshnminio/billing.go
+++ b/pkg/comp-functions/functions/vshnminio/billing.go
@@ -9,8 +9,8 @@ import (
 	"github.com/vshn/appcat/v4/pkg/comp-functions/runtime"
 )
 
-// AddServiceBillingLabel adds billingLabel to all the objects of a services that must be billed
-func AddServiceBillingLabel(ctx context.Context, comp *v1.VSHNMinio, svc *runtime.ServiceRuntime) *xfnproto.Result {
+// AddBilling enables billing for this service
+func AddBilling(ctx context.Context, comp *v1.VSHNMinio, svc *runtime.ServiceRuntime) *xfnproto.Result {
 	err := svc.GetObservedComposite(comp)
 	if err != nil {
 		return runtime.NewFatalResult(fmt.Errorf("can't get composite: %w", err))

--- a/pkg/comp-functions/functions/vshnminio/register.go
+++ b/pkg/comp-functions/functions/vshnminio/register.go
@@ -45,7 +45,7 @@ func init() {
 			},
 			{
 				Name:    "billing",
-				Execute: AddServiceBillingLabel,
+				Execute: AddBilling,
 			},
 		},
 	})

--- a/pkg/comp-functions/functions/vshnnextcloud/billing.go
+++ b/pkg/comp-functions/functions/vshnnextcloud/billing.go
@@ -9,8 +9,8 @@ import (
 	"github.com/vshn/appcat/v4/pkg/comp-functions/runtime"
 )
 
-// AddServiceBillingLabel adds billingLabel to all the objects of a services that must be billed
-func AddServiceBillingLabel(ctx context.Context, comp *v1.VSHNNextcloud, svc *runtime.ServiceRuntime) *xfnproto.Result {
+// AddBilling enables billing for this service
+func AddBilling(ctx context.Context, comp *v1.VSHNNextcloud, svc *runtime.ServiceRuntime) *xfnproto.Result {
 
 	err := svc.GetObservedComposite(comp)
 	if err != nil {

--- a/pkg/comp-functions/functions/vshnnextcloud/register.go
+++ b/pkg/comp-functions/functions/vshnnextcloud/register.go
@@ -27,7 +27,7 @@ func init() {
 			},
 			{
 				Name:    "billing",
-				Execute: AddServiceBillingLabel,
+				Execute: AddBilling,
 			},
 		},
 	})

--- a/pkg/comp-functions/functions/vshnpostgres/billing.go
+++ b/pkg/comp-functions/functions/vshnpostgres/billing.go
@@ -9,8 +9,8 @@ import (
 	"github.com/vshn/appcat/v4/pkg/comp-functions/runtime"
 )
 
-// AddServiceBillingLabel adds billingLabel to all the objects of a services that must be billed
-func AddServiceBillingLabel(ctx context.Context, comp *v1.VSHNPostgreSQL, svc *runtime.ServiceRuntime) *xfnproto.Result {
+// AddBilling enables billing for this service
+func AddBilling(ctx context.Context, comp *v1.VSHNPostgreSQL, svc *runtime.ServiceRuntime) *xfnproto.Result {
 	err := svc.GetObservedComposite(comp)
 	if err != nil {
 		return runtime.NewFatalResult(fmt.Errorf("can't get composite: %w", err))

--- a/pkg/comp-functions/functions/vshnpostgres/extensions.go
+++ b/pkg/comp-functions/functions/vshnpostgres/extensions.go
@@ -52,7 +52,7 @@ func AddExtensions(ctx context.Context, comp *vshnv1.VSHNPostgreSQL, svc *runtim
 			return runtime.NewFatalResult(fmt.Errorf("cannot add timescaldb to config: %w", err))
 		}
 	} else {
-		err := disableTimescaleDB(ctx, svc)
+		err := disableTimescaleDB(ctx, svc, comp.GetName())
 		if err != nil {
 			return runtime.NewFatalResult(fmt.Errorf("cannot ensure timescaldb absent from config: %w", err))
 		}
@@ -105,10 +105,10 @@ func enableTimescaleDB(ctx context.Context, svc *runtime.ServiceRuntime, name st
 		config.Spec.PostgresqlConf[sharedLibraries] = fmt.Sprintf("%s,%s", toAppend, timescaleExtName)
 	}
 
-	return svc.SetDesiredKubeObjectWithName(config, name+"-"+configResourceName, configResourceName)
+	return svc.SetDesiredKubeObject(config, name+"-"+configResourceName)
 }
 
-func disableTimescaleDB(ctx context.Context, svc *runtime.ServiceRuntime) error {
+func disableTimescaleDB(ctx context.Context, svc *runtime.ServiceRuntime, name string) error {
 
 	config := &stackgresv1.SGPostgresConfig{}
 
@@ -135,5 +135,5 @@ func disableTimescaleDB(ctx context.Context, svc *runtime.ServiceRuntime) error 
 
 	config.Spec.PostgresqlConf[sharedLibraries] = strings.Join(finalElements, ", ")
 
-	return svc.SetDesiredKubeObject(config, configResourceName)
+	return svc.SetDesiredKubeObject(config, name+"-"+configResourceName)
 }

--- a/pkg/comp-functions/functions/vshnpostgres/extensions_test.go
+++ b/pkg/comp-functions/functions/vshnpostgres/extensions_test.go
@@ -50,7 +50,7 @@ func Test_enableTimescaleDB(t *testing.T) {
 
 		config := &stackgresv1.SGPostgresConfig{}
 
-		assert.NoError(t, svc.GetDesiredKubeObject(config, configResourceName))
+		assert.NoError(t, svc.GetDesiredKubeObject(config, comp.GetName()+"-"+configResourceName))
 
 		assert.Contains(t, config.Spec.PostgresqlConf[sharedLibraries], timescaleExtName)
 
@@ -81,7 +81,7 @@ func Test_disableTimescaleDB(t *testing.T) {
 		svc := commontest.LoadRuntimeFromFile(t, tt.iofFile)
 
 		t.Run(tt.name, func(t *testing.T) {
-			if err := disableTimescaleDB(ctx, svc); (err != nil) != tt.wantErr {
+			if err := disableTimescaleDB(ctx, svc, configResourceName); (err != nil) != tt.wantErr {
 				t.Errorf("disableTimescaleDB() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/pkg/comp-functions/functions/vshnpostgres/postgresql_deploy.go
+++ b/pkg/comp-functions/functions/vshnpostgres/postgresql_deploy.go
@@ -334,7 +334,7 @@ func createSgPostgresConfig(comp *vshnv1.VSHNPostgreSQL, svc *runtime.ServiceRun
 		},
 	}
 
-	err := svc.SetDesiredKubeObjectWithName(sgPostgresConfig, comp.GetName()+"-pgconf", "pg-conf")
+	err := svc.SetDesiredKubeObject(sgPostgresConfig, comp.GetName()+"-"+configResourceName)
 	if err != nil {
 		err = fmt.Errorf("cannot create sgInstanceProfile: %w", err)
 		return err

--- a/pkg/comp-functions/functions/vshnpostgres/postgresql_deploy_test.go
+++ b/pkg/comp-functions/functions/vshnpostgres/postgresql_deploy_test.go
@@ -82,7 +82,7 @@ func TestPostgreSqlDeploy(t *testing.T) {
 	assert.Nil(t, sgInstanceProfile.Spec.HugePages)
 
 	sgPostgresConfig := &sgv1.SGPostgresConfig{}
-	assert.NoError(t, svc.GetDesiredKubeObject(sgPostgresConfig, "pg-conf"))
+	assert.NoError(t, svc.GetDesiredKubeObject(sgPostgresConfig, comp.GetName()+"-"+configResourceName))
 	assert.Equal(t, comp.Spec.Parameters.Service.MajorVersion, sgPostgresConfig.Spec.PostgresVersion)
 	assert.Equal(t, map[string]string{}, sgPostgresConfig.Spec.PostgresqlConf)
 
@@ -113,7 +113,7 @@ func TestPostgreSqlDeployWithPgConfig(t *testing.T) {
 	assert.NoError(t, svc.GetDesiredKubeObject(cluster, "cluster"))
 
 	sgPostgresConfig := &sgv1.SGPostgresConfig{}
-	assert.NoError(t, svc.GetDesiredKubeObject(sgPostgresConfig, "pg-conf"))
+	assert.NoError(t, svc.GetDesiredKubeObject(sgPostgresConfig, "pgsql-gc9x4-"+configResourceName))
 	assert.Contains(t, sgPostgresConfig.Spec.PostgresqlConf, "timezone")
 	assert.Equal(t, "Europe/Zurich", sgPostgresConfig.Spec.PostgresqlConf["timezone"])
 }

--- a/pkg/comp-functions/functions/vshnpostgres/register.go
+++ b/pkg/comp-functions/functions/vshnpostgres/register.go
@@ -79,7 +79,7 @@ func init() {
 			},
 			{
 				Name:    "billing",
-				Execute: AddServiceBillingLabel,
+				Execute: AddBilling,
 			},
 		},
 	})

--- a/pkg/comp-functions/functions/vshnredis/billing.go
+++ b/pkg/comp-functions/functions/vshnredis/billing.go
@@ -9,8 +9,8 @@ import (
 	"github.com/vshn/appcat/v4/pkg/comp-functions/runtime"
 )
 
-// AddServiceBillingLabel adds billingLabel to all the objects of a services that must be billed
-func AddServiceBillingLabel(ctx context.Context, comp *v1.VSHNRedis, svc *runtime.ServiceRuntime) *xfnproto.Result {
+// AddBilling enables billing for this service
+func AddBilling(ctx context.Context, comp *v1.VSHNRedis, svc *runtime.ServiceRuntime) *xfnproto.Result {
 	err := svc.GetObservedComposite(comp)
 	if err != nil {
 		return runtime.NewFatalResult(fmt.Errorf("can't get composite: %w", err))

--- a/pkg/comp-functions/functions/vshnredis/register.go
+++ b/pkg/comp-functions/functions/vshnredis/register.go
@@ -52,7 +52,7 @@ func init() {
 			},
 			{
 				Name:    "billing",
-				Execute: AddServiceBillingLabel,
+				Execute: AddBilling,
 			},
 		},
 	})


### PR DESCRIPTION
## Summary

* Seems like we are creating a pg-config object for all instances in a cluster. To resolve this issue we change the name in the desired object.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
