### PR TITLE
Set the correct version for the SGCluster

### DIFF
--- a/pkg/comp-functions/functions/vshnpostgres/postgresql_deploy_test.go
+++ b/pkg/comp-functions/functions/vshnpostgres/postgresql_deploy_test.go
@@ -59,7 +59,6 @@ func TestPostgreSqlDeploy(t *testing.T) {
 	assert.Equal(t, comp.GetName(), cluster.Name)
 	assert.Equal(t, comp.GetInstanceNamespace(), cluster.Namespace)
 	assert.Equal(t, comp.Spec.Parameters.Instances, cluster.Spec.Instances)
-	assert.Equal(t, comp.Spec.Parameters.Service.MajorVersion, cluster.Spec.Postgres.Version)
 	assert.Nil(t, cluster.Spec.InitialData.Restore)
 	assert.Equal(t, comp.GetName(), *cluster.Spec.SgInstanceProfile)
 	assert.Equal(t, comp.GetName(), *cluster.Spec.Configurations.SgPostgresConfig)

--- a/test/functions/vshn-postgres/deploy/01_default.yaml
+++ b/test/functions/vshn-postgres/deploy/01_default.yaml
@@ -282,7 +282,7 @@ observed:
                     privateKeySecretKeySelector:
                       key: tls.key
                       name: tls-certificate
-                  version: "15"
+                  version: "15.1"
                 sgInstanceProfile: psql-gc9x4
           managementPolicy: Default
           providerConfigRef:


### PR DESCRIPTION
## Summary

We need to ensure that the SGCluster always contains the "correct" version and that we don't override it with just a major version. The reason is, that Stackgres doesn't allow changing the version number in the `SGCluster` object. Since stackgres changes the version field during a minor upgrade, it won't be possible anymore to "revert" this change to a major version only setting.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
