### PR TITLE
Add support for Kafka 3.8

### DIFF
--- a/apis/exoscale/v1/dbaas_exoscale_kafka.go
+++ b/apis/exoscale/v1/dbaas_exoscale_kafka.go
@@ -65,11 +65,11 @@ type ExoscaleKafkaServiceSpec struct {
 	// KafkaSettings contains additional Kafka settings.
 	KafkaSettings runtime.RawExtension `json:"kafkaSettings,omitempty"`
 
-	// +kubebuilder:validation:Enum="3.4"
-	// +kubebuilder:default="3.4"
+	// +kubebuilder:validation:Enum="3.8"
+	// +kubebuilder:default="3.8"
 
 	// Version contains the minor version for Kafka.
-	// Currently only "3.4" is supported. Leave it empty to always get the latest supported version.
+	// Currently only "3.8" is supported. Leave it empty to always get the latest supported version.
 	Version string `json:"version,omitempty"`
 }
 

--- a/crds/exoscale.appcat.vshn.io_exoscalekafkas.yaml
+++ b/crds/exoscale.appcat.vshn.io_exoscalekafkas.yaml
@@ -102,12 +102,12 @@ spec:
                           type: object
                           x-kubernetes-preserve-unknown-fields: true
                         version:
-                          default: "3.4"
+                          default: "3.8"
                           description: |-
                             Version contains the minor version for Kafka.
-                            Currently only "3.4" is supported. Leave it empty to always get the latest supported version.
+                            Currently only "3.8" is supported. Leave it empty to always get the latest supported version.
                           enum:
-                            - "3.4"
+                            - "3.8"
                           type: string
                         zone:
                           default: ch-gva-2


### PR DESCRIPTION
## Summary

* Version 3.4 is not available anymore and therefore won't work. This PR will set the version to 3.8 which is the currently supported version

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [ ] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
