### PR TITLE
correct default in postgresql crds

### DIFF
--- a/apis/vshn/v1/dbaas_vshn_postgresql.go
+++ b/apis/vshn/v1/dbaas_vshn_postgresql.go
@@ -118,7 +118,7 @@ type VSHNPostgreSQLUpdateStrategy struct {
 	// +kubebuilder:validation:Enum="Immediate";"OnRestart"
 	// +kubebuilder:default="Immediate"
 
-	// Type indicates the type of the UpdateStrategy. Default is OnRestart.
+	// Type indicates the type of the UpdateStrategy. Default is Immediate.
 	// Possible enum values:
 	//   - `"OnRestart"` indicates that the changes to the spec will only be applied once the instance is restarted by other means, most likely during maintenance.
 	//   - `"Immediate"` indicates that update will be applied to the instance as soon as the spec changes. Please be aware that this might lead to short downtime.

--- a/crds/vshn.appcat.vshn.io_vshnkeycloaks.yaml
+++ b/crds/vshn.appcat.vshn.io_vshnkeycloaks.yaml
@@ -9936,7 +9936,7 @@ spec:
                                 type:
                                   default: Immediate
                                   description: |-
-                                    Type indicates the type of the UpdateStrategy. Default is OnRestart.
+                                    Type indicates the type of the UpdateStrategy. Default is Immediate.
                                     Possible enum values:
                                       - `"OnRestart"` indicates that the changes to the spec will only be applied once the instance is restarted by other means, most likely during maintenance.
                                       - `"Immediate"` indicates that update will be applied to the instance as soon as the spec changes. Please be aware that this might lead to short downtime.

--- a/crds/vshn.appcat.vshn.io_vshnnextclouds.yaml
+++ b/crds/vshn.appcat.vshn.io_vshnnextclouds.yaml
@@ -9918,7 +9918,7 @@ spec:
                                 type:
                                   default: Immediate
                                   description: |-
-                                    Type indicates the type of the UpdateStrategy. Default is OnRestart.
+                                    Type indicates the type of the UpdateStrategy. Default is Immediate.
                                     Possible enum values:
                                       - `"OnRestart"` indicates that the changes to the spec will only be applied once the instance is restarted by other means, most likely during maintenance.
                                       - `"Immediate"` indicates that update will be applied to the instance as soon as the spec changes. Please be aware that this might lead to short downtime.

--- a/crds/vshn.appcat.vshn.io_vshnpostgresqls.yaml
+++ b/crds/vshn.appcat.vshn.io_vshnpostgresqls.yaml
@@ -5127,7 +5127,7 @@ spec:
                         type:
                           default: Immediate
                           description: |-
-                            Type indicates the type of the UpdateStrategy. Default is OnRestart.
+                            Type indicates the type of the UpdateStrategy. Default is Immediate.
                             Possible enum values:
                               - `"OnRestart"` indicates that the changes to the spec will only be applied once the instance is restarted by other means, most likely during maintenance.
                               - `"Immediate"` indicates that update will be applied to the instance as soon as the spec changes. Please be aware that this might lead to short downtime.

--- a/crds/vshn.appcat.vshn.io_xvshnkeycloaks.yaml
+++ b/crds/vshn.appcat.vshn.io_xvshnkeycloaks.yaml
@@ -11733,7 +11733,7 @@ spec:
                               type:
                                 default: Immediate
                                 description: |-
-                                  Type indicates the type of the UpdateStrategy. Default is OnRestart.
+                                  Type indicates the type of the UpdateStrategy. Default is Immediate.
                                   Possible enum values:
                                     - `"OnRestart"` indicates that the changes to the spec will only be applied once the instance is restarted by other means, most likely during maintenance.
                                     - `"Immediate"` indicates that update will be applied to the instance as soon as the spec changes. Please be aware that this might lead to short downtime.

--- a/crds/vshn.appcat.vshn.io_xvshnnextclouds.yaml
+++ b/crds/vshn.appcat.vshn.io_xvshnnextclouds.yaml
@@ -11718,7 +11718,7 @@ spec:
                               type:
                                 default: Immediate
                                 description: |-
-                                  Type indicates the type of the UpdateStrategy. Default is OnRestart.
+                                  Type indicates the type of the UpdateStrategy. Default is Immediate.
                                   Possible enum values:
                                     - `"OnRestart"` indicates that the changes to the spec will only be applied once the instance is restarted by other means, most likely during maintenance.
                                     - `"Immediate"` indicates that update will be applied to the instance as soon as the spec changes. Please be aware that this might lead to short downtime.

--- a/crds/vshn.appcat.vshn.io_xvshnpostgresqls.yaml
+++ b/crds/vshn.appcat.vshn.io_xvshnpostgresqls.yaml
@@ -5824,7 +5824,7 @@ spec:
                       type:
                         default: Immediate
                         description: |-
-                          Type indicates the type of the UpdateStrategy. Default is OnRestart.
+                          Type indicates the type of the UpdateStrategy. Default is Immediate.
                           Possible enum values:
                             - `"OnRestart"` indicates that the changes to the spec will only be applied once the instance is restarted by other means, most likely during maintenance.
                             - `"Immediate"` indicates that update will be applied to the instance as soon as the spec changes. Please be aware that this might lead to short downtime.


### PR DESCRIPTION
## Summary

* Our defaults in CRD should reflect what's written to docs.appcat.ch

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [x] Link this PR to related issues.
