### PR TITLE
Re-write alerts so they work with cluster monitoring

### DIFF
--- a/pkg/comp-functions/functions/common/nonsla/alerting_test.go
+++ b/pkg/comp-functions/functions/common/nonsla/alerting_test.go
@@ -9,25 +9,24 @@ import (
 
 var (
 	// PostgreSQL alerts - most specific as currently those are the only ones where we have different container name and namespace
-	patroniPersistentVolumeExpectedToFillUp = `label_replace( bottomk(1, (kubelet_volume_stats_available_bytes{job="kubelet",metrics_path="/metrics"} / kubelet_volume_stats_capacity_bytes{job="kubelet",metrics_path="/metrics"}) < 0.15 and kubelet_volume_stats_used_bytes{job="kubelet",metrics_path="/metrics"} > 0 and predict_linear(kubelet_volume_stats_available_bytes{job="kubelet",metrics_path="/metrics"}[6h], 4 * 24 * 3600) < 0  unless on(namespace, persistentvolumeclaim) kube_persistentvolumeclaim_access_mode{access_mode="ReadOnlyMany"} == 1 unless on(namespace,persistentvolumeclaim) kube_persistentvolumeclaim_labels{label_excluded_from_alerts="true"}== 1) * on(namespace) group_left(label_appcat_vshn_io_claim_namespace)kube_namespace_labels, "name", "$1", "namespace","vshn-postgresql-(.+)-.+")`
+	patroniPersistentVolumeExpectedToFillUp = `label_replace( bottomk(1, (kubelet_volume_stats_available_bytes{job="kubelet",metrics_path="/metrics"} / kubelet_volume_stats_capacity_bytes{job="kubelet",metrics_path="/metrics"}) < 0.15 and kubelet_volume_stats_used_bytes{job="kubelet",metrics_path="/metrics"} > 0 and predict_linear(kubelet_volume_stats_available_bytes{job="kubelet",metrics_path="/metrics"}[6h], 4 * 24 * 3600) < 0  unless on(namespace, persistentvolumeclaim) kube_persistentvolumeclaim_access_mode{access_mode="ReadOnlyMany"} == 1 unless on(namespace,persistentvolumeclaim) kube_persistentvolumeclaim_labels{label_excluded_from_alerts="true"}== 1) * on(namespace) group_left(label_appcat_vshn_io_claim_namespace)kube_namespace_labels, "name", "$1", "namespace","vshn-postgresql-test")`
 
-	patroniMemoryCritical = `label_replace( topk(1, (max(container_memory_working_set_bytes{container="patroni"})without (name, id)  / on(container,pod,namespace)  kube_pod_container_resource_limits{resource="memory"}* 100) > 85) * on(namespace) group_left(label_appcat_vshn_io_claim_namespace)kube_namespace_labels, "name", "$1", "namespace","vshn-postgresql-(.+)-.+")`
+	patroniMemoryCritical = `label_replace( topk(1, (max(container_memory_working_set_bytes{container="patroni"})without (name, id)  / on(container,pod,namespace)  kube_pod_container_resource_limits{resource="memory"}* 100) > 85) * on(namespace) group_left(label_appcat_vshn_io_claim_namespace)kube_namespace_labels, "name", "$1", "namespace","vshn-postgresql-test")`
 
-	patroniPersistentVolumeFillingUp = `label_replace( bottomk(1, (kubelet_volume_stats_available_bytes{job="kubelet", metrics_path="/metrics"} / kubelet_volume_stats_capacity_bytes{job="kubelet",metrics_path="/metrics"}) < 0.03 and kubelet_volume_stats_used_bytes{job="kubelet",metrics_path="/metrics"} > 0 unless on(namespace,persistentvolumeclaim) kube_persistentvolumeclaim_access_mode{access_mode="ReadOnlyMany"} == 1 unless on(namespace,persistentvolumeclaim) kube_persistentvolumeclaim_labels{label_excluded_from_alerts="true"}== 1) * on(namespace) group_left(label_appcat_vshn_io_claim_namespace)kube_namespace_labels, "name", "$1", "namespace","vshn-postgresql-(.+)-.+")`
+	patroniPersistentVolumeFillingUp = `label_replace( bottomk(1, (kubelet_volume_stats_available_bytes{job="kubelet", metrics_path="/metrics"} / kubelet_volume_stats_capacity_bytes{job="kubelet",metrics_path="/metrics"}) < 0.03 and kubelet_volume_stats_used_bytes{job="kubelet",metrics_path="/metrics"} > 0 unless on(namespace,persistentvolumeclaim) kube_persistentvolumeclaim_access_mode{access_mode="ReadOnlyMany"} == 1 unless on(namespace,persistentvolumeclaim) kube_persistentvolumeclaim_labels{label_excluded_from_alerts="true"}== 1) * on(namespace) group_left(label_appcat_vshn_io_claim_namespace)kube_namespace_labels, "name", "$1", "namespace","vshn-postgresql-test")`
 
-	mariadbPersistentVolumeFillingUp = `label_replace( bottomk(1, (kubelet_volume_stats_available_bytes{job="kubelet", metrics_path="/metrics"} / kubelet_volume_stats_capacity_bytes{job="kubelet",metrics_path="/metrics"}) < 0.03 and kubelet_volume_stats_used_bytes{job="kubelet",metrics_path="/metrics"} > 0 unless on(namespace,persistentvolumeclaim) kube_persistentvolumeclaim_access_mode{access_mode="ReadOnlyMany"} == 1 unless on(namespace,persistentvolumeclaim) kube_persistentvolumeclaim_labels{label_excluded_from_alerts="true"}== 1) * on(namespace) group_left(label_appcat_vshn_io_claim_namespace)kube_namespace_labels, "name", "$1", "namespace","vshn-mariadb-(.+)-.+")`
+	mariadbPersistentVolumeFillingUp = `label_replace( bottomk(1, (kubelet_volume_stats_available_bytes{job="kubelet", metrics_path="/metrics"} / kubelet_volume_stats_capacity_bytes{job="kubelet",metrics_path="/metrics"}) < 0.03 and kubelet_volume_stats_used_bytes{job="kubelet",metrics_path="/metrics"} > 0 unless on(namespace,persistentvolumeclaim) kube_persistentvolumeclaim_access_mode{access_mode="ReadOnlyMany"} == 1 unless on(namespace,persistentvolumeclaim) kube_persistentvolumeclaim_labels{label_excluded_from_alerts="true"}== 1) * on(namespace) group_left(label_appcat_vshn_io_claim_namespace)kube_namespace_labels, "name", "$1", "namespace","vshn-mariadb-myinstance")`
 
-	keycloakMemoryCritical = `label_replace( topk(1, (max(container_memory_working_set_bytes{container="keycloak"})without (name, id)  / on(container,pod,namespace)  kube_pod_container_resource_limits{resource="memory"}* 100) > 85) * on(namespace) group_left(label_appcat_vshn_io_claim_namespace)kube_namespace_labels, "name", "$1", "namespace","vshn-keycloak-(.+)-.+")`
+	keycloakMemoryCritical = `label_replace( topk(1, (max(container_memory_working_set_bytes{container="keycloak"})without (name, id)  / on(container,pod,namespace)  kube_pod_container_resource_limits{resource="memory"}* 100) > 85) * on(namespace) group_left(label_appcat_vshn_io_claim_namespace)kube_namespace_labels, "name", "$1", "namespace","vshn-keycloak-myinstance")`
 )
 
 func TestNewAlertSetBuilder(t *testing.T) {
 	containerName := "patroni"
-	namespace := "postgresql"
-	builder := NewAlertSetBuilder(containerName, namespace)
+	namespace := "vshn-postgresql-test"
+	builder := NewAlertSetBuilder(containerName)
 
 	assert.NotNil(t, builder)
 	assert.Equal(t, containerName, builder.as.alertContainerName)
-	assert.Equal(t, namespace, builder.as.namespace)
 	assert.Empty(t, builder.as.customRules)
 	assert.Empty(t, builder.as.alerts)
 
@@ -40,8 +39,8 @@ func TestNewAlertSetBuilder(t *testing.T) {
 
 	rules := make([]promV1.Rule, 0)
 	for _, a := range builder.as.alerts {
-		f := AlertDefinitions[a]
-		r := f(builder.as.alertContainerName, builder.as.namespace)
+		f := alertDefinitions[a]
+		r := f(builder.as.alertContainerName, namespace)
 		rules = append(rules, r)
 	}
 	rules = append(rules, builder.as.customRules...)
@@ -67,14 +66,14 @@ func TestNewAlertSetBuilder(t *testing.T) {
 
 	// test for mariadb
 	containerName = "mariadb"
-	namespace = "mariadb"
-	builder = NewAlertSetBuilder(containerName, namespace)
+	namespace = "vshn-mariadb-myinstance"
+	builder = NewAlertSetBuilder(containerName)
 	builder.AddDiskFillingUp()
 
 	rules = make([]promV1.Rule, 0)
 	for _, a := range builder.as.alerts {
-		f := AlertDefinitions[a]
-		r := f(builder.as.alertContainerName, builder.as.namespace)
+		f := alertDefinitions[a]
+		r := f(builder.as.alertContainerName, namespace)
 		rules = append(rules, r)
 	}
 	assert.Equal(t, len(rules), 1)
@@ -82,14 +81,14 @@ func TestNewAlertSetBuilder(t *testing.T) {
 
 	// test for keycloak
 	containerName = "keycloak"
-	namespace = "keycloak"
-	builder = NewAlertSetBuilder(containerName, namespace)
+	namespace = "vshn-keycloak-myinstance"
+	builder = NewAlertSetBuilder(containerName)
 	builder.AddMemory()
 
 	rules = make([]promV1.Rule, 0)
 	for _, a := range builder.as.alerts {
-		f := AlertDefinitions[a]
-		r := f(builder.as.alertContainerName, builder.as.namespace)
+		f := alertDefinitions[a]
+		r := f(builder.as.alertContainerName, namespace)
 		rules = append(rules, r)
 	}
 	assert.Equal(t, len(rules), 1)

--- a/pkg/comp-functions/functions/common/nonsla/non_sla_prom_rules.go
+++ b/pkg/comp-functions/functions/common/nonsla/non_sla_prom_rules.go
@@ -32,8 +32,8 @@ func GenerateNonSLAPromRules[T client.Object](alerts Alerts) func(ctx context.Co
 
 		rules := make([]promV1.Rule, 0)
 		for _, a := range alerts.alerts {
-			f := AlertDefinitions[a]
-			r := f(alerts.alertContainerName, alerts.namespace)
+			f := alerts.alertDefinitions[a]
+			r := f(alerts.alertContainerName, elem.GetInstanceNamespace())
 			rules = append(rules, r)
 		}
 		rules = append(rules, alerts.customRules...)

--- a/pkg/comp-functions/functions/vshnkeycloak/register.go
+++ b/pkg/comp-functions/functions/vshnkeycloak/register.go
@@ -33,7 +33,7 @@ func init() {
 			},
 			{
 				Name:    "non-sla-prometheus-rules",
-				Execute: nonsla.GenerateNonSLAPromRules[*vshnv1.VSHNKeycloak](nonsla.NewAlertSetBuilder("keycloak", "keycloak").AddMemory().GetAlerts()),
+				Execute: nonsla.GenerateNonSLAPromRules[*vshnv1.VSHNKeycloak](nonsla.NewAlertSetBuilder("keycloak").AddMemory().GetAlerts()),
 			},
 			{
 				Name:    "pdb",

--- a/pkg/comp-functions/functions/vshnmariadb/register.go
+++ b/pkg/comp-functions/functions/vshnmariadb/register.go
@@ -33,7 +33,7 @@ func init() {
 			},
 			{
 				Name:    "non-sla-prometheus-rules",
-				Execute: nonsla.GenerateNonSLAPromRules[*vshnv1.VSHNMariaDB](nonsla.NewAlertSetBuilder("mariadb", "mariadb").AddAll().GetAlerts()),
+				Execute: nonsla.GenerateNonSLAPromRules[*vshnv1.VSHNMariaDB](nonsla.NewAlertSetBuilder("mariadb").AddAll().GetAlerts()),
 			},
 			{
 				Name:    "billing",

--- a/pkg/comp-functions/functions/vshnminio/register.go
+++ b/pkg/comp-functions/functions/vshnminio/register.go
@@ -25,7 +25,7 @@ func init() {
 			},
 			{
 				Name:    "non-sla-prometheus-rules",
-				Execute: nonsla.GenerateNonSLAPromRules[*vshnv1.VSHNMinio](nonsla.NewAlertSetBuilder("minio", "minio").AddAll().GetAlerts()),
+				Execute: nonsla.GenerateNonSLAPromRules[*vshnv1.VSHNMinio](nonsla.NewAlertSetBuilder("minio").AddAll().GetAlerts()),
 			},
 			{
 				Name:    "securitycontext",

--- a/pkg/comp-functions/functions/vshnpostgres/alerts.go
+++ b/pkg/comp-functions/functions/vshnpostgres/alerts.go
@@ -6,20 +6,23 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-var maxConnectionsAlert = promv1.Rule{
-	Alert: "PostgreSQLConnectionsCritical",
-	Annotations: map[string]string{
-		"description": "The connections to {{ $labels.pod }} have been over 90% of the configured connections for 2 hours.\n  Please reduce the load of this instance.",
-		"runbook_url": "https://kb.vshn.ch/app-catalog/how-tos/appcat/vshn/postgres/PostgreSQLConnectionsCritical.html",
-		"summary":     "Connection usage critical",
-	},
-	Expr: intstr.IntOrString{
-		Type:   intstr.String,
-		StrVal: "sum(pg_stat_activity_count) by (pod)\n  > 90/100 * sum(pg_settings_max_connections) by (pod)",
-	},
-	For: nonsla.TwoHourInterval,
-	Labels: map[string]string{
-		"severity": nonsla.SeverityCritical,
-		"syn_team": nonsla.SynTeam,
-	},
+func maxConnectionsAlert(service, namespace string) promv1.Rule {
+	return promv1.Rule{
+		Alert: "PostgreSQLConnectionsCritical",
+		Annotations: map[string]string{
+			"description": "The connections to {{ $labels.pod }} have been over 90% of the configured connections for 2 hours.\n  Please reduce the load of this instance.",
+			"runbook_url": "https://kb.vshn.ch/app-catalog/how-tos/appcat/vshn/postgres/PostgreSQLConnectionsCritical.html",
+			"summary":     "Connection usage critical",
+		},
+		Expr: intstr.IntOrString{
+			Type:   intstr.String,
+			StrVal: `sum(pg_stat_activity_count{exported_namespace="` + namespace + `"}) by (pod)\n  > 90/100 * sum(pg_settings_max_connections{exported_namespace="` + namespace + `"}) by (pod)`,
+		},
+		For: nonsla.TwoHourInterval,
+		Labels: map[string]string{
+			"severity": nonsla.SeverityCritical,
+			"syn_team": nonsla.SynTeam,
+			"syn":      "true",
+		},
+	}
 }

--- a/pkg/comp-functions/functions/vshnpostgres/register.go
+++ b/pkg/comp-functions/functions/vshnpostgres/register.go
@@ -1,14 +1,13 @@
 package vshnpostgres
 
 import (
-	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	vshnv1 "github.com/vshn/appcat/v4/apis/vshn/v1"
 	"github.com/vshn/appcat/v4/pkg/comp-functions/functions/common"
 	"github.com/vshn/appcat/v4/pkg/comp-functions/functions/common/nonsla"
 	"github.com/vshn/appcat/v4/pkg/comp-functions/runtime"
 )
 
-var pgAlerts = nonsla.NewAlertSetBuilder("patroni", "postgresql").AddAll().AddCustom([]promv1.Rule{maxConnectionsAlert}).GetAlerts()
+var pgAlerts = nonsla.NewAlertSetBuilder("patroni").AddAll().AddCustomServiceRule("maxconnections", maxConnectionsAlert).GetAlerts()
 
 func init() {
 	runtime.RegisterService[*vshnv1.VSHNPostgreSQL]("postgresql", runtime.Service[*vshnv1.VSHNPostgreSQL]{

--- a/pkg/comp-functions/functions/vshnredis/register.go
+++ b/pkg/comp-functions/functions/vshnredis/register.go
@@ -48,7 +48,7 @@ func init() {
 			},
 			{
 				Name:    "non-sla-prometheus-rules",
-				Execute: nonsla.GenerateNonSLAPromRules[*vshnv1.VSHNRedis](nonsla.NewAlertSetBuilder("redis", "redis").AddAll().GetAlerts()),
+				Execute: nonsla.GenerateNonSLAPromRules[*vshnv1.VSHNRedis](nonsla.NewAlertSetBuilder("redis").AddAll().GetAlerts()),
 			},
 			{
 				Name:    "billing",


### PR DESCRIPTION


## Summary

The current user-workload alerts will not properly work with the cluster workload monitoring, because:

* A specific `"syn": "true"` label is missing
* They don't filter for the namespace. So each alert would trigger for each instance that is running.

The second part needed a bit more involved refactoring, as we have to pass the specific namespace for each instance and can't just match in a generic manner.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
