### PR TITLE
Implement webhook logic for split control-plane - service cluster setup

### DIFF
--- a/pkg/comp-functions/functions/common/instance_namespace.go
+++ b/pkg/comp-functions/functions/common/instance_namespace.go
@@ -89,8 +89,11 @@ func createNamespaceObserver(claimNs string, instance string, svc *runtime.Servi
 			Name: claimNs,
 		},
 	}
+	labels := map[string]string{
+		"appcat.vshn.io/ignore-provider-config": "true",
+	}
 
-	return svc.SetDesiredKubeObserveObject(ns, instance+claimNsObserverSuffix)
+	return svc.SetDesiredKubeObject(ns, instance+claimNsObserverSuffix, runtime.KubeOptionAddLabels(labels), runtime.KubeOptionObserve)
 }
 
 // Create the namespace for the service instance

--- a/pkg/comp-functions/functions/vshnkeycloak/deploy.go
+++ b/pkg/comp-functions/functions/vshnkeycloak/deploy.go
@@ -627,7 +627,7 @@ func copyConfigMap(comp *vshnv1.VSHNKeycloak, svc *runtime.ServiceRuntime) (*cor
 			Namespace: comp.GetClaimNamespace(),
 		},
 	}
-	err := svc.SetDesiredKubeObserveObject(cmClaimObserver, cmObjectName)
+	err := svc.SetDesiredKubeObject(cmClaimObserver, cmObjectName, runtime.KubeOptionObserve)
 
 	if err != nil {
 		svc.Log.Info("Can't observe Keycloak config Configmap")
@@ -664,7 +664,7 @@ func copySecret(comp *vshnv1.VSHNKeycloak, svc *runtime.ServiceRuntime) error {
 			Namespace: comp.GetClaimNamespace(),
 		},
 	}
-	err := svc.SetDesiredKubeObserveObject(secretClaimObserver, secretObjectName)
+	err := svc.SetDesiredKubeObject(secretClaimObserver, secretObjectName, runtime.KubeOptionObserve)
 
 	if err != nil {
 		svc.Log.Info("Can't observe Keycloak env variable secret")

--- a/pkg/comp-functions/functions/vshnminio/minio_deploy.go
+++ b/pkg/comp-functions/functions/vshnminio/minio_deploy.go
@@ -214,7 +214,7 @@ func createServiceObserver(comp *vshnv1.VSHNMinio, svc *runtime.ServiceRuntime) 
 		},
 	}
 
-	return svc.SetDesiredKubeObserveObject(service, comp.Name+"-service-observer")
+	return svc.SetDesiredKubeObject(service, comp.Name+"-service-observer", runtime.KubeOptionObserve)
 }
 
 func getConnectionDetails(comp *vshnv1.VSHNMinio, svc *runtime.ServiceRuntime) error {

--- a/pkg/comp-functions/functions/vshnpostgres/objectbucket.go
+++ b/pkg/comp-functions/functions/vshnpostgres/objectbucket.go
@@ -25,6 +25,9 @@ func EnsureObjectBucketLabels(ctx context.Context, comp *vshnv1.VSHNPostgreSQL, 
 	if err != nil {
 		return runtime.NewWarningResult("cannot get xobjectbucket")
 	}
+	labels := bucket.GetLabels()
+	labels["appcat.vshn.io/ignore-provider-config"] = "true"
+	bucket.SetLabels(labels)
 
 	err = svc.SetDesiredComposedResourceWithName(bucket, "pg-bucket")
 	if err != nil {

--- a/pkg/comp-functions/functions/vshnpostgres/objectbucket.go
+++ b/pkg/comp-functions/functions/vshnpostgres/objectbucket.go
@@ -25,9 +25,12 @@ func EnsureObjectBucketLabels(ctx context.Context, comp *vshnv1.VSHNPostgreSQL, 
 	if err != nil {
 		return runtime.NewWarningResult("cannot get xobjectbucket")
 	}
-	labels := bucket.GetLabels()
-	labels["appcat.vshn.io/ignore-provider-config"] = "true"
-	bucket.SetLabels(labels)
+
+	labels := map[string]string{
+		"appcat.vshn.io/ignore-provider-config": "true",
+	}
+
+	svc.AddLabels(bucket, labels)
 
 	err = svc.SetDesiredComposedResourceWithName(bucket, "pg-bucket")
 	if err != nil {

--- a/pkg/comp-functions/functions/vshnredis/pvcresize_test.go
+++ b/pkg/comp-functions/functions/vshnredis/pvcresize_test.go
@@ -185,10 +185,8 @@ func Test_needReleasePatch(t *testing.T) {
 	}
 	for _, tt := range tests {
 
-		ctx := context.TODO()
-
 		t.Run(tt.name, func(t *testing.T) {
-			got, got1 := needReleasePatch(ctx, tt.args.comp, tt.args.values)
+			got, got1 := needReleasePatch(tt.args.comp, tt.args.values)
 
 			assert.Equal(t, tt.want, got)
 

--- a/pkg/comp-functions/functions/vshnredis/release.go
+++ b/pkg/comp-functions/functions/vshnredis/release.go
@@ -31,11 +31,11 @@ func ManageRelease(ctx context.Context, comp *vshnv1.VSHNRedis, svc *runtime.Ser
 		return runtime.NewFatalResult(fmt.Errorf("can't get composite: %w", err))
 	}
 
-	desiredRelease, err := getRelease(ctx, svc)
+	desiredRelease, err := getRelease(svc)
 	if err != nil {
 		return runtime.NewFatalResult(fmt.Errorf("cannot get redis release from iof: %w", err))
 	}
-	observedRelease, err := getObservedRelease(ctx, svc)
+	observedRelease, err := getObservedRelease(svc)
 	if err != nil {
 		return runtime.NewWarningResult("cannot get observed release, skipping")
 	}
@@ -67,7 +67,7 @@ func ManageRelease(ctx context.Context, comp *vshnv1.VSHNRedis, svc *runtime.Ser
 	return nil
 }
 
-func getRelease(ctx context.Context, svc *runtime.ServiceRuntime) (*xhelmv1.Release, error) {
+func getRelease(svc *runtime.ServiceRuntime) (*xhelmv1.Release, error) {
 	r := &xhelmv1.Release{}
 	err := svc.GetDesiredComposedResourceByName(r, redisRelease)
 	if err != nil {
@@ -76,7 +76,7 @@ func getRelease(ctx context.Context, svc *runtime.ServiceRuntime) (*xhelmv1.Rele
 	return r, nil
 }
 
-func getObservedRelease(ctx context.Context, svc *runtime.ServiceRuntime) (*xhelmv1.Release, error) {
+func getObservedRelease(svc *runtime.ServiceRuntime) (*xhelmv1.Release, error) {
 	r := &xhelmv1.Release{}
 	err := svc.GetObservedComposedResource(r, redisRelease)
 	if errors.Is(err, runtime.ErrNotFound) {

--- a/pkg/comp-functions/runtime/function_mgr.go
+++ b/pkg/comp-functions/runtime/function_mgr.go
@@ -446,7 +446,7 @@ func ComposedOptionProtects(resName string) ComposedResourceOption {
 // adds it to the desired composed resources. It takes options to manipulate the resulting kubec object before applying.
 func (s *ServiceRuntime) SetDesiredKubeObject(obj client.Object, objectName string, opts ...KubeObjectOption) error {
 
-	kobj, err := s.putIntoObject(false, obj, objectName, objectName)
+	kobj, err := s.putIntoObject(obj, objectName, objectName)
 	if err != nil {
 		return err
 	}
@@ -463,7 +463,7 @@ func (s *ServiceRuntime) SetDesiredKubeObject(obj client.Object, objectName stri
 // This should be used if manipulating objects that are declared in the P+T composition.
 func (s *ServiceRuntime) SetDesiredKubeObjectWithName(obj client.Object, objectName, resourceName string, opts ...KubeObjectOption) error {
 
-	kobj, err := s.putIntoObject(false, obj, objectName, resourceName)
+	kobj, err := s.putIntoObject(obj, objectName, resourceName)
 	if err != nil {
 		return err
 	}
@@ -473,6 +473,20 @@ func (s *ServiceRuntime) SetDesiredKubeObjectWithName(obj client.Object, objectN
 	}
 
 	return s.SetDesiredComposedResourceWithName(kobj, resourceName)
+}
+
+// KubeOptionLabeler adds the given labels to the kube object.
+func KubeOptionAddLabels(labels map[string]string) KubeObjectOption {
+	return func(obj *xkube.Object) {
+		current := obj.GetLabels()
+		if current == nil {
+			current = map[string]string{}
+		}
+		for val, key := range labels {
+			current[val] = key
+		}
+		obj.SetLabels(current)
+	}
 }
 
 // KubeOptionAddRefs adds the given references to the kube object.
@@ -535,20 +549,6 @@ func KubeOptionProtects(resName string) KubeObjectOption {
 	}
 }
 
-// KubeOptionLabeler adds the given labels to the kube object.
-func KubeOptionAddLabels(labels map[string]string) KubeObjectOption {
-	return func(obj *xkube.Object) {
-		current := obj.GetLabels()
-		if current == nil {
-			current = map[string]string{}
-		}
-		for val, key := range labels {
-			current[val] = key
-		}
-		obj.SetLabels(current)
-	}
-}
-
 func addProtectionAnnotation(resName, protectionType string, obj client.Object) {
 	annotations := obj.GetAnnotations()
 	if annotations == nil {
@@ -577,21 +577,9 @@ func removeDuplicate(strSlice []string) []string {
 	return list
 }
 
-// SetDesiredKubeObserveObject takes any `runtime.Object`, puts it into a provider-kubernetes Object and then
-// adds it to the desired composed resources.
-func (s *ServiceRuntime) SetDesiredKubeObserveObject(obj client.Object, objectName string, refs ...xkube.Reference) error {
-
-	kobj, err := s.putIntoObject(true, obj, objectName, objectName, refs...)
-	if err != nil {
-		return err
-	}
-
-	return s.SetDesiredComposedResourceWithName(kobj, objectName)
-}
-
 // putIntoObject adds or updates the desired resource into its kube object
 // It will inject the same labels as any managed resource gets.
-func (s *ServiceRuntime) putIntoObject(observeOnly bool, o client.Object, kon, resourceName string, refs ...xkube.Reference) (*xkube.Object, error) {
+func (s *ServiceRuntime) putIntoObject(o client.Object, kon, resourceName string, refs ...xkube.Reference) (*xkube.Object, error) {
 
 	s.addOwnerReferenceAnnotation(o, false)
 
@@ -648,11 +636,6 @@ func (s *ServiceRuntime) putIntoObject(observeOnly bool, o client.Object, kon, r
 	// Only set the refs if they are actually set.
 	if len(refs) > 0 {
 		ko.Spec.References = refs
-	}
-
-	if observeOnly {
-		ko.Spec.ManagementPolicies = nil
-		ko.Spec.ManagementPolicies = append(ko.Spec.ManagementPolicies, xpv1.ManagementActionObserve)
 	}
 
 	ko.Spec.ForProvider.Manifest = runtime.RawExtension{Object: o}

--- a/pkg/comp-functions/runtime/function_mgr.go
+++ b/pkg/comp-functions/runtime/function_mgr.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"reflect"
 	"strconv"
 	"strings"
@@ -575,6 +576,12 @@ func removeDuplicate(strSlice []string) []string {
 		}
 	}
 	return list
+}
+
+func (s *ServiceRuntime) AddLabels(obj client.Object, labels map[string]string) {
+	l := obj.GetLabels()
+	maps.Copy(l, labels)
+	obj.SetLabels(l)
 }
 
 // putIntoObject adds or updates the desired resource into its kube object

--- a/pkg/controller/webhooks/deletionprotection_test.go
+++ b/pkg/controller/webhooks/deletionprotection_test.go
@@ -86,7 +86,7 @@ func Test_checkManagedObject(t *testing.T) {
 		Build()
 
 	// Then expect parent
-	compInfo, err := checkManagedObject(context.TODO(), obj, c, logr.Discard())
+	compInfo, err := checkManagedObject(context.TODO(), obj, c, c, logr.Discard())
 	assert.NoError(t, err)
 	assert.Equal(t, compositeInfo{Exists: true, Name: "redis"}, compInfo)
 
@@ -96,7 +96,7 @@ func Test_checkManagedObject(t *testing.T) {
 	obj.SetLabels(labels)
 
 	// Then don't expect parent
-	compInfo, err = checkManagedObject(context.TODO(), obj, c, logr.Discard())
+	compInfo, err = checkManagedObject(context.TODO(), obj, c, c, logr.Discard())
 	assert.NoError(t, err)
 	assert.Equal(t, compositeInfo{Exists: false, Name: "redis"}, compInfo)
 
@@ -127,7 +127,7 @@ func Test_checkManagedObject(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Then expect parent
-	compInfo, err = checkUnmanagedObject(context.TODO(), pvc, c, logr.Discard())
+	compInfo, err = checkUnmanagedObject(context.TODO(), pvc, c, c, logr.Discard())
 	assert.NoError(t, err)
 	assert.Equal(t, compositeInfo{Exists: true, Name: "redis"}, compInfo)
 
@@ -137,7 +137,7 @@ func Test_checkManagedObject(t *testing.T) {
 	pvc.SetLabels(labels)
 
 	// Then expect no parent
-	compInfo, err = checkUnmanagedObject(context.TODO(), pvc, c, logr.Discard())
+	compInfo, err = checkUnmanagedObject(context.TODO(), pvc, c, c, logr.Discard())
 	assert.NoError(t, err)
 	assert.Equal(t, compositeInfo{Exists: false, Name: "redis"}, compInfo)
 

--- a/pkg/controller/webhooks/generic_deletionprotection_handler.go
+++ b/pkg/controller/webhooks/generic_deletionprotection_handler.go
@@ -14,8 +14,9 @@ import (
 var _ webhook.CustomValidator = &GenericDeletionProtectionHandler{}
 
 type GenericDeletionProtectionHandler struct {
-	client client.Client
-	log    logr.Logger
+	client             client.Client
+	controlPlaneClient client.Client
+	log                logr.Logger
 }
 
 // ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type
@@ -40,7 +41,7 @@ func (p *GenericDeletionProtectionHandler) ValidateDelete(ctx context.Context, o
 
 	l := p.log.WithValues("object", resource.GetName(), "object", resource.GetNamespace(), "GVK", resource.GetObjectKind().GroupVersionKind().String())
 
-	compInfo, err := checkManagedObject(ctx, resource, p.client, l)
+	compInfo, err := checkManagedObject(ctx, resource, p.client, p.controlPlaneClient, l)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/webhooks/keycloak.go
+++ b/pkg/controller/webhooks/keycloak.go
@@ -25,7 +25,6 @@ type KeycloakWebhookHandler struct {
 
 // SetupKeycloakWebhookHandlerWithManager registers the validation webhook with the manager.
 func SetupKeycloakWebhookHandlerWithManager(mgr ctrl.Manager, withQuota bool) error {
-
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(&vshnv1.VSHNKeycloak{}).
 		WithValidator(&KeycloakWebhookHandler{

--- a/pkg/controller/webhooks/namespace.go
+++ b/pkg/controller/webhooks/namespace.go
@@ -9,12 +9,17 @@ import (
 
 // SetupNamespaceDeletionProtectionHandlerWithManager registers the validation webhook with the manager.
 func SetupNamespaceDeletionProtectionHandlerWithManager(mgr ctrl.Manager) error {
+	cpClient, err := getControlPlaneClient(mgr)
+	if err != nil {
+		return err
+	}
 
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(&corev1.Namespace{}).
 		WithValidator(&GenericDeletionProtectionHandler{
-			client: mgr.GetClient(),
-			log:    mgr.GetLogger().WithName("webhook").WithName("namespace"),
+			client:             mgr.GetClient(),
+			controlPlaneClient: cpClient,
+			log:                mgr.GetLogger().WithName("webhook").WithName("namespace"),
 		}).
 		Complete()
 }

--- a/pkg/controller/webhooks/object.go
+++ b/pkg/controller/webhooks/object.go
@@ -15,24 +15,24 @@ import (
 
 // SetupObjectDeletionProtectionHandlerWithManager registers the validation webhook with the manager.
 func SetupObjectDeletionProtectionHandlerWithManager(mgr ctrl.Manager) error {
-
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(&xkubev1alpha2.Object{}).
 		WithValidator(&GenericDeletionProtectionHandler{
-			client: mgr.GetClient(),
-			log:    mgr.GetLogger().WithName("webhook").WithName("object"),
+			client:             mgr.GetClient(),
+			controlPlaneClient: mgr.GetClient(),
+			log:                mgr.GetLogger().WithName("webhook").WithName("object"),
 		}).
 		Complete()
 }
 
 // SetupObjectv1alpha1DeletionProtectionHandlerWithManager registers the validation webhook with the manager.
 func SetupObjectv1alpha1DeletionProtectionHandlerWithManager(mgr ctrl.Manager) error {
-
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(&xkubev1alpha1.Object{}).
 		WithValidator(&GenericDeletionProtectionHandler{
-			client: mgr.GetClient(),
-			log:    mgr.GetLogger().WithName("webhook").WithName("object"),
+			client:             mgr.GetClient(),
+			controlPlaneClient: mgr.GetClient(),
+			log:                mgr.GetLogger().WithName("webhook").WithName("object"),
 		}).
 		Complete()
 }

--- a/pkg/controller/webhooks/release.go
+++ b/pkg/controller/webhooks/release.go
@@ -14,12 +14,12 @@ import (
 
 // SetupReleaseDeletionProtectionHandlerWithManager registers the validation webhook with the manager.
 func SetupReleaseDeletionProtectionHandlerWithManager(mgr ctrl.Manager) error {
-
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(&helmv1beta1.Release{}).
 		WithValidator(&GenericDeletionProtectionHandler{
-			client: mgr.GetClient(),
-			log:    mgr.GetLogger().WithName("webhook").WithName("release"),
+			client:             mgr.GetClient(),
+			controlPlaneClient: mgr.GetClient(),
+			log:                mgr.GetLogger().WithName("webhook").WithName("release"),
 		}).
 		Complete()
 }

--- a/pkg/controller/webhooks/xobjectbuckets.go
+++ b/pkg/controller/webhooks/xobjectbuckets.go
@@ -20,8 +20,9 @@ var _ webhook.CustomValidator = &XObjectbucketDeletionProtectionHandler{}
 
 // XObjectbucketDeletionProtectionHandler
 type XObjectbucketDeletionProtectionHandler struct {
-	client client.Client
-	log    logr.Logger
+	client             client.Client
+	controlPlaneClient client.Client
+	log                logr.Logger
 }
 
 // SetupXObjectbucketCDeletionProtectionHandlerWithManager registers the validation webhook with the manager.
@@ -68,7 +69,7 @@ func (p *XObjectbucketDeletionProtectionHandler) ValidateDelete(ctx context.Cont
 
 	l := p.log.WithValues("object", bucket.GetName(), "namespace", bucket.GetNamespace(), "GVK", bucket.GetObjectKind().GroupVersionKind().String())
 
-	compInfo, err := checkManagedObject(ctx, bucket, p.client, l)
+	compInfo, err := checkManagedObject(ctx, bucket, p.client, p.controlPlaneClient, l)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

* This PR adds support for connecting the webhook controller to another cluster.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [ ] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
