### PR TITLE
Fix disable pg bouncer name parameter

### DIFF
--- a/apis/vshn/v1/dbaas_vshn_postgresql.go
+++ b/apis/vshn/v1/dbaas_vshn_postgresql.go
@@ -150,7 +150,7 @@ type VSHNPostgreSQLServiceSpec struct {
 
 	// Disable connection pooling service PgBouncer. All connections will go straight to PostgreSQL instance.
 	// +kubebuilder:default=false
-	DisablePgBouncer bool `json:"DisablePgBouncer,omitempty"`
+	DisablePgBouncer bool `json:"disablePgBouncer,omitempty"`
 
 	// +kubebuilder:default=true
 	// This is default option if neither repack or vacuum are selected

--- a/crds/vshn.appcat.vshn.io_vshnkeycloaks.yaml
+++ b/crds/vshn.appcat.vshn.io_vshnkeycloaks.yaml
@@ -9775,10 +9775,6 @@ spec:
                             service:
                               description: Service contains PostgreSQL DBaaS specific properties
                               properties:
-                                DisablePgBouncer:
-                                  default: false
-                                  description: Disable connection pooling service PgBouncer. All connections will go straight to PostgreSQL instance.
-                                  type: boolean
                                 access:
                                   description: Access defines additional users and databases for this instance.
                                   items:
@@ -9820,6 +9816,10 @@ spec:
                                       - user
                                     type: object
                                   type: array
+                                disablePgBouncer:
+                                  default: false
+                                  description: Disable connection pooling service PgBouncer. All connections will go straight to PostgreSQL instance.
+                                  type: boolean
                                 extensions:
                                   description: Extensions allow to enable/disable any of the supported
                                   items:

--- a/crds/vshn.appcat.vshn.io_vshnnextclouds.yaml
+++ b/crds/vshn.appcat.vshn.io_vshnnextclouds.yaml
@@ -9754,10 +9754,6 @@ spec:
                             service:
                               description: Service contains PostgreSQL DBaaS specific properties
                               properties:
-                                DisablePgBouncer:
-                                  default: false
-                                  description: Disable connection pooling service PgBouncer. All connections will go straight to PostgreSQL instance.
-                                  type: boolean
                                 access:
                                   description: Access defines additional users and databases for this instance.
                                   items:
@@ -9799,6 +9795,10 @@ spec:
                                       - user
                                     type: object
                                   type: array
+                                disablePgBouncer:
+                                  default: false
+                                  description: Disable connection pooling service PgBouncer. All connections will go straight to PostgreSQL instance.
+                                  type: boolean
                                 extensions:
                                   description: Extensions allow to enable/disable any of the supported
                                   items:

--- a/crds/vshn.appcat.vshn.io_vshnpostgresqls.yaml
+++ b/crds/vshn.appcat.vshn.io_vshnpostgresqls.yaml
@@ -4965,10 +4965,6 @@ spec:
                     service:
                       description: Service contains PostgreSQL DBaaS specific properties
                       properties:
-                        DisablePgBouncer:
-                          default: false
-                          description: Disable connection pooling service PgBouncer. All connections will go straight to PostgreSQL instance.
-                          type: boolean
                         access:
                           description: Access defines additional users and databases for this instance.
                           items:
@@ -5010,6 +5006,10 @@ spec:
                               - user
                             type: object
                           type: array
+                        disablePgBouncer:
+                          default: false
+                          description: Disable connection pooling service PgBouncer. All connections will go straight to PostgreSQL instance.
+                          type: boolean
                         extensions:
                           description: Extensions allow to enable/disable any of the supported
                           items:

--- a/crds/vshn.appcat.vshn.io_xvshnkeycloaks.yaml
+++ b/crds/vshn.appcat.vshn.io_xvshnkeycloaks.yaml
@@ -11555,11 +11555,6 @@ spec:
                             description: Service contains PostgreSQL DBaaS specific
                               properties
                             properties:
-                              DisablePgBouncer:
-                                default: false
-                                description: Disable connection pooling service PgBouncer.
-                                  All connections will go straight to PostgreSQL instance.
-                                type: boolean
                               access:
                                 description: Access defines additional users and databases
                                   for this instance.
@@ -11603,6 +11598,11 @@ spec:
                                   - user
                                   type: object
                                 type: array
+                              disablePgBouncer:
+                                default: false
+                                description: Disable connection pooling service PgBouncer.
+                                  All connections will go straight to PostgreSQL instance.
+                                type: boolean
                               extensions:
                                 description: Extensions allow to enable/disable any
                                   of the supported

--- a/crds/vshn.appcat.vshn.io_xvshnnextclouds.yaml
+++ b/crds/vshn.appcat.vshn.io_xvshnnextclouds.yaml
@@ -11537,11 +11537,6 @@ spec:
                             description: Service contains PostgreSQL DBaaS specific
                               properties
                             properties:
-                              DisablePgBouncer:
-                                default: false
-                                description: Disable connection pooling service PgBouncer.
-                                  All connections will go straight to PostgreSQL instance.
-                                type: boolean
                               access:
                                 description: Access defines additional users and databases
                                   for this instance.
@@ -11585,6 +11580,11 @@ spec:
                                   - user
                                   type: object
                                 type: array
+                              disablePgBouncer:
+                                default: false
+                                description: Disable connection pooling service PgBouncer.
+                                  All connections will go straight to PostgreSQL instance.
+                                type: boolean
                               extensions:
                                 description: Extensions allow to enable/disable any
                                   of the supported

--- a/crds/vshn.appcat.vshn.io_xvshnpostgresqls.yaml
+++ b/crds/vshn.appcat.vshn.io_xvshnpostgresqls.yaml
@@ -5647,11 +5647,6 @@ spec:
                   service:
                     description: Service contains PostgreSQL DBaaS specific properties
                     properties:
-                      DisablePgBouncer:
-                        default: false
-                        description: Disable connection pooling service PgBouncer.
-                          All connections will go straight to PostgreSQL instance.
-                        type: boolean
                       access:
                         description: Access defines additional users and databases
                           for this instance.
@@ -5695,6 +5690,11 @@ spec:
                           - user
                           type: object
                         type: array
+                      disablePgBouncer:
+                        default: false
+                        description: Disable connection pooling service PgBouncer.
+                          All connections will go straight to PostgreSQL instance.
+                        type: boolean
                       extensions:
                         description: Extensions allow to enable/disable any of the
                           supported


### PR DESCRIPTION
## Summary

* There is a type in the disable pg bouncer parameter.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
