### PR TITLE
Add image repository parameter, to be able to override the registry

### DIFF
--- a/pkg/comp-functions/functions/vshnnextcloud/collabora.go
+++ b/pkg/comp-functions/functions/vshnnextcloud/collabora.go
@@ -536,7 +536,7 @@ func createInstallCollaboraJob(comp *vshnv1.VSHNNextcloud, svc *runtime.ServiceR
 					Containers: []corev1.Container{
 						{
 							Name:  comp.GetName() + "-install-collabora",
-							Image: "quay.io/appuio/oc:v4.13",
+							Image: svc.Config.Data["oc_image"],
 							Command: []string{
 								"bash",
 								"-cefx",

--- a/pkg/comp-functions/functions/vshnnextcloud/deploy.go
+++ b/pkg/comp-functions/functions/vshnnextcloud/deploy.go
@@ -223,7 +223,7 @@ func newValues(ctx context.Context, svc *runtime.ServiceRuntime, comp *vshnv1.VS
 		extraInitContainers = []map[string]any{
 			{
 				"name":  "dbchecker",
-				"image": "docker.io/busybox",
+				"image": svc.Config.Data["busybox_image"],
 				"command": []string{
 					"sh",
 					"-c",

--- a/pkg/comp-functions/functions/vshnnextcloud/deploy.go
+++ b/pkg/comp-functions/functions/vshnnextcloud/deploy.go
@@ -264,6 +264,9 @@ func newValues(ctx context.Context, svc *runtime.ServiceRuntime, comp *vshnv1.VS
 
 	updatedNextcloudConfig := setBackgroundJobMaintenance(comp.Spec.Parameters.Maintenance.GetMaintenanceTimeOfDay(), nextcloudConfig)
 	values = map[string]any{
+		"image": map[string]any{
+			"repository": svc.Config.Data["nextcloud_image"],
+		},
 		"nextcloud": map[string]any{
 			"host":           comp.Spec.Parameters.Service.FQDN[0],
 			"trustedDomains": trustedDomain,


### PR DESCRIPTION
## Summary

Currently, the registry is hardcoded to docker.io. However, we want to be able to use a different registry in some cases (eg. to avoid rate-limiting). Using this parameter allows us to change the registry for the nextcloud image to another registry.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [ ] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
