### PR TITLE
Remove v1alpha1 for objects from webhook definition

### DIFF
--- a/config/controller/webhooks.yaml
+++ b/config/controller/webhooks.yaml
@@ -105,25 +105,6 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
-      path: /validate-kubernetes-crossplane-io-v1alpha1-object
-  failurePolicy: Fail
-  name: objectsv1alpha1.vshn.appcat.vshn.io
-  rules:
-  - apiGroups:
-    - kubernetes.crossplane.io
-    apiVersions:
-    - v1alpha1
-    operations:
-    - DELETE
-    resources:
-    - objects
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: webhook-service
-      namespace: system
       path: /validate-vshn-appcat-vshn-io-v1-vshnpostgresql
   failurePolicy: Fail
   name: postgresql.vshn.appcat.vshn.io

--- a/pkg/controller/webhooks/object.go
+++ b/pkg/controller/webhooks/object.go
@@ -6,7 +6,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
-//+kubebuilder:webhook:verbs=delete,path=/validate-kubernetes-crossplane-io-v1alpha1-object,mutating=false,failurePolicy=fail,groups="kubernetes.crossplane.io",resources=objects,versions=v1alpha1,name=objectsv1alpha1.vshn.appcat.vshn.io,sideEffects=None,admissionReviewVersions=v1
 //+kubebuilder:webhook:verbs=delete,path=/validate-kubernetes-crossplane-io-v1alpha2-object,mutating=false,failurePolicy=fail,groups="kubernetes.crossplane.io",resources=objects,versions=v1alpha2,name=objects.vshn.appcat.vshn.io,sideEffects=None,admissionReviewVersions=v1
 
 //+kubebuilder:rbac:groups=syn.tools,resources=compositeredisinstances,verbs=get;list;watch;patch;update


### PR DESCRIPTION
## Summary

* If the v1alpha1 version is not available, the webhook will fail. We will therefore remove it here, and manually add it where required

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [ ] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
