### PR TITLE
Fix typo in the usage protecting the instance NS

### DIFF
--- a/pkg/comp-functions/functions/vshnmariadb/user_management.go
+++ b/pkg/comp-functions/functions/vshnmariadb/user_management.go
@@ -142,7 +142,7 @@ func addProviderConfig(comp *vshnv1.VSHNMariaDB, svc *runtime.ServiceRuntime) {
 	}
 
 	opts := []runtime.KubeObjectOption{
-		runtime.KubeOptionProtects(comp.GetName() + "-instanceNs"),
+		runtime.KubeOptionProtects(comp.GetName() + "-instancens"),
 		runtime.KubeOptionProtects(comp.GetName() + "-release"),
 		runtime.KubeOptionProtects(comp.GetName() + "-netpol"),
 		runtime.KubeOptionProtects(comp.GetName() + "-main-service"),


### PR DESCRIPTION


## Summary

Crossplane resource names are always lower case. If the name doesn't match exactly, then the usage won't be applied properly.

This lead to a race condition when deprovisioning MariaDB with users.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
