### PR TITLE
Set SSLMode for provider-sqls provider-config

### DIFF
--- a/pkg/comp-functions/functions/vshnpostgres/user_management_test.go
+++ b/pkg/comp-functions/functions/vshnpostgres/user_management_test.go
@@ -20,7 +20,7 @@ func Test_addProviderConfig(t *testing.T) {
 	// when
 	comp := &vshnv1.VSHNPostgreSQL{}
 	assert.NoError(t, svc.GetObservedComposite(comp))
-	addProviderConfig(comp, svc)
+	addProviderConfig(comp, svc, comp.Spec.Parameters.Service.TLS.Enabled)
 
 	// then
 	secret := &corev1.Secret{}
@@ -29,6 +29,27 @@ func Test_addProviderConfig(t *testing.T) {
 	config := &pgv1alpha1.ProviderConfig{}
 	assert.NoError(t, svc.GetDesiredKubeObject(config, comp.GetName()+"-providerconfig"))
 	assert.Equal(t, comp.GetInstanceNamespace(), secret.GetNamespace())
+	assert.Equal(t, *config.Spec.SSLMode, "required")
+
+}
+
+func Test_tlsDisabled(t *testing.T) {
+	// given
+	svc := commontest.LoadRuntimeFromFile(t, "vshn-postgres/usermanagement/02-tls-disabled.yaml")
+
+	// when
+	comp := &vshnv1.VSHNPostgreSQL{}
+	assert.NoError(t, svc.GetObservedComposite(comp))
+	addProviderConfig(comp, svc, comp.Spec.Parameters.Service.TLS.Enabled)
+
+	// then
+	secret := &corev1.Secret{}
+	assert.NoError(t, svc.GetDesiredKubeObject(secret, comp.GetName()+"-provider-conf-credentials"))
+
+	config := &pgv1alpha1.ProviderConfig{}
+	assert.NoError(t, svc.GetDesiredKubeObject(config, comp.GetName()+"-providerconfig"))
+	assert.Equal(t, comp.GetInstanceNamespace(), secret.GetNamespace())
+	assert.Equal(t, *config.Spec.SSLMode, "disable")
 
 }
 

--- a/test/functions/vshn-postgres/usermanagement/02-tls-disabled.yaml
+++ b/test/functions/vshn-postgres/usermanagement/02-tls-disabled.yaml
@@ -24,7 +24,7 @@ desired:
         parameters:
           service:
             tls:
-              enabled: true
+              enabled: false
         writeConnectionSecretToRef: {}
       status: {}
 observed:
@@ -53,6 +53,6 @@ observed:
         parameters:
           service:
             tls:
-              enabled: true
+              enabled: false
         writeConnectionSecretToRef: {}
       status: {}


### PR DESCRIPTION
## Summary

We need to pass the correct ssl mode to the provider-config for provider-sql in order to be able to connect to the postgresql server depending on the ssl mode of the server itself.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
