### PR TITLE
Fix pg-conf naming issues

### DIFF
--- a/pkg/comp-functions/functions/vshnpostgres/delay_cluster.go
+++ b/pkg/comp-functions/functions/vshnpostgres/delay_cluster.go
@@ -48,7 +48,7 @@ func DelayClusterDeployment(_ context.Context, comp *vshnv1.VSHNPostgreSQL, svc 
 		return runtime.NewWarningResult("SGObjectStorage is not yet ready, skipping creation of cluster")
 	}
 
-	if !kubeObjectSyncedAndReady("pg-conf", svc) {
+	if !kubeObjectSyncedAndReady(comp.GetName()+"-"+configResourceName, svc) {
 		return runtime.NewWarningResult("SGPostgresConfig is not yet ready, skipping creation of cluster")
 	}
 

--- a/pkg/comp-functions/functions/vshnpostgres/extensions.go
+++ b/pkg/comp-functions/functions/vshnpostgres/extensions.go
@@ -88,7 +88,7 @@ func enableTimescaleDB(ctx context.Context, svc *runtime.ServiceRuntime, name st
 
 	config := &stackgresv1.SGPostgresConfig{}
 
-	err := svc.GetDesiredKubeObject(config, configResourceName)
+	err := svc.GetDesiredKubeObject(config, name+"-"+configResourceName)
 	if err != nil && err == runtime.ErrNotFound {
 		controllerruntime.LoggerFrom(ctx).Info("no pg-conf found")
 		return nil
@@ -112,7 +112,7 @@ func disableTimescaleDB(ctx context.Context, svc *runtime.ServiceRuntime, name s
 
 	config := &stackgresv1.SGPostgresConfig{}
 
-	err := svc.GetDesiredKubeObject(config, configResourceName)
+	err := svc.GetDesiredKubeObject(config, name+"-"+configResourceName)
 	if err != nil && err == runtime.ErrNotFound {
 		controllerruntime.LoggerFrom(ctx).Info("no pg-conf found")
 		return nil

--- a/pkg/comp-functions/functions/vshnpostgres/extensions_test.go
+++ b/pkg/comp-functions/functions/vshnpostgres/extensions_test.go
@@ -81,14 +81,14 @@ func Test_disableTimescaleDB(t *testing.T) {
 		svc := commontest.LoadRuntimeFromFile(t, tt.iofFile)
 
 		t.Run(tt.name, func(t *testing.T) {
-			if err := disableTimescaleDB(ctx, svc, configResourceName); (err != nil) != tt.wantErr {
+			if err := disableTimescaleDB(ctx, svc, "pgsql-gc9x4"); (err != nil) != tt.wantErr {
 				t.Errorf("disableTimescaleDB() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 
 		config := &stackgresv1.SGPostgresConfig{}
 
-		assert.NoError(t, svc.GetDesiredKubeObject(config, configResourceName))
+		assert.NoError(t, svc.GetDesiredKubeObject(config, "pgsql-gc9x4-"+configResourceName))
 
 		assert.NotContains(t, config.Spec.PostgresqlConf[sharedLibraries], timescaleExtName)
 

--- a/test/functions/vshn-postgres/delay_cluster/01_GivenAllDependencies.yaml
+++ b/test/functions/vshn-postgres/delay_cluster/01_GivenAllDependencies.yaml
@@ -100,7 +100,7 @@ observed:
               reason: ReconcileSuccess
               status: 'True'
               type: Synced
-    pg-conf:
+    pgsql-gc9x4-pg-conf:
       resource:
         apiVersion: kubernetes.crossplane.io/v1alpha1
         kind: Object

--- a/test/functions/vshn-postgres/extensions/01-GivenAlreadyEnabled.yaml
+++ b/test/functions/vshn-postgres/extensions/01-GivenAlreadyEnabled.yaml
@@ -23,7 +23,7 @@ desired:
         writeConnectionSecretToRef: {}
       status: {}
   resources:
-    pg-conf:
+    pgsql-gc9x4-pg-conf:
       resource:
         apiVersion: kubernetes.crossplane.io/v1alpha1
         kind: Object

--- a/test/functions/vshn-postgres/extensions/01-GivenFreshConfig.yaml
+++ b/test/functions/vshn-postgres/extensions/01-GivenFreshConfig.yaml
@@ -23,7 +23,7 @@ desired:
         writeConnectionSecretToRef: {}
       status: {}
   resources:
-    pg-conf:
+    pgsql-gc9x4-pg-conf:
       resource:
         apiVersion: kubernetes.crossplane.io/v1alpha1
         kind: Object


### PR DESCRIPTION
## Summary

* Issues with pg-conf kube object not being updated properly

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
