### PR TITLE
Allow rotation of the restart ops

### DIFF
--- a/pkg/comp-functions/functions/vshnpostgres/restart.go
+++ b/pkg/comp-functions/functions/vshnpostgres/restart.go
@@ -121,7 +121,7 @@ func scheduleRestart(ctx context.Context, svc *runtime.ServiceRuntime, compName 
 			RunAt: ptr.To(restartTime.Format(time.RFC3339)),
 		},
 	}
-	return svc.SetDesiredKubeObject(ops, fmt.Sprintf("%s-%s", compName, name))
+	return svc.SetDesiredKubeObject(ops, fmt.Sprintf("%s-%s", compName, name), runtime.KubeOptionAllowDeletion)
 }
 
 func keepRecentRestartOps(ctx context.Context, svc *runtime.ServiceRuntime, compName string, now func() time.Time) error {


### PR DESCRIPTION

## Summary

Without the annotation Crossplane won't be able to remove the old ops and get stuck in `Synced: false` state.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
