### PR TITLE
Make connection details split cluster compatible

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "name": "KubeBuilder Example",
+  "name": "AppCat Devcontainer",
   "build": {
     "dockerfile": "./Dockerfile"
   },

--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,7 @@ test: ## Run tests
 .PHONY: kind-load-branch-tag
 kind-load-branch-tag: ## load docker image with current branch tag into kind
 	tag=$$(git rev-parse --abbrev-ref HEAD) && \
-	kind load docker-image --name kindev ghcr.io/vshn/appcat:"$${tag////_}"
+	kind load docker-image --name kindev ghcr.io/vshn/appcat:"$$(echo $$tag | sed 's#/#_#g')"
 
 # Generate webhook certificates.
 # This is only relevant when debugging.

--- a/apis/vshn/v1/dbaas_vshn_mariadb.go
+++ b/apis/vshn/v1/dbaas_vshn_mariadb.go
@@ -78,6 +78,9 @@ type VSHNMariaDBParameters struct {
 	// Monitoring contains settings to control monitoring.
 	Monitoring VSHNMonitoring `json:"monitoring,omitempty"`
 
+	// Network contains any network related settings.
+	Network VSHNDBaaSNetworkSpec `json:"network,omitempty"`
+
 	// Security defines the security of a service
 	Security Security `json:"security,omitempty"`
 

--- a/apis/vshn/v1/zz_generated.deepcopy.go
+++ b/apis/vshn/v1/zz_generated.deepcopy.go
@@ -533,6 +533,7 @@ func (in *VSHNMariaDBParameters) DeepCopyInto(out *VSHNMariaDBParameters) {
 	out.Restore = in.Restore
 	out.Maintenance = in.Maintenance
 	in.Monitoring.DeepCopyInto(&out.Monitoring)
+	in.Network.DeepCopyInto(&out.Network)
 	in.Security.DeepCopyInto(&out.Security)
 }
 

--- a/crds/vshn.appcat.vshn.io_vshnmariadbs.yaml
+++ b/crds/vshn.appcat.vshn.io_vshnmariadbs.yaml
@@ -4804,6 +4804,31 @@ spec:
                           description: Email necessary to send alerts via email
                           type: string
                       type: object
+                    network:
+                      description: Network contains any network related settings.
+                      properties:
+                        ipFilter:
+                          default:
+                            - 0.0.0.0/0
+                          description: |-
+                            IPFilter is a list of allowed IPv4 CIDR ranges that can access the service.
+                            If no IP Filter is set, you may not be able to reach the service.
+                            A value of `0.0.0.0/0` will open the service to all addresses on the public internet.
+                          items:
+                            type: string
+                          type: array
+                        serviceType:
+                          default: ClusterIP
+                          description: |-
+                            ServiceType defines the type of the service.
+                            Possible enum values:
+                              - `"ClusterIP"` indicates that the service is only reachable from within the cluster.
+                              - `"LoadBalancer"` indicates that the service is reachable from the public internet via dedicated Ipv4 address.
+                          enum:
+                            - ClusterIP
+                            - LoadBalancer
+                          type: string
+                      type: object
                     restore:
                       description: Restore contains settings to control the restore of an instance.
                       properties:

--- a/crds/vshn.appcat.vshn.io_xvshnmariadbs.yaml
+++ b/crds/vshn.appcat.vshn.io_xvshnmariadbs.yaml
@@ -5518,6 +5518,31 @@ spec:
                         description: Email necessary to send alerts via email
                         type: string
                     type: object
+                  network:
+                    description: Network contains any network related settings.
+                    properties:
+                      ipFilter:
+                        default:
+                        - 0.0.0.0/0
+                        description: |-
+                          IPFilter is a list of allowed IPv4 CIDR ranges that can access the service.
+                          If no IP Filter is set, you may not be able to reach the service.
+                          A value of `0.0.0.0/0` will open the service to all addresses on the public internet.
+                        items:
+                          type: string
+                        type: array
+                      serviceType:
+                        default: ClusterIP
+                        description: |-
+                          ServiceType defines the type of the service.
+                          Possible enum values:
+                            - `"ClusterIP"` indicates that the service is only reachable from within the cluster.
+                            - `"LoadBalancer"` indicates that the service is reachable from the public internet via dedicated Ipv4 address.
+                        enum:
+                        - ClusterIP
+                        - LoadBalancer
+                        type: string
+                    type: object
                   restore:
                     description: Restore contains settings to control the restore
                       of an instance.

--- a/pkg/comp-functions/functions/buckets/cloudscalebucket/cloudscalebucket.go
+++ b/pkg/comp-functions/functions/buckets/cloudscalebucket/cloudscalebucket.go
@@ -87,7 +87,11 @@ func addBucket(svc *runtime.ServiceRuntime, bucket *appcatv1.ObjectBucket, confi
 func addUser(svc *runtime.ServiceRuntime, bucket *appcatv1.ObjectBucket, config string) error {
 
 	user := &cloudscalev1.ObjectsUser{
-		ObjectMeta: metav1.ObjectMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				runtime.IgnoreConnectionDetailsAnnotation: "true",
+			},
+		},
 		Spec: cloudscalev1.ObjectsUserSpec{
 			ResourceSpec: xpv1.ResourceSpec{
 				ProviderConfigReference: &xpv1.Reference{

--- a/pkg/comp-functions/functions/buckets/exoscalebucket/exoscalebucket.go
+++ b/pkg/comp-functions/functions/buckets/exoscalebucket/exoscalebucket.go
@@ -80,9 +80,12 @@ func addBucket(svc *runtime.ServiceRuntime, bucket *appcatv1.ObjectBucket, confi
 }
 
 func addUser(svc *runtime.ServiceRuntime, bucket *appcatv1.ObjectBucket, config string) error {
-
 	user := &exoscalev1.IAMKey{
-		ObjectMeta: metav1.ObjectMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				runtime.IgnoreConnectionDetailsAnnotation: "true",
+			},
+		},
 		Spec: exoscalev1.IAMKeySpec{
 			ResourceSpec: xpv1.ResourceSpec{
 				ProviderConfigReference: &xpv1.Reference{

--- a/pkg/comp-functions/functions/buckets/miniobucket/miniobucket.go
+++ b/pkg/comp-functions/functions/buckets/miniobucket/miniobucket.go
@@ -79,6 +79,9 @@ func addUser(svc *runtime.ServiceRuntime, bucket *appcatv1.ObjectBucket, config 
 	user := &miniov1.User{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: bucket.Spec.Parameters.BucketName,
+			Annotations: map[string]string{
+				runtime.IgnoreConnectionDetailsAnnotation: "true",
+			},
 		},
 		Spec: miniov1.UserSpec{
 			ResourceSpec: xpv1.ResourceSpec{
@@ -87,7 +90,7 @@ func addUser(svc *runtime.ServiceRuntime, bucket *appcatv1.ObjectBucket, config 
 				},
 				WriteConnectionSecretToReference: &xpv1.SecretReference{
 					Name:      bucket.GetName(),
-					Namespace: "syn-crossplane",
+					Namespace: svc.GetCrossplaneNamespace(),
 				},
 			},
 			ForProvider: miniov1.UserParameters{

--- a/pkg/comp-functions/functions/common/backup/backup.go
+++ b/pkg/comp-functions/functions/common/backup/backup.go
@@ -67,8 +67,8 @@ func createObjectBucket(ctx context.Context, comp common.InfoGetter, svc *runtim
 			},
 			ResourceSpec: xpv1.ResourceSpec{
 				WriteConnectionSecretToReference: &xpv1.SecretReference{
-					Namespace: comp.GetInstanceNamespace(),
-					Name:      credentialSecretName,
+					Namespace: svc.GetCrossplaneNamespace(),
+					Name:      comp.GetName() + "-" + credentialSecretName,
 				},
 			},
 		},
@@ -148,7 +148,7 @@ func createK8upSchedule(ctx context.Context, comp common.InfoGetter, svc *runtim
 					Bucket:   bucket,
 					AccessKeyIDSecretRef: &corev1.SecretKeySelector{
 						LocalObjectReference: corev1.LocalObjectReference{
-							Name: credentialSecretName,
+							Name: comp.GetName() + "-" + credentialSecretName,
 						},
 						Key: "AWS_ACCESS_KEY_ID",
 					},

--- a/pkg/comp-functions/functions/common/backup/backup.go
+++ b/pkg/comp-functions/functions/common/backup/backup.go
@@ -68,7 +68,7 @@ func createObjectBucket(ctx context.Context, comp common.InfoGetter, svc *runtim
 			ResourceSpec: xpv1.ResourceSpec{
 				WriteConnectionSecretToReference: &xpv1.SecretReference{
 					Namespace: svc.GetCrossplaneNamespace(),
-					Name:      comp.GetName() + "-" + credentialSecretName,
+					Name:      credentialSecretName,
 				},
 			},
 		},
@@ -148,7 +148,7 @@ func createK8upSchedule(ctx context.Context, comp common.InfoGetter, svc *runtim
 					Bucket:   bucket,
 					AccessKeyIDSecretRef: &corev1.SecretKeySelector{
 						LocalObjectReference: corev1.LocalObjectReference{
-							Name: comp.GetName() + "-" + credentialSecretName,
+							Name: credentialSecretName,
 						},
 						Key: "AWS_ACCESS_KEY_ID",
 					},

--- a/pkg/comp-functions/functions/common/instance_namespace.go
+++ b/pkg/comp-functions/functions/common/instance_namespace.go
@@ -89,11 +89,8 @@ func createNamespaceObserver(claimNs string, instance string, svc *runtime.Servi
 			Name: claimNs,
 		},
 	}
-	labels := map[string]string{
-		"appcat.vshn.io/ignore-provider-config": "true",
-	}
 
-	return svc.SetDesiredKubeObject(ns, instance+claimNsObserverSuffix, runtime.KubeOptionAddLabels(labels), runtime.KubeOptionObserve)
+	return svc.SetDesiredKubeObject(ns, instance+claimNsObserverSuffix, runtime.KubeOptionDeployOnControlPlane, runtime.KubeOptionObserve)
 }
 
 // Create the namespace for the service instance

--- a/pkg/comp-functions/functions/common/mailgun_alerting.go
+++ b/pkg/comp-functions/functions/common/mailgun_alerting.go
@@ -109,31 +109,25 @@ func deployAlertmanagerConfig(ctx context.Context, name, email, instanceNamespac
 
 	xRef := xkube.Reference{
 		DependsOn: &xkube.DependsOn{
-			APIVersion: "v1",
-			Kind:       "Secret",
-			Namespace:  instanceNamespace,
-			Name:       alertManagerConfigSecretName,
+			Name: alertManagerConfigSecretName,
 		},
 	}
 
 	patchSecretWithOtherSecret := xkube.Reference{
 		PatchesFrom: &xkube.PatchesFrom{
 			DependsOn: xkube.DependsOn{
-				APIVersion: "v1",
-				Kind:       "Secret",
-				Namespace:  svc.Config.Data["emailAlertingSecretNamespace"],
-				Name:       svc.Config.Data["emailAlertingSecretName"],
+				Name: alertManagerConfigSecretName,
 			},
-			FieldPath: ptr.To("data.password"),
+			FieldPath: ptr.To("status.atProvider.manifest.data.password"),
 		},
 		ToFieldPath: ptr.To("data.password"),
 	}
 
-	if err := svc.SetDesiredKubeObject(secret, alertManagerConfigSecretName, runtime.KubeOptionAddRefs(patchSecretWithOtherSecret)); err != nil {
+	if err := svc.SetDesiredKubeObject(secret, alertManagerConfigSecretName, runtime.KubeOptionAddRefs(patchSecretWithOtherSecret), runtime.KubeOptionAllowDeletion); err != nil {
 		return err
 	}
 
-	return svc.SetDesiredKubeObject(ac, alertManagerConfigName, runtime.KubeOptionAddRefs(xRef))
+	return svc.SetDesiredKubeObject(ac, alertManagerConfigName, runtime.KubeOptionAddRefs(xRef), runtime.KubeOptionAllowDeletion)
 }
 
 func mailAlertingEnabled(config *v1.ConfigMap) bool {

--- a/pkg/comp-functions/functions/common/netpol.go
+++ b/pkg/comp-functions/functions/common/netpol.go
@@ -79,3 +79,27 @@ func CustomCreateNetworkPolicy(sourceNS []string, instanceNs, name string, allow
 
 	return nil
 }
+
+// AddLoadbalancerNetpolicy will allow all traffic to the namespace, so that the loabalancer
+// connection works as well.
+func AddLoadbalancerNetpolicy(svc *runtime.ServiceRuntime, comp InfoGetter) error {
+	np := &netv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "allow-all",
+			Namespace: comp.GetInstanceNamespace(),
+		},
+		Spec: netv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{},
+			Ingress: []netv1.NetworkPolicyIngressRule{
+				{},
+			},
+		},
+	}
+
+	err := svc.SetDesiredKubeObject(np, comp.GetName()+"-allow-all")
+	if err != nil {
+		return fmt.Errorf("cannot deploy allow all network policy: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/comp-functions/functions/common/password.go
+++ b/pkg/comp-functions/functions/common/password.go
@@ -55,6 +55,8 @@ func AddGenericSecret(comp InfoGetter, svc *runtime.ServiceRuntime, suffix strin
 	for _, field := range fieldList {
 		cd = append(cd, xkube.ConnectionDetail{
 			ObjectReference: corev1.ObjectReference{
+				// APIVersion: xkube.ObjectKindAPIVersion,
+				// Kind:       xkube.ObjectKind,
 				APIVersion: "v1",
 				Kind:       "Secret",
 				Namespace:  comp.GetInstanceNamespace(),
@@ -69,7 +71,7 @@ func AddGenericSecret(comp InfoGetter, svc *runtime.ServiceRuntime, suffix strin
 		cd = o(secret, cd)
 	}
 
-	return secretObjectName, svc.SetDesiredKubeObject(secret, secretObjectName, runtime.KubeOptionAddConnectionDetails(comp.GetInstanceNamespace(), cd...))
+	return secretObjectName, svc.SetDesiredKubeObject(secret, secretObjectName, runtime.KubeOptionAddConnectionDetails(svc.GetCrossplaneNamespace(), cd...))
 }
 
 func genPassword() (string, error) {

--- a/pkg/comp-functions/functions/common/password.go
+++ b/pkg/comp-functions/functions/common/password.go
@@ -55,8 +55,6 @@ func AddGenericSecret(comp InfoGetter, svc *runtime.ServiceRuntime, suffix strin
 	for _, field := range fieldList {
 		cd = append(cd, xkube.ConnectionDetail{
 			ObjectReference: corev1.ObjectReference{
-				// APIVersion: xkube.ObjectKindAPIVersion,
-				// Kind:       xkube.ObjectKind,
 				APIVersion: "v1",
 				Kind:       "Secret",
 				Namespace:  comp.GetInstanceNamespace(),

--- a/pkg/comp-functions/functions/common/postgresql.go
+++ b/pkg/comp-functions/functions/common/postgresql.go
@@ -48,7 +48,9 @@ func (a *PostgreSQLDependencyBuilder) SetCustomMaintenanceSchedule(timeOfDayMain
 	return a
 }
 
-func (a *PostgreSQLDependencyBuilder) CreateDependency() error {
+// CreateDependency applies the postgresql instance to the desired state.
+// It returns the name of the secret that will contain the connection details.
+func (a *PostgreSQLDependencyBuilder) CreateDependency() (string, error) {
 	// Unfortunately k8up and stackgres backups don't match up very well...
 	// if no daily backup is set we just do the default.
 	retention := 6
@@ -62,7 +64,7 @@ func (a *PostgreSQLDependencyBuilder) CreateDependency() error {
 
 			pgBouncerConfigBytes, err := json.Marshal(a.pgBouncerConfig)
 			if err != nil {
-				return err
+				return "", err
 			}
 			pgBouncerRaw = k8sruntime.RawExtension{
 				Raw: pgBouncerConfigBytes,
@@ -90,7 +92,7 @@ func (a *PostgreSQLDependencyBuilder) CreateDependency() error {
 	if a.psqlParams != nil {
 		err := mergo.Merge(params, a.psqlParams, mergo.WithOverride)
 		if err != nil {
-			return err
+			return "", err
 		}
 
 		// Mergo doesn't override non-default values with default values. So
@@ -110,30 +112,39 @@ func (a *PostgreSQLDependencyBuilder) CreateDependency() error {
 	// and would therefore override any value we set before the merge.
 	params.Instances = a.comp.GetInstances()
 
+	// We have to ignore the provideconfig on the composite itself.
 	pg := &vshnv1.XVSHNPostgreSQL{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: a.comp.GetName() + PgInstanceNameSuffix,
+			Labels: map[string]string{
+				runtime.ProviderConfigIgnoreLabel: "true",
+			},
 		},
 		Spec: vshnv1.XVSHNPostgreSQLSpec{
 			Parameters: *params,
 			ResourceSpec: xpv1.ResourceSpec{
 				WriteConnectionSecretToReference: &xpv1.SecretReference{
-					Name:      PgSecretName,
+					Name:      a.comp.GetName() + "-" + PgSecretName,
 					Namespace: a.comp.GetInstanceNamespace(),
 				},
 			},
 		},
 	}
 
+	// But pass the parent's provider config properly to the instance.
+	if v, exists := a.comp.GetLabels()[runtime.ProviderConfigLabel]; exists {
+		pg.Labels[runtime.ProviderConfigLabel] = v
+	}
+
 	err := CustomCreateNetworkPolicy([]string{a.comp.GetInstanceNamespace()}, pg.GetInstanceNamespace(), pg.GetName()+"-"+a.comp.GetServiceName(), false, a.svc)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	err = DisableBilling(pg.GetInstanceNamespace(), a.svc)
 	if err != nil {
-		return err
+		return "", err
 	}
 
-	return a.svc.SetDesiredComposedResource(pg)
+	return a.comp.GetName() + "-" + PgSecretName, a.svc.SetDesiredComposedResource(pg)
 }

--- a/pkg/comp-functions/functions/common/postgresql.go
+++ b/pkg/comp-functions/functions/common/postgresql.go
@@ -124,7 +124,7 @@ func (a *PostgreSQLDependencyBuilder) CreateDependency() (string, error) {
 			Parameters: *params,
 			ResourceSpec: xpv1.ResourceSpec{
 				WriteConnectionSecretToReference: &xpv1.SecretReference{
-					Name:      a.comp.GetName() + "-" + PgSecretName,
+					Name:      PgSecretName,
 					Namespace: a.comp.GetInstanceNamespace(),
 				},
 			},
@@ -146,5 +146,5 @@ func (a *PostgreSQLDependencyBuilder) CreateDependency() (string, error) {
 		return "", err
 	}
 
-	return a.comp.GetName() + "-" + PgSecretName, a.svc.SetDesiredComposedResource(pg)
+	return PgSecretName, a.svc.SetDesiredComposedResource(pg)
 }

--- a/pkg/comp-functions/functions/common/release.go
+++ b/pkg/comp-functions/functions/common/release.go
@@ -70,7 +70,7 @@ func getDesiredRelease(svc *runtime.ServiceRuntime, releaseName string) (*xhelmv
 }
 
 // NewRelease returns a new release with some defaults set.
-func NewRelease(ctx context.Context, svc *runtime.ServiceRuntime, comp InfoGetter, values map[string]any, cd ...xhelmv1.ConnectionDetail) (*xhelmv1.Release, error) {
+func NewRelease(ctx context.Context, svc *runtime.ServiceRuntime, comp InfoGetter, values map[string]any, resName string, cd ...xhelmv1.ConnectionDetail) (*xhelmv1.Release, error) {
 
 	vb, err := json.Marshal(values)
 	if err != nil {
@@ -101,12 +101,17 @@ func NewRelease(ctx context.Context, svc *runtime.ServiceRuntime, comp InfoGette
 				},
 				WriteConnectionSecretToReference: &xpv1.SecretReference{
 					Name:      comp.GetName() + "-connection",
-					Namespace: comp.GetInstanceNamespace(),
+					Namespace: svc.GetCrossplaneNamespace(),
 				},
 			},
 			ConnectionDetails: cd,
 		},
 	}
+
+	// err = svc.DeployConnectionDetailsToInstanceNS(comp.GetName()+"-connection", comp.GetInstanceNamespace(), comp.GetName(), resName)
+	// if err != nil {
+	// 	return nil, err
+	// }
 
 	return release, nil
 }

--- a/pkg/comp-functions/functions/common/release.go
+++ b/pkg/comp-functions/functions/common/release.go
@@ -108,10 +108,5 @@ func NewRelease(ctx context.Context, svc *runtime.ServiceRuntime, comp InfoGette
 		},
 	}
 
-	// err = svc.DeployConnectionDetailsToInstanceNS(comp.GetName()+"-connection", comp.GetInstanceNamespace(), comp.GetName(), resName)
-	// if err != nil {
-	// 	return nil, err
-	// }
-
 	return release, nil
 }

--- a/pkg/comp-functions/functions/common/tls.go
+++ b/pkg/comp-functions/functions/common/tls.go
@@ -171,7 +171,7 @@ func CreateTLSCerts(ctx context.Context, ns string, serviceName string, svc *run
 		},
 	}
 
-	err = svc.SetDesiredKubeObject(serverCert, serviceName+"-server-cert", runtime.KubeOptionAddConnectionDetails(ns, cd...))
+	err = svc.SetDesiredKubeObject(serverCert, serviceName+"-server-cert", runtime.KubeOptionAddConnectionDetails(svc.GetCrossplaneNamespace(), cd...))
 	if err != nil {
 		err = fmt.Errorf("cannot create serverCert object: %w", err)
 		return serverCertsSecret, err

--- a/pkg/comp-functions/functions/vshnkeycloak/deploy_test.go
+++ b/pkg/comp-functions/functions/vshnkeycloak/deploy_test.go
@@ -20,9 +20,10 @@ func Test_addPostgreSQL(t *testing.T) {
 
 	comp := &vshnv1.VSHNKeycloak{}
 
-	assert.NoError(t, common.NewPostgreSQLDependencyBuilder(svc, comp).
+	_, err := common.NewPostgreSQLDependencyBuilder(svc, comp).
 		AddParameters(comp.Spec.Parameters.Service.PostgreSQLParameters).
-		CreateDependency())
+		CreateDependency()
+	assert.NoError(t, err)
 
 	pg := &vshnv1.XVSHNPostgreSQL{}
 
@@ -40,7 +41,8 @@ func Test_addPostgreSQL(t *testing.T) {
 		},
 	}
 
-	assert.NoError(t, common.NewPostgreSQLDependencyBuilder(svc, comp).AddParameters(comp.Spec.Parameters.Service.PostgreSQLParameters).CreateDependency())
+	_, err = common.NewPostgreSQLDependencyBuilder(svc, comp).AddParameters(comp.Spec.Parameters.Service.PostgreSQLParameters).CreateDependency()
+	assert.NoError(t, err)
 	assert.NoError(t, svc.GetDesiredComposedResourceByName(pg, comp.GetName()+common.PgInstanceNameSuffix))
 	assert.False(t, *pg.Spec.Parameters.Backup.DeletionProtection)
 	assert.Equal(t, 1, pg.Spec.Parameters.Backup.Retention)
@@ -63,7 +65,7 @@ func Test_addRelease(t *testing.T) {
 		},
 	}
 
-	assert.NoError(t, addRelease(context.TODO(), svc, comp, "mysecret"))
+	assert.NoError(t, addRelease(context.TODO(), svc, comp, "mysecret", "mysecret"))
 
 	release := &xhelmv1.Release{}
 
@@ -89,7 +91,7 @@ func Test_addHARelease(t *testing.T) {
 		},
 	}
 
-	assert.NoError(t, addRelease(context.TODO(), svc, comp, "mysecret"))
+	assert.NoError(t, addRelease(context.TODO(), svc, comp, "mysecret", "mysecret"))
 	release := &xhelmv1.Release{}
 	assert.NoError(t, svc.GetDesiredComposedResourceByName(release, comp.GetName()+"-release"))
 	values := map[string]any{}
@@ -98,7 +100,8 @@ func Test_addHARelease(t *testing.T) {
 
 	pg := &vshnv1.XVSHNPostgreSQL{}
 
-	assert.NoError(t, common.NewPostgreSQLDependencyBuilder(svc, comp).AddParameters(comp.Spec.Parameters.Service.PostgreSQLParameters).CreateDependency())
+	_, err := common.NewPostgreSQLDependencyBuilder(svc, comp).AddParameters(comp.Spec.Parameters.Service.PostgreSQLParameters).CreateDependency()
+	assert.NoError(t, err)
 	assert.NoError(t, svc.GetDesiredComposedResourceByName(pg, comp.GetName()+common.PgInstanceNameSuffix))
 	assert.Equal(t, 2, pg.Spec.Parameters.Instances)
 

--- a/pkg/comp-functions/functions/vshnmariadb/proxysql_test.go
+++ b/pkg/comp-functions/functions/vshnmariadb/proxysql_test.go
@@ -29,7 +29,7 @@ func getComp() *vshnv1.VSHNMariaDB {
 }
 
 func Test_copyCertificateSecret(t *testing.T) {
-	svc := commontest.LoadRuntimeFromFile(t, "empty.yaml")
+	svc := commontest.LoadRuntimeFromFile(t, "vshnmariadb/01-user-management.yaml")
 
 	// Given TLS
 	comp := getComp()
@@ -40,7 +40,7 @@ func Test_copyCertificateSecret(t *testing.T) {
 	//Then expect secret
 	assert.NoError(t, svc.GetDesiredComposedResourceByName(obj, comp.GetName()+"-proxysql-specific-certs"))
 
-	svc = commontest.LoadRuntimeFromFile(t, "empty.yaml")
+	svc = commontest.LoadRuntimeFromFile(t, "vshnmariadb/01-user-management.yaml")
 	// Given no TLS
 	comp.Spec.Parameters.TLS.TLSEnabled = false
 	// When applied

--- a/pkg/comp-functions/functions/vshnmariadb/proxysql_test.go
+++ b/pkg/comp-functions/functions/vshnmariadb/proxysql_test.go
@@ -35,7 +35,7 @@ func Test_copyCertificateSecret(t *testing.T) {
 	comp := getComp()
 
 	// When applied
-	assert.NoError(t, copyCertificateSecret(comp, svc, "test", false))
+	assert.NoError(t, copyCertificateSecret(comp, svc, false))
 	obj := &xkubev1.Object{}
 	//Then expect secret
 	assert.NoError(t, svc.GetDesiredComposedResourceByName(obj, comp.GetName()+"-proxysql-specific-certs"))
@@ -44,7 +44,7 @@ func Test_copyCertificateSecret(t *testing.T) {
 	// Given no TLS
 	comp.Spec.Parameters.TLS.TLSEnabled = false
 	// When applied
-	assert.NoError(t, copyCertificateSecret(comp, svc, "test", false))
+	assert.NoError(t, copyCertificateSecret(comp, svc, false))
 	//Then expect no secret
 	assert.Error(t, svc.GetDesiredComposedResourceByName(obj, comp.GetName()+"-proxysql-specific-certs"))
 }

--- a/pkg/comp-functions/functions/vshnmariadb/user_management.go
+++ b/pkg/comp-functions/functions/vshnmariadb/user_management.go
@@ -6,6 +6,7 @@ import (
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	xfnproto "github.com/crossplane/function-sdk-go/proto/v1beta1"
+	xkube "github.com/vshn/appcat/v4/apis/kubernetes/v1alpha2"
 	my1alpha1 "github.com/vshn/appcat/v4/apis/sql/mysql/v1alpha1"
 	vshnv1 "github.com/vshn/appcat/v4/apis/vshn/v1"
 	"github.com/vshn/appcat/v4/pkg/comp-functions/functions/common"
@@ -75,7 +76,29 @@ func addUser(comp common.Composite, svc *runtime.ServiceRuntime, username string
 		},
 	}
 
-	err = svc.SetDesiredComposedResource(role, runtime.ComposedOptionProtects(comp.GetName()+"-provider-conf-credentials"), runtime.ComposedOptionProtects(secretName))
+	// we need to get the secret object to mark it as deletable
+	obj := &xkube.Object{}
+	err = svc.GetDesiredComposedResourceByName(obj, secretName)
+	if err != nil {
+		svc.Log.Error(err, "cannot get user password secret")
+		svc.AddResult(runtime.NewWarningResult(fmt.Sprintf("cannot get user password secret: %s", err)))
+	}
+
+	if obj.Labels == nil {
+		obj.Labels = map[string]string{}
+	}
+
+	obj.Labels[runtime.WebhookAllowDeletionLabel] = "true"
+
+	err = svc.SetDesiredComposedResource(obj)
+	if err != nil {
+		svc.Log.Error(err, "cannot set allow deletion label on user password secret")
+		svc.AddResult(runtime.NewWarningResult(fmt.Sprintf("cannot set allow deletion label on user password secret: %s", err)))
+	}
+
+	err = svc.SetDesiredComposedResource(role,
+		runtime.ComposedOptionProtects(comp.GetName()+"-provider-conf-credentials"),
+		runtime.ComposedOptionProtects(secretName))
 	if err != nil {
 		svc.Log.Error(err, "cannot apply user")
 		svc.AddResult(runtime.NewWarningResult(fmt.Sprintf("cannot apply user: %s", err)))
@@ -118,7 +141,9 @@ func addConnectionDetail(comp common.Composite, svc *runtime.ServiceRuntime, sec
 		},
 	}
 
-	err = svc.SetDesiredKubeObject(userpassSecret, fmt.Sprintf("%s-user-%s", comp.GetName(), username))
+	err = svc.SetDesiredKubeObject(userpassSecret, fmt.Sprintf("%s-user-%s", comp.GetName(), username),
+		runtime.KubeOptionAllowDeletion,
+		runtime.KubeOptionDeployOnControlPlane)
 	if err != nil {
 		svc.Log.Error(err, "cannot get userpassword from secret")
 		svc.AddResult(runtime.NewWarningResult(fmt.Sprintf("cannot get userpassword from secret: %s", err)))
@@ -128,15 +153,20 @@ func addConnectionDetail(comp common.Composite, svc *runtime.ServiceRuntime, sec
 func addProviderConfig(comp *vshnv1.VSHNMariaDB, svc *runtime.ServiceRuntime) {
 	cd := svc.GetConnectionDetails()
 
+	endpoint := cd["MARIADB_HOST"]
+	if _, exists := cd["LOADBALANCER_IP"]; exists {
+		endpoint = cd["LOADBALANCER_IP"]
+	}
+
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "provider-conf-credentials",
-			Namespace: comp.GetInstanceNamespace(),
+			Name:      comp.GetName() + "-provider-conf-credentials",
+			Namespace: svc.GetCrossplaneNamespace(),
 		},
 		Data: map[string][]byte{
 			"username": cd["MARIADB_USERNAME"],
 			"password": cd["MARIADB_PASSWORD"],
-			"endpoint": cd["MARIADB_HOST"],
+			"endpoint": endpoint,
 			"port":     cd["MARIADB_PORT"],
 		},
 	}
@@ -146,6 +176,8 @@ func addProviderConfig(comp *vshnv1.VSHNMariaDB, svc *runtime.ServiceRuntime) {
 		runtime.KubeOptionProtects(comp.GetName() + "-release"),
 		runtime.KubeOptionProtects(comp.GetName() + "-netpol"),
 		runtime.KubeOptionProtects(comp.GetName() + "-main-service"),
+		runtime.KubeOptionDeployOnControlPlane,
+		runtime.KubeOptionAllowDeletion,
 	}
 
 	if comp.GetInstances() != 1 {
@@ -174,14 +206,16 @@ func addProviderConfig(comp *vshnv1.VSHNMariaDB, svc *runtime.ServiceRuntime) {
 			Credentials: my1alpha1.ProviderCredentials{
 				Source: "MySQLConnectionSecret",
 				ConnectionSecretRef: &xpv1.SecretReference{
-					Name:      "provider-conf-credentials",
-					Namespace: comp.GetInstanceNamespace(),
+					Name:      comp.GetName() + "-provider-conf-credentials",
+					Namespace: svc.GetCrossplaneNamespace(),
 				},
 			},
 		},
 	}
 
-	err = svc.SetDesiredKubeObject(config, comp.GetName()+"-providerconfig")
+	err = svc.SetDesiredKubeObject(config, comp.GetName()+"-providerconfig",
+		runtime.KubeOptionDeployOnControlPlane,
+		runtime.KubeOptionAllowDeletion)
 	if err != nil {
 		svc.AddResult(runtime.NewWarningResult(fmt.Sprintf("cannot apply the provider config for provider sql: %s", err)))
 		svc.Log.Error(err, "cannot apply the provider config for provider sql")

--- a/pkg/comp-functions/functions/vshnmariadb/user_management_test.go
+++ b/pkg/comp-functions/functions/vshnmariadb/user_management_test.go
@@ -29,7 +29,6 @@ func Test_addProviderConfig(t *testing.T) {
 
 	config := &pgv1alpha1.ProviderConfig{}
 	assert.NoError(t, svc.GetDesiredKubeObject(config, comp.GetName()+"-providerconfig"))
-	assert.Equal(t, comp.GetInstanceNamespace(), secret.GetNamespace())
 
 }
 

--- a/pkg/comp-functions/functions/vshnminio/minio_deploy.go
+++ b/pkg/comp-functions/functions/vshnminio/minio_deploy.go
@@ -314,6 +314,9 @@ func createSliBucket(comp *vshnv1.VSHNMinio, xminioName string, svc *runtime.Ser
 		},
 	}
 
+	// Because `ObjectBucket` is a wrapped claim it's `WriteConnectionSecretToRef` is
+	// masked by the wrapping kube object, it won't work with the runtime's connectionSecret handling.
+	// So this is a hack to still deploy it to the right place.
 	cd, err := svc.GetObservedComposedResourceConnectionDetails(comp.GetName() + resNameSuffix)
 	if err != nil {
 		if err != runtime.ErrNotFound {

--- a/pkg/comp-functions/functions/vshnminio/providerconfig.go
+++ b/pkg/comp-functions/functions/vshnminio/providerconfig.go
@@ -40,7 +40,7 @@ func DeployMinioProviderConfig(_ context.Context, comp *vshnv1.VSHNMinio, svc *r
 		},
 	}
 
-	err = svc.SetDesiredKubeObject(config, comp.GetName()+"-providerconfig")
+	err = svc.SetDesiredKubeObject(config, comp.GetName()+"-providerconfig", runtime.KubeOptionDeployOnControlPlane)
 	if err != nil {
 		err = fmt.Errorf("cannot get providerconfig: %w", err)
 		return runtime.NewFatalResult(err)

--- a/pkg/comp-functions/functions/vshnpostgres/connection_details.go
+++ b/pkg/comp-functions/functions/vshnpostgres/connection_details.go
@@ -152,10 +152,5 @@ func addConnectionDetailsToObject(obj *xkubev1.Object, comp *vshnv1.VSHNPostgreS
 		return fmt.Errorf("cannot deploy postgresql connection details: %w", err)
 	}
 
-	// err = svc.DeployConnectionDetailsToInstanceNS(obj.GetWriteConnectionSecretToReference().Name, comp.GetInstanceNamespace(), comp.GetName(), "cluster")
-	// if err != nil {
-	// 	return fmt.Errorf("cannot deploy postgresql connection details to instanceNamespace: %w", err)
-	// }
-
 	return nil
 }

--- a/pkg/comp-functions/functions/vshnpostgres/connection_details.go
+++ b/pkg/comp-functions/functions/vshnpostgres/connection_details.go
@@ -144,8 +144,18 @@ func addConnectionDetailsToObject(obj *xkubev1.Object, comp *vshnv1.VSHNPostgreS
 
 	obj.Spec.WriteConnectionSecretToReference = &commonv1.SecretReference{
 		Name:      comp.GetName() + "-connection",
-		Namespace: comp.GetInstanceNamespace(),
+		Namespace: svc.GetCrossplaneNamespace(),
 	}
 
-	return svc.SetDesiredComposedResourceWithName(obj, "cluster")
+	err := svc.SetDesiredComposedResourceWithName(obj, "cluster")
+	if err != nil {
+		return fmt.Errorf("cannot deploy postgresql connection details: %w", err)
+	}
+
+	// err = svc.DeployConnectionDetailsToInstanceNS(obj.GetWriteConnectionSecretToReference().Name, comp.GetInstanceNamespace(), comp.GetName(), "cluster")
+	// if err != nil {
+	// 	return fmt.Errorf("cannot deploy postgresql connection details to instanceNamespace: %w", err)
+	// }
+
+	return nil
 }

--- a/pkg/comp-functions/functions/vshnpostgres/pgqexporter_config.go
+++ b/pkg/comp-functions/functions/vshnpostgres/pgqexporter_config.go
@@ -40,10 +40,7 @@ func PgExporterConfig(ctx context.Context, comp *vshnv1.VSHNPostgreSQL, svc *run
 	}
 	xRef := xkube.Reference{
 		DependsOn: &xkube.DependsOn{
-			APIVersion: "stackgres.io/v1",
-			Kind:       "SGCluster",
-			Name:       comp.GetName(),
-			Namespace:  comp.GetInstanceNamespace(),
+			Name: comp.GetName() + "-cluster",
 		},
 	}
 	// add crossplane object containing ConfigMap

--- a/pkg/comp-functions/functions/vshnpostgres/postgresql_deploy.go
+++ b/pkg/comp-functions/functions/vshnpostgres/postgresql_deploy.go
@@ -376,14 +376,6 @@ func createSgCluster(ctx context.Context, comp *vshnv1.VSHNPostgreSQL, svc *runt
 				},
 			},
 		}
-		backupRef = xkubev1.Reference{
-			DependsOn: &xkubev1.DependsOn{
-				APIVersion: "stackgres.io/v1",
-				Kind:       "SGBackup",
-				Name:       comp.Spec.Parameters.Restore.BackupName,
-				Namespace:  comp.GetInstanceNamespace(),
-			},
-		}
 	}
 
 	sgCluster := &sgv1.SGCluster{
@@ -474,7 +466,7 @@ func createObjectBucket(comp *vshnv1.VSHNPostgreSQL, svc *runtime.ServiceRuntime
 			ResourceSpec: xpv1.ResourceSpec{
 				WriteConnectionSecretToReference: &xpv1.SecretReference{
 					Name:      "pgbucket-" + comp.GetName(),
-					Namespace: comp.GetInstanceNamespace(),
+					Namespace: svc.GetCrossplaneNamespace(),
 				},
 			},
 		},
@@ -485,6 +477,11 @@ func createObjectBucket(comp *vshnv1.VSHNPostgreSQL, svc *runtime.ServiceRuntime
 		err = fmt.Errorf("cannot create xObjectBucket: %w", err)
 		return err
 	}
+
+	// err = svc.DeployConnectionDetailsToInstanceNS(xObjectBucket.GetWriteConnectionSecretToReference().Name, comp.GetInstanceNamespace(), comp.GetName(), "pg-bucket")
+	// if err != nil {
+	// 	return fmt.Errorf("cannot deploy connection details to instanceNamespace: %w", err)
+	// }
 
 	return nil
 }

--- a/pkg/comp-functions/functions/vshnpostgres/postgresql_deploy.go
+++ b/pkg/comp-functions/functions/vshnpostgres/postgresql_deploy.go
@@ -32,6 +32,7 @@ import (
 
 const (
 	certificateSecretName = "tls-certificate"
+	namespaceResName      = "namespace-conditions"
 )
 
 //go:embed scripts/copy-pg-backup.sh
@@ -46,7 +47,7 @@ func DeployPostgreSQL(ctx context.Context, comp *vshnv1.VSHNPostgreSQL, svc *run
 	}
 
 	l.Info("Bootstrapping instance namespace and rbac rules")
-	err = common.BootstrapInstanceNs(ctx, comp, "postgresql", "namespace-conditions", svc)
+	err = common.BootstrapInstanceNs(ctx, comp, "postgresql", namespaceResName, svc)
 	if err != nil {
 		return runtime.NewWarningResult(fmt.Errorf("cannot bootstrap instance namespace: %w", err).Error())
 	}
@@ -439,7 +440,9 @@ func createSgCluster(ctx context.Context, comp *vshnv1.VSHNPostgreSQL, svc *runt
 
 	configureReplication(comp, sgCluster)
 
-	err = svc.SetDesiredKubeObjectWithName(sgCluster, comp.GetName()+"-cluster", "cluster", runtime.KubeOptionAddRefs(backupRef))
+	// We need to protect the namespace, otherwise, if the namespace get deleted first during de-provisioning, it can delete objects that
+	// are referenced in the kube object. This will lead to the object getting stuck indefinitely.
+	err = svc.SetDesiredKubeObjectWithName(sgCluster, comp.GetName()+"-cluster", "cluster", runtime.KubeOptionAddRefs(backupRef), runtime.KubeOptionProtects(namespaceResName))
 	if err != nil {
 		err = fmt.Errorf("cannot create sgInstanceProfile: %w", err)
 		return err

--- a/pkg/comp-functions/functions/vshnpostgres/postgresql_deploy.go
+++ b/pkg/comp-functions/functions/vshnpostgres/postgresql_deploy.go
@@ -481,11 +481,6 @@ func createObjectBucket(comp *vshnv1.VSHNPostgreSQL, svc *runtime.ServiceRuntime
 		return err
 	}
 
-	// err = svc.DeployConnectionDetailsToInstanceNS(xObjectBucket.GetWriteConnectionSecretToReference().Name, comp.GetInstanceNamespace(), comp.GetName(), "pg-bucket")
-	// if err != nil {
-	// 	return fmt.Errorf("cannot deploy connection details to instanceNamespace: %w", err)
-	// }
-
 	return nil
 }
 

--- a/pkg/comp-functions/functions/vshnpostgres/user_management_test.go
+++ b/pkg/comp-functions/functions/vshnpostgres/user_management_test.go
@@ -28,7 +28,6 @@ func Test_addProviderConfig(t *testing.T) {
 
 	config := &pgv1alpha1.ProviderConfig{}
 	assert.NoError(t, svc.GetDesiredKubeObject(config, comp.GetName()+"-providerconfig"))
-	assert.Equal(t, comp.GetInstanceNamespace(), secret.GetNamespace())
 	assert.Equal(t, *config.Spec.SSLMode, "required")
 
 }
@@ -48,7 +47,6 @@ func Test_tlsDisabled(t *testing.T) {
 
 	config := &pgv1alpha1.ProviderConfig{}
 	assert.NoError(t, svc.GetDesiredKubeObject(config, comp.GetName()+"-providerconfig"))
-	assert.Equal(t, comp.GetInstanceNamespace(), secret.GetNamespace())
 	assert.Equal(t, *config.Spec.SSLMode, "disable")
 
 }

--- a/test/functions/vshnmariadb/01-user-management.yaml
+++ b/test/functions/vshnmariadb/01-user-management.yaml
@@ -1,0 +1,10 @@
+desired: {}
+input: {}
+observed:
+  resources:
+    myinstance-server-cert:
+      resource: {}
+      connection_details:
+        ca.crt: test
+        tls.crt: test
+        tls.key: test


### PR DESCRIPTION
## Summary

With this change we ensure that we never reference an instance namespace directly in the connection details' `WriteConnectionSecretToReference`. Instead, we hard code it to the Crossplane namespace. Then there's a new function in the runtime that will check each managed resource for connection details, if it's set, it will automatically create a secret in the instance namespace on the service cluster via the provider-kubernetes.
    
There's an annotation that can be set on the managed resources to disable this functionality for specific resources.

This is necessary, because the instance namespaces don't exist on the control clusters. As the `WriteConnectionSecretToReference` is a property of the managed resources, it's not aware about the instance namespace. That's why these changes are necessary. The references are automatically converted to point to the Crossplane namespace, while simultaneously deploying a new object that will write the secrets to the instance namespaces. This ensures that it will behave the same way as before.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
