### PR TITLE
Fix typo in rule expr

### DIFF
--- a/pkg/comp-functions/functions/vshnpostgres/alerts.go
+++ b/pkg/comp-functions/functions/vshnpostgres/alerts.go
@@ -16,7 +16,7 @@ func maxConnectionsAlert(service, namespace string) promv1.Rule {
 		},
 		Expr: intstr.IntOrString{
 			Type:   intstr.String,
-			StrVal: `sum(pg_stat_activity_count{exported_namespace="` + namespace + `"}) by (pod)\n  > 90/100 * sum(pg_settings_max_connections{exported_namespace="` + namespace + `"}) by (pod)`,
+			StrVal: `sum(pg_stat_activity_count{exported_namespace="` + namespace + `"}) by (pod) > 90/100 * sum(pg_settings_max_connections{exported_namespace="` + namespace + `"}) by (pod)`,
 		},
 		For: nonsla.TwoHourInterval,
 		Labels: map[string]string{


### PR DESCRIPTION
## Summary

* There was a `\n` in the rule expr

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
