### PR TITLE
add TLS fix

### DIFF
--- a/apis/vshn/v1/dbaas_vshn_postgresql.go
+++ b/apis/vshn/v1/dbaas_vshn_postgresql.go
@@ -14,7 +14,7 @@ import (
 //go:generate yq -i e ../../generated/vshn.appcat.vshn.io_vshnpostgresqls.yaml --expression "with(.spec.versions[]; .schema.openAPIV3Schema.properties.spec.properties.parameters.default={})"
 //go:generate yq -i e ../../generated/vshn.appcat.vshn.io_vshnpostgresqls.yaml --expression "with(.spec.versions[]; .schema.openAPIV3Schema.properties.spec.properties.parameters.properties.size.default={})"
 //go:generate yq -i e ../../generated/vshn.appcat.vshn.io_vshnpostgresqls.yaml --expression "with(.spec.versions[]; .schema.openAPIV3Schema.properties.spec.properties.parameters.properties.service.default={})"
-//go:generate yq -i e ../../generated/vshn.appcat.vshn.io_vshnpostgresqls.yaml --expression "with(.spec.versions[]; .schema.openAPIV3Schema.properties.spec.properties.parameters.properties.service.tls.default={})"
+//go:generate yq -i e ../../generated/vshn.appcat.vshn.io_vshnpostgresqls.yaml --expression "with(.spec.versions[]; .schema.openAPIV3Schema.properties.spec.properties.parameters.properties.service.properties.tls.default={})"
 //go:generate yq -i e ../../generated/vshn.appcat.vshn.io_vshnpostgresqls.yaml --expression "with(.spec.versions[]; .schema.openAPIV3Schema.properties.spec.properties.parameters.properties.backup.default={})"
 //go:generate yq -i e ../../generated/vshn.appcat.vshn.io_vshnpostgresqls.yaml --expression "with(.spec.versions[]; .schema.openAPIV3Schema.properties.spec.properties.parameters.properties.maintenance.default={})"
 //go:generate yq -i e ../../generated/vshn.appcat.vshn.io_vshnpostgresqls.yaml --expression "with(.spec.versions[]; .schema.openAPIV3Schema.properties.spec.properties.parameters.properties.security.default={})"

--- a/crds/vshn.appcat.vshn.io_vshnpostgresqls.yaml
+++ b/crds/vshn.appcat.vshn.io_vshnpostgresqls.yaml
@@ -5088,13 +5088,12 @@ spec:
                                 This change takes effect immediately and does not require a restart of the database.
                               type: boolean
                           type: object
+                          default: {}
                         vacuumEnabled:
                           default: false
                           type: boolean
                       type: object
                       default: {}
-                      tls:
-                        default: {}
                     size:
                       description: Size contains settings to control the sizing of a service.
                       properties:


### PR DESCRIPTION
## Summary

* Fixing TLS settings
* For context: there is a difference if we initialize nested map inside some struct and single field. I had to add `properties` entry to generator to make it work.
* Currently our XVSHNPostgreSQL receives new struct inside `spec.parameters.service` and has a form:
```        
        repackEnabled: true
        serviceLevel: besteffort
 ++  tls:
 ++      enabled: true
        vacuumEnabled: false
```
* test cases I did:
** new instance
** existing instance during migration from `master` branch
** existing instances with previous fixes and partially applied fields 

