### PR TITLE
Add support for remote control plane to SLI exporter

### DIFF
--- a/apis/vshn/v1/dbaas_vshn_mariadb.go
+++ b/apis/vshn/v1/dbaas_vshn_mariadb.go
@@ -171,6 +171,10 @@ type XVSHNMariaDB struct {
 	Status XVSHNMariaDBStatus `json:"status,omitempty"`
 }
 
+func (v *XVSHNMariaDB) GetInstanceNamespace() string {
+	return fmt.Sprintf("vshn-mariadb-%s", v.GetName())
+}
+
 // XVSHNMariaDBSpec defines the desired state of a VSHNMariaDB.
 type XVSHNMariaDBSpec struct {
 	// Parameters are the configurable fields of a VSHNMariaDB.

--- a/apis/vshn/v1/dbaas_vshn_redis.go
+++ b/apis/vshn/v1/dbaas_vshn_redis.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"fmt"
+
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -164,6 +165,10 @@ type XVSHNRedis struct {
 
 	Spec   XVSHNRedisSpec   `json:"spec"`
 	Status XVSHNRedisStatus `json:"status,omitempty"`
+}
+
+func (v *XVSHNRedis) GetInstanceNamespace() string {
+	return fmt.Sprintf("vshn-redis-%s", v.GetName())
 }
 
 // XVSHNRedisSpec defines the desired state of a VSHNRedis.

--- a/apis/vshn/v1/vshn_minio.go
+++ b/apis/vshn/v1/vshn_minio.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"fmt"
+
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -128,6 +129,10 @@ type XVSHNMinio struct {
 
 	Spec   XVSHNMinioSpec   `json:"spec"`
 	Status XVSHNMinioStatus `json:"status,omitempty"`
+}
+
+func (v *XVSHNMinio) GetInstanceNamespace() string {
+	return fmt.Sprintf("vshn-minio-%s", v.GetName())
 }
 
 // XVSHNMinioSpec defines the desired state of a VSHNMinio.

--- a/pkg/apiserver/appcat/appcat.go
+++ b/pkg/apiserver/appcat/appcat.go
@@ -3,8 +3,8 @@ package appcat
 import (
 	crossplane "github.com/crossplane/crossplane/apis/apiextensions/v1"
 	appcatv1 "github.com/vshn/appcat/v4/apis/apiserver/v1"
-	"github.com/vshn/appcat/v4/pkg/apiserver"
 	"github.com/vshn/appcat/v4/pkg/apiserver/noop"
+	"github.com/vshn/appcat/v4/pkg/common/utils"
 	"k8s.io/apimachinery/pkg/runtime"
 	genericregistry "k8s.io/apiserver/pkg/registry/generic"
 	"k8s.io/apiserver/pkg/registry/rest"
@@ -37,7 +37,7 @@ func New() restbuilder.ResourceHandlerProvider {
 
 		noopImplementation := noop.New(s, &appcatv1.AppCat{}, &appcatv1.AppCatList{})
 
-		if !apiserver.IsTypeAvailable(crossplane.SchemeGroupVersion.String(), "Composition") {
+		if !utils.IsKindAvailable(crossplane.SchemeGroupVersion, "Composition", loopback.GetLoopbackMasterClientConfig()) {
 			return noopImplementation, nil
 		}
 

--- a/pkg/apiserver/common.go
+++ b/pkg/apiserver/common.go
@@ -6,8 +6,6 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/discovery"
-	"sigs.k8s.io/apiserver-runtime/pkg/util/loopback"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -90,22 +88,4 @@ func GetBackupColumnDefinition() []metav1.TableColumnDefinition {
 		{Name: "Status", Type: "string", Description: "The state of this backup"},
 		{Name: "Age", Type: "date", Description: desc["creationTimestamp"]},
 	}
-}
-
-func IsTypeAvailable(gv string, kind string) bool {
-	d, err := discovery.NewDiscoveryClientForConfig(loopback.GetLoopbackMasterClientConfig())
-	if err != nil {
-		return false
-	}
-	resources, err := d.ServerResourcesForGroupVersion(gv)
-	if err != nil {
-		return false
-	}
-
-	for _, res := range resources.APIResources {
-		if res.Kind == kind {
-			return true
-		}
-	}
-	return false
 }

--- a/pkg/apiserver/vshn/mariadb/backup.go
+++ b/pkg/apiserver/vshn/mariadb/backup.go
@@ -4,9 +4,9 @@ import (
 	k8upv1 "github.com/k8up-io/k8up/v2/api/v1"
 	appcatv1 "github.com/vshn/appcat/v4/apis/apiserver/v1"
 	vshnv1 "github.com/vshn/appcat/v4/apis/vshn/v1"
-	"github.com/vshn/appcat/v4/pkg/apiserver"
 	"github.com/vshn/appcat/v4/pkg/apiserver/noop"
 	"github.com/vshn/appcat/v4/pkg/apiserver/vshn/k8up"
+	"github.com/vshn/appcat/v4/pkg/common/utils"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	genericregistry "k8s.io/apiserver/pkg/registry/generic"
@@ -37,7 +37,7 @@ func New() restbuilder.ResourceHandlerProvider {
 
 		noopImplementation := noop.New(s, &appcatv1.VSHNMariaDBBackup{}, &appcatv1.VSHNMariaDBBackupList{})
 
-		if !apiserver.IsTypeAvailable(vshnv1.GroupVersion.String(), "XVSHNMariaDB") {
+		if !utils.IsKindAvailable(vshnv1.GroupVersion, "XVSHNMariaDB", loopback.GetLoopbackMasterClientConfig()) {
 			return noopImplementation, nil
 		}
 

--- a/pkg/apiserver/vshn/nextcloud/backup.go
+++ b/pkg/apiserver/vshn/nextcloud/backup.go
@@ -4,10 +4,10 @@ import (
 	k8upv1 "github.com/k8up-io/k8up/v2/api/v1"
 	appcatv1 "github.com/vshn/appcat/v4/apis/apiserver/v1"
 	vshnv1 "github.com/vshn/appcat/v4/apis/vshn/v1"
-	"github.com/vshn/appcat/v4/pkg/apiserver"
 	"github.com/vshn/appcat/v4/pkg/apiserver/noop"
 	"github.com/vshn/appcat/v4/pkg/apiserver/vshn/k8up"
 	"github.com/vshn/appcat/v4/pkg/apiserver/vshn/postgres"
+	"github.com/vshn/appcat/v4/pkg/common/utils"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	genericregistry "k8s.io/apiserver/pkg/registry/generic"
@@ -41,7 +41,7 @@ func New() restbuilder.ResourceHandlerProvider {
 
 		noopImplementation := noop.New(s, &appcatv1.VSHNNextcloudBackup{}, &appcatv1.VSHNNextcloudBackupList{})
 
-		if !apiserver.IsTypeAvailable(vshnv1.GroupVersion.String(), "XVSHNNextcloud") {
+		if !utils.IsKindAvailable(vshnv1.GroupVersion, "XVSHNNextcloud", loopback.GetLoopbackMasterClientConfig()) {
 			return noopImplementation, nil
 		}
 

--- a/pkg/apiserver/vshn/postgres/backup.go
+++ b/pkg/apiserver/vshn/postgres/backup.go
@@ -3,8 +3,8 @@ package postgres
 import (
 	appcatv1 "github.com/vshn/appcat/v4/apis/apiserver/v1"
 	vshnv1 "github.com/vshn/appcat/v4/apis/vshn/v1"
-	"github.com/vshn/appcat/v4/pkg/apiserver"
 	"github.com/vshn/appcat/v4/pkg/apiserver/noop"
+	"github.com/vshn/appcat/v4/pkg/common/utils"
 	"k8s.io/apimachinery/pkg/runtime"
 	genericregistry "k8s.io/apiserver/pkg/registry/generic"
 	"k8s.io/apiserver/pkg/registry/rest"
@@ -29,7 +29,7 @@ func New() restbuilder.ResourceHandlerProvider {
 
 		noopImplementation := noop.New(s, &appcatv1.VSHNPostgresBackup{}, &appcatv1.VSHNPostgresBackupList{})
 
-		if !apiserver.IsTypeAvailable(vshnv1.GroupVersion.String(), "VSHNPostgreSQL") {
+		if !utils.IsKindAvailable(vshnv1.GroupVersion, "VSHNPostgreSQL", loopback.GetLoopbackMasterClientConfig()) {
 			return noopImplementation, nil
 		}
 

--- a/pkg/apiserver/vshn/redis/backup.go
+++ b/pkg/apiserver/vshn/redis/backup.go
@@ -4,9 +4,9 @@ import (
 	k8upv1 "github.com/k8up-io/k8up/v2/api/v1"
 	appcatv1 "github.com/vshn/appcat/v4/apis/apiserver/v1"
 	vshnv1 "github.com/vshn/appcat/v4/apis/vshn/v1"
-	"github.com/vshn/appcat/v4/pkg/apiserver"
 	"github.com/vshn/appcat/v4/pkg/apiserver/noop"
 	"github.com/vshn/appcat/v4/pkg/apiserver/vshn/k8up"
+	"github.com/vshn/appcat/v4/pkg/common/utils"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	genericregistry "k8s.io/apiserver/pkg/registry/generic"
@@ -37,7 +37,7 @@ func New() restbuilder.ResourceHandlerProvider {
 
 		noopImplementation := noop.New(s, &appcatv1.VSHNRedisBackup{}, &appcatv1.VSHNRedisBackupList{})
 
-		if !apiserver.IsTypeAvailable(vshnv1.GroupVersion.String(), "XVSHNRedis") {
+		if !utils.IsKindAvailable(vshnv1.GroupVersion, "XVSHNRedis", loopback.GetLoopbackMasterClientConfig()) {
 			return noopImplementation, nil
 		}
 

--- a/pkg/common/utils/kinds.go
+++ b/pkg/common/utils/kinds.go
@@ -1,0 +1,26 @@
+package utils
+
+import (
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+)
+
+// IsKindAvailable will check if the given type is available
+func IsKindAvailable(gv schema.GroupVersion, kind string, config *rest.Config) bool {
+	d, err := discovery.NewDiscoveryClientForConfig(config)
+	if err != nil {
+		return false
+	}
+	resources, err := d.ServerResourcesForGroupVersion(gv.String())
+	if err != nil {
+		return false
+	}
+
+	for _, res := range resources.APIResources {
+		if res.Kind == kind {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/comp-functions/functions/common/interfaces.go
+++ b/pkg/comp-functions/functions/common/interfaces.go
@@ -28,10 +28,15 @@ type InfoGetter interface {
 // InstanceNamespaceInfo provides all the necessary information to create
 // an instance namespace.
 type InstanceNamespaceInfo interface {
+	InstanceNamespaceGetter
 	GetName() string
 	GetClaimNamespace() string
-	GetInstanceNamespace() string
 	GetLabels() map[string]string
+}
+
+// InstanceNamespaceGetter returns the instance namespace of the given object
+type InstanceNamespaceGetter interface {
+	GetInstanceNamespace() string
 }
 
 // Composite can get and set the relevant information on a given composite.

--- a/pkg/sliexporter/vshnkeycloak_controller/vshnkeycloak_controller.go
+++ b/pkg/sliexporter/vshnkeycloak_controller/vshnkeycloak_controller.go
@@ -32,6 +32,7 @@ type VSHNKeycloakReconciler struct {
 
 	ProbeManager       probeManager
 	StartupGracePeriod time.Duration
+	ScClient           client.Client
 }
 
 type probeManager interface {
@@ -52,7 +53,7 @@ func (r *VSHNKeycloakReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	inst := &vshnv1.XVSHNKeycloak{}
 
-	reconciler := slireconciler.New(inst, l, r.ProbeManager, vshnKeycloakServiceKey, req.NamespacedName, r.Client, r.StartupGracePeriod, r.getKeycloakProber)
+	reconciler := slireconciler.New(inst, l, r.ProbeManager, vshnKeycloakServiceKey, req.NamespacedName, r.Client, r.StartupGracePeriod, r.getKeycloakProber, r.ScClient)
 
 	return reconciler.Reconcile(ctx)
 

--- a/pkg/sliexporter/vshnkeycloak_controller/vshnkeycloak_controller_test.go
+++ b/pkg/sliexporter/vshnkeycloak_controller/vshnkeycloak_controller_test.go
@@ -50,10 +50,10 @@ func getFakeKey(pi probes.ProbeInfo) key {
 }
 
 func TestVSHNKeycloakReconciler_Reconcile(t *testing.T) {
-	keycloak := newTestVSHNKeycloak("bar", "foo", "cred")
+	keycloak, ns := newTestVSHNKeycloak("bar", "foo", "cred")
 
 	r, manager, client := setupVSHNKeycloakTest(t,
-		keycloak,
+		keycloak, ns,
 		newTestVSHNKeycloakCred("bar", "cred"))
 
 	req := ctrl.Request{
@@ -92,13 +92,14 @@ func setupVSHNKeycloakTest(t *testing.T, objs ...client.Object) (VSHNKeycloakRec
 		Scheme:             scheme,
 		StartupGracePeriod: 5 * time.Minute,
 		ProbeManager:       manager,
+		ScClient:           client,
 	}
 
 	return r, manager, client
 }
 
-func newTestVSHNKeycloak(namespace, name, cred string) *vshnv1.XVSHNKeycloak {
-	return &vshnv1.XVSHNKeycloak{
+func newTestVSHNKeycloak(namespace, name, cred string) (*vshnv1.XVSHNKeycloak, *corev1.Namespace) {
+	claim := &vshnv1.XVSHNKeycloak{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
@@ -113,6 +114,14 @@ func newTestVSHNKeycloak(namespace, name, cred string) *vshnv1.XVSHNKeycloak {
 			},
 		},
 	}
+
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: claim.GetInstanceNamespace(),
+		},
+	}
+
+	return claim, ns
 }
 
 func newTestVSHNKeycloakCred(namespace, name string) *corev1.Secret {

--- a/pkg/sliexporter/vshnmariadb_controller/vshnmariadb_controller.go
+++ b/pkg/sliexporter/vshnmariadb_controller/vshnmariadb_controller.go
@@ -37,6 +37,7 @@ type VSHNMariaDBReconciler struct {
 	ProbeManager       probeManager
 	StartupGracePeriod time.Duration
 	MariaDBDialer      func(service, name, namespace, dsn, organization, serviceLevel, caCRT string, ha, TLSEnabled bool) (*probes.MariaDB, error)
+	ScClient           client.Client
 }
 
 //+kubebuilder:rbac:groups=vshn.appcat.vshn.io,resources=xvshnmariadbs,verbs=get;list;watch
@@ -54,7 +55,7 @@ func (r *VSHNMariaDBReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 	inst := &vshnv1.XVSHNMariaDB{}
 
-	reconciler := slireconciler.New(inst, l, r.ProbeManager, vshnMariadbServiceKey, req.NamespacedName, r.Client, r.StartupGracePeriod, r.fetchProberFor)
+	reconciler := slireconciler.New(inst, l, r.ProbeManager, vshnMariadbServiceKey, req.NamespacedName, r.Client, r.StartupGracePeriod, r.fetchProberFor, r.ScClient)
 
 	return reconciler.Reconcile(ctx)
 }

--- a/pkg/sliexporter/vshnmariadb_controller/vshnmariadb_controller_test.go
+++ b/pkg/sliexporter/vshnmariadb_controller/vshnmariadb_controller_test.go
@@ -52,10 +52,10 @@ func getFakeKey(pi probes.ProbeInfo) key {
 }
 
 func TestVSHNMariaDB_Reconcile(t *testing.T) {
-	mariadb := newTestVSHNMariaDB("bar", "foo", "cred")
+	mariadb, ns := newTestVSHNMariaDB("bar", "foo", "cred")
 
 	r, manager, client := setupVSHNMariaDBTest(t,
-		mariadb,
+		mariadb, ns,
 		newTestVSHNMariaDBCred("bar", "cred"))
 
 	req := ctrl.Request{
@@ -94,13 +94,14 @@ func setupVSHNMariaDBTest(t *testing.T, objs ...client.Object) (VSHNMariaDBRecon
 		Scheme:             scheme,
 		StartupGracePeriod: 5 * time.Minute,
 		ProbeManager:       manager,
+		ScClient:           client,
 	}
 
 	return r, manager, client
 }
 
-func newTestVSHNMariaDB(namespace, name, cred string) *vshnv1.XVSHNMariaDB {
-	return &vshnv1.XVSHNMariaDB{
+func newTestVSHNMariaDB(namespace, name, cred string) (*vshnv1.XVSHNMariaDB, *corev1.Namespace) {
+	claim := &vshnv1.XVSHNMariaDB{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
@@ -115,6 +116,14 @@ func newTestVSHNMariaDB(namespace, name, cred string) *vshnv1.XVSHNMariaDB {
 			},
 		},
 	}
+
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: claim.GetInstanceNamespace(),
+		},
+	}
+
+	return claim, ns
 }
 
 func newTestVSHNMariaDBCred(namespace, name string) *corev1.Secret {

--- a/pkg/sliexporter/vshnminio_controller/vshnminio_controller.go
+++ b/pkg/sliexporter/vshnminio_controller/vshnminio_controller.go
@@ -34,6 +34,7 @@ type VSHNMinioReconciler struct {
 	ProbeManager       probeManager
 	StartupGracePeriod time.Duration
 	MinioDialer        func(service, name, namespace, organization, sla, endpointURL string, ha bool, opts minio.Options) (*probes.VSHNMinio, error)
+	ScClient           client.Client
 }
 
 type probeManager interface {
@@ -54,7 +55,7 @@ func (r *VSHNMinioReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	inst := &vshnv1.XVSHNMinio{}
 
-	reconciler := slireconciler.New(inst, l, r.ProbeManager, vshnMinioServiceKey, req.NamespacedName, r.Client, r.StartupGracePeriod, r.getMinioProber)
+	reconciler := slireconciler.New(inst, l, r.ProbeManager, vshnMinioServiceKey, req.NamespacedName, r.Client, r.StartupGracePeriod, r.getMinioProber, r.ScClient)
 
 	return reconciler.Reconcile(ctx)
 

--- a/pkg/sliexporter/vshnpostgresql_controller/vshnpostgresql_controller.go
+++ b/pkg/sliexporter/vshnpostgresql_controller/vshnpostgresql_controller.go
@@ -50,6 +50,7 @@ type VSHNPostgreSQLReconciler struct {
 	ProbeManager       probeManager
 	StartupGracePeriod time.Duration
 	PostgreDialer      func(service, name, namespace, dsn, organization, serviceLevel string, ha bool, ops ...func(*pgxpool.Config) error) (*probes.PostgreSQL, error)
+	ScClient           client.Client
 }
 
 type probeManager interface {
@@ -71,7 +72,7 @@ func (r *VSHNPostgreSQLReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 	inst := &vshnv1.XVSHNPostgreSQL{}
 
-	reconciler := slireconciler.New(inst, l, r.ProbeManager, vshnpostgresqlsServiceKey, req.NamespacedName, r.Client, r.StartupGracePeriod, r.fetchProberFor)
+	reconciler := slireconciler.New(inst, l, r.ProbeManager, vshnpostgresqlsServiceKey, req.NamespacedName, r.Client, r.StartupGracePeriod, r.fetchProberFor, r.ScClient)
 
 	return reconciler.Reconcile(ctx)
 }

--- a/pkg/sliexporter/vshnredis_controller/vshnredis_controller.go
+++ b/pkg/sliexporter/vshnredis_controller/vshnredis_controller.go
@@ -35,6 +35,7 @@ type VSHNRedisReconciler struct {
 	ProbeManager       probeManager
 	StartupGracePeriod time.Duration
 	RedisDialer        func(service, name, namespace, organization, sla string, ha bool, opts redis.Options) (*probes.VSHNRedis, error)
+	ScClient           client.Client
 }
 
 type probeManager interface {
@@ -54,7 +55,7 @@ func (r *VSHNRedisReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	l.Info("Reconciling VSHNRedis")
 	inst := &vshnv1.XVSHNRedis{}
 
-	reconciler := slireconciler.New(inst, l, r.ProbeManager, vshnRedisServiceKey, req.NamespacedName, r.Client, r.StartupGracePeriod, r.getRedisProber)
+	reconciler := slireconciler.New(inst, l, r.ProbeManager, vshnRedisServiceKey, req.NamespacedName, r.Client, r.StartupGracePeriod, r.getRedisProber, r.ScClient)
 
 	return reconciler.Reconcile(ctx)
 


### PR DESCRIPTION
## Summary

This adds support for remote control planes for the SLI exporter. It now
takes an additional `KUBECONFIG` env var to connect to the control plane.

Additionally to determine the state of the maintenance of the service
cluster, it connects to the local service cluster to reconcile on
`UpgradeJob` objects.

Also the SLI-Prober doesn't need any configuration about the services
anymore. It will detect these on startup.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
