### PR TITLE
Switch instances monitoring from cluster to user-workload monitoring

### DIFF
--- a/pkg/comp-functions/functions/common/billing.go
+++ b/pkg/comp-functions/functions/common/billing.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
+
 	xfnproto "github.com/crossplane/function-sdk-go/proto/v1beta1"
 	v1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/vshn/appcat/v4/pkg/comp-functions/runtime"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 )
@@ -75,6 +77,13 @@ func CreateBillingRecord(ctx context.Context, svc *runtime.ServiceRuntime, comp 
 	}
 
 	p := &v1.PrometheusRule{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				// This label is required, the ensure that the rule is added to Prometheus and
+				// not the Thanos Rules in the Openshift User Workload Monitoring
+				"openshift.io/prometheus-rule-evaluation-scope": "leaf-prometheus",
+			},
+		},
 		Spec: v1.PrometheusRuleSpec{
 			Groups: []v1.RuleGroup{
 				rg,

--- a/pkg/comp-functions/functions/common/instance_namespace.go
+++ b/pkg/comp-functions/functions/common/instance_namespace.go
@@ -121,7 +121,7 @@ func createInstanceNamespace(serviceName, compName, claimNamespace, instanceName
 				"appuio.io/no-rbac-creation":      "true",
 				"appuio.io/billing-name":          billingName,
 				"appuio.io/organization":          org,
-				"openshift.io/cluster-monitoring": "true",
+				"openshift.io/cluster-monitoring": "false",
 			},
 		},
 	}


### PR DESCRIPTION
## Summary

This PR will switch the monitoring of the instances from cluster monitoring to user-workload monitoring.
This is required to have alerting and monitoring work for the end users


## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [ ] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
