### PR TITLE
Use a default client if controlPanel client is nil

### DIFF
--- a/pkg/controller/webhooks/deletionprotection.go
+++ b/pkg/controller/webhooks/deletionprotection.go
@@ -44,6 +44,10 @@ type DeletionProtectionInfo interface {
 // Anything that either contains an owner reference to a composite or an owner annotation.
 func checkManagedObject(ctx context.Context, obj client.Object, c client.Client, cpClient client.Client, l logr.Logger) (compositeInfo, error) {
 
+	if cpClient == nil {
+		cpClient = c
+	}
+
 	ownerKind, ok := obj.GetLabels()[runtime.OwnerKindAnnotation]
 	if !ok || ownerKind == "" {
 		l.Info(runtime.OwnerKindAnnotation + " label not set, skipping evaluation")
@@ -115,6 +119,10 @@ func checkManagedObject(ctx context.Context, obj client.Object, c client.Client,
 // Such objects would be: any helm generated object, pvcs for sts and any other 3rd party managed objects.
 func checkUnmanagedObject(ctx context.Context, obj client.Object, c client.Client, cpClient client.Client, l logr.Logger) (compositeInfo, error) {
 	namespace := &corev1.Namespace{}
+
+	if cpClient == nil {
+		cpClient = c
+	}
 
 	err := cpClient.Get(ctx, client.ObjectKey{Name: obj.GetNamespace()}, namespace)
 	if err != nil {


### PR DESCRIPTION


## Summary

XObjectBuckets and mysql provder-sql objects did not have a valid cpClient specified. This causes nilpointers if any of these should get deleted.

Resulting in errors like these:
```
Error from server (InternalError): Internal error occurred: failed calling webhook "users.mysql.vshn.appcat.vshn.io": failed to call webhook: Post "https://webhook-service.syn-appcat.svc:443/validate-mysql-sql-crossplane-io-v1alpha1-user?timeout=10s": EOF
```

These are Crossplane managed resources and always reside on the control plane.

So they will always have the same clients for local and control plane connections.

If the cpClient isn't specified we default to the other client. This change will make it easier in the future to add managed resources as we don't have to specify both clients seperately (and potentially forget them...).

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
