### PR TITLE
Allow deletion of PDBs

### DIFF
--- a/pkg/comp-functions/functions/common/pdb.go
+++ b/pkg/comp-functions/functions/common/pdb.go
@@ -46,7 +46,7 @@ func AddPDBSettings[T client.Object](ctx context.Context, obj T, svc *runtime.Se
 		},
 	}
 
-	err = svc.SetDesiredKubeObject(x, comp.GetName()+"-pdb")
+	err = svc.SetDesiredKubeObject(x, comp.GetName()+"-pdb", runtime.KubeOptionAllowDeletion)
 	if err != nil {
 		return runtime.NewFatalResult(fmt.Errorf("could not set desired kube compect: %w", err))
 	}


### PR DESCRIPTION
## Summary

* Currently whenever the pg instnace is being rescaled the PDB cannot be deleted by crossplane as it is protected by deletion protection.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
