### PR TITLE
Generalize Ingress creation, use wildcard cert with OCP apps domain

### DIFF
--- a/pkg/comp-functions/functions/common/ingress.go
+++ b/pkg/comp-functions/functions/common/ingress.go
@@ -1,0 +1,261 @@
+package common
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/vshn/appcat/v4/pkg/comp-functions/runtime"
+	"gopkg.in/yaml.v2"
+	netv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+)
+
+// IngressConfig contains general information for generating an Ingress obect
+type IngressConfig struct {
+	AdditionalAnnotations  map[string]string // Optional
+	AdditionalIngressNames []string          // Optional
+	FQDNs                  []string
+	ServiceConfig          IngressRuleConfig
+	TlsCertBaseName        string
+}
+
+// IngressRuleConfig describes an ingress rule configuration
+type IngressRuleConfig struct {
+	RelPath           string // Optional, defaults to "/"
+	ServiceNameSuffix string // Optional
+	ServicePortName   string // Has preference over ServicePortNumber
+	ServicePortNumber int32
+}
+
+// Checks if an FQDN is part of a reference FQDN, e.g. an OpenShift Apps domain; "*nextcloud*.apps.cluster.com".
+// Returns true if yes and FQDN is not a 2nd level subdomain (i.e. *sub2.sub1*.apps.cluster.com)
+func IsSingleSubdomainOfRefDomain(fqdn string, reference string) bool {
+	if !strings.Contains(fqdn, reference) || reference == "" {
+		return false
+	}
+
+	noSuffix, _ := strings.CutSuffix(fqdn, reference)
+	return len(strings.Split(noSuffix, ".")) == 2 // Handles prefixed dot of reference domain
+}
+
+// Obtain ingress annotations and optionally extend them using additionalAnnotations
+func getIngressAnnotations(svc *runtime.ServiceRuntime, additionalAnnotations map[string]string) map[string]string {
+	annotations := map[string]string{}
+	if svc.Config.Data["ingress_annotations"] != "" {
+		err := yaml.Unmarshal([]byte(svc.Config.Data["ingress_annotations"]), annotations)
+		if err != nil {
+			svc.Log.Error(err, "cannot unmarshal ingress annotations from input")
+			svc.AddResult(runtime.NewWarningResult(fmt.Sprintf("cannot unmarshal ingress annotations from input: %s", err)))
+		}
+	} else {
+		svc.Log.Info("no ingress annotations are defined")
+	}
+
+	for k, v := range additionalAnnotations {
+		annotations[k] = v
+	}
+
+	return annotations
+}
+
+// Creates ingress rules based on a single service name and port. svcNameSuffix is optional and gets appended.
+// Will use svcPortName over svcPortNumber (if specified)
+func createIngressRule(comp InfoGetter, fqdns []string, ruleConfig IngressRuleConfig) []netv1.IngressRule {
+	svcNameSuffix := ruleConfig.ServiceNameSuffix
+	if !strings.HasPrefix(svcNameSuffix, "-") && len(svcNameSuffix) > 0 {
+		svcNameSuffix = "-" + svcNameSuffix
+	}
+
+	relPath := ruleConfig.RelPath
+	if relPath == "" {
+		relPath = "/"
+	}
+
+	ingressRules := []netv1.IngressRule{}
+
+	// prefer ServicePortName over ServicePortNumber
+	serviceBackendPort := netv1.ServiceBackendPort{}
+	if ruleConfig.ServicePortName != "" {
+		serviceBackendPort.Name = ruleConfig.ServicePortName
+	} else {
+		serviceBackendPort.Number = ruleConfig.ServicePortNumber
+	}
+
+	for _, fqdn := range fqdns {
+		rule := netv1.IngressRule{
+			Host: fqdn,
+			IngressRuleValue: netv1.IngressRuleValue{
+				HTTP: &netv1.HTTPIngressRuleValue{
+					Paths: []netv1.HTTPIngressPath{
+						{
+							Path:     relPath,
+							PathType: ptr.To(netv1.PathType("Prefix")),
+							Backend: netv1.IngressBackend{
+								Service: &netv1.IngressServiceBackend{
+									Name: comp.GetName() + svcNameSuffix,
+									Port: serviceBackendPort,
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		ingressRules = append(ingressRules, rule)
+	}
+
+	return ingressRules
+}
+
+// Generate an ingress TLS secret name as "<baseName>-ingress-cert"
+func generateTlsSecretName(baseName string) string {
+	return strings.Trim(baseName, "-") + "-ingress-cert"
+}
+
+// Generate an ingress name. additionalNames will be assembled as "comp.GetName()-<n1>-<n2>-<nX>-ingress"
+func generateIngressName(comp InfoGetter, additionalNames ...string) string {
+	ingressName := comp.GetName()
+	if len(additionalNames) > 0 {
+		for _, n := range additionalNames {
+			n = strings.Trim(n, "-")
+			ingressName = ingressName + "-" + n
+		}
+	}
+	ingressName = ingressName + "-ingress"
+
+	return ingressName
+}
+
+// Generate up to 2 ingresses that bundle FQDNs depending on the following:
+// FQDNs that are one subdomain ON defaultAppsDomain (e.g. sub1.apps.cluster.com) -> Empty TLS config (uses wildcard cert on OCP).
+// FQDNs that do not statisfy the former -> TLS config using a Let's Encrypt certificate.
+func GenerateBundledIngresses(comp InfoGetter, svc *runtime.ServiceRuntime, ingressConfig IngressConfig) ([]*netv1.Ingress, error) {
+	if len(ingressConfig.FQDNs) == 0 {
+		return nil, fmt.Errorf("no FQDNs")
+	}
+
+	for _, fqdn := range ingressConfig.FQDNs {
+		if fqdn == "" {
+			return nil, fmt.Errorf("an empty FQDN has been passed. Passed FQDNs are: %v", ingressConfig.FQDNs)
+		}
+	}
+
+	// bool: true -> Use wildcard, false -> Use LE, []string: List of FQDNs
+	ingressMap := map[bool][]string{}
+
+	ocpDefaultAppsDomain := svc.Config.Data["ocpDefaultAppsDomain"]
+	if ocpDefaultAppsDomain != "" {
+		for _, fqdn := range ingressConfig.FQDNs {
+			useWildcard := IsSingleSubdomainOfRefDomain(fqdn, ocpDefaultAppsDomain)
+			ingressMap[useWildcard] = append(ingressMap[useWildcard], fqdn)
+		}
+	} else {
+		ingressMap[false] = ingressConfig.FQDNs
+	}
+
+	// Create ingresses that bundle FQDNs depending on their certificate requirements (LE/Wildcard)
+	var ingresses []*netv1.Ingress
+	fqdnsLetsEncrypt, fqdnsWildcard := ingressMap[false], ingressMap[true]
+
+	tlsName := generateTlsSecretName(ingressConfig.TlsCertBaseName)
+	if tlsName == "" {
+		return nil, fmt.Errorf("a TLS cert base name must be defined")
+	}
+
+	ingressMetadata := metav1.ObjectMeta{
+		Namespace:   comp.GetInstanceNamespace(),
+		Annotations: getIngressAnnotations(svc, ingressConfig.AdditionalAnnotations),
+	}
+
+	// Ingress using Let's Encrypt
+	if len(fqdnsLetsEncrypt) > 0 {
+		ingressMetadata.Name = generateIngressName(comp, "letsencrypt")
+		ingresses = append(ingresses, &netv1.Ingress{
+			ObjectMeta: ingressMetadata,
+			Spec: netv1.IngressSpec{
+				Rules: createIngressRule(comp, fqdnsLetsEncrypt, ingressConfig.ServiceConfig),
+				TLS: []netv1.IngressTLS{
+					{
+						Hosts:      fqdnsLetsEncrypt,
+						SecretName: tlsName,
+					},
+				},
+			},
+		})
+	}
+
+	// Ingress using apps domain wildcard
+	if len(fqdnsWildcard) > 0 {
+		ingressMetadata.Name = generateIngressName(comp, "wildcard")
+		ingresses = append(ingresses, &netv1.Ingress{
+			ObjectMeta: ingressMetadata,
+			Spec: netv1.IngressSpec{
+				Rules: createIngressRule(comp, fqdnsWildcard, ingressConfig.ServiceConfig),
+				TLS:   []netv1.IngressTLS{{}},
+			},
+		})
+	}
+
+	return ingresses, nil
+}
+
+// Generate an Ingress containing a single FQDN using a TLS config as such:
+// FQDN is one subdomain ON defaultAppsDomain (e.g. sub1.apps.cluster.com) -> Empty TLS config (uses wildcard cert on OCP).
+// FQDN does not statisfy the former -> TLS config using a Let's Encrypt certificate.
+func GenerateIngress(comp InfoGetter, svc *runtime.ServiceRuntime, ingressConfig IngressConfig) (*netv1.Ingress, error) {
+	if len(ingressConfig.FQDNs) == 0 || ingressConfig.FQDNs[0] == "" {
+		return nil, fmt.Errorf("no FQDN passed")
+	}
+
+	fqdn := ingressConfig.FQDNs[0]
+	if len(ingressConfig.FQDNs) > 1 {
+		svc.AddResult(
+			runtime.NewWarningResult(
+				fmt.Sprintf("More than 1 FQDN has been passed to a singleton ingress object, using first available: %s", fqdn),
+			),
+		)
+	}
+
+	annotations := getIngressAnnotations(svc, ingressConfig.AdditionalAnnotations)
+
+	tlsName := ingressConfig.TlsCertBaseName
+	if tlsName == "" {
+		return nil, fmt.Errorf("a TLS cert base name must be defined")
+	}
+	for _, an := range ingressConfig.AdditionalIngressNames {
+		tlsName = tlsName + "-" + strings.Trim(an, "-")
+	}
+
+	tlsConfig := netv1.IngressTLS{}
+	if !IsSingleSubdomainOfRefDomain(fqdn, svc.Config.Data["ocpDefaultAppsDomain"]) {
+		tlsConfig.Hosts = []string{fqdn}
+		tlsConfig.SecretName = generateTlsSecretName(tlsName)
+	}
+
+	ingress := &netv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        generateIngressName(comp, ingressConfig.AdditionalIngressNames...),
+			Namespace:   comp.GetInstanceNamespace(),
+			Annotations: annotations,
+		},
+		Spec: netv1.IngressSpec{
+			Rules: createIngressRule(comp, []string{fqdn}, ingressConfig.ServiceConfig),
+			TLS:   []netv1.IngressTLS{tlsConfig},
+		},
+	}
+
+	return ingress, nil
+}
+
+// Apply generated ingresses using svc.SetDesiredKubeObject()
+func CreateIngresses(comp InfoGetter, svc *runtime.ServiceRuntime, ingresses []*netv1.Ingress, opts ...runtime.KubeObjectOption) error {
+	for _, ingress := range ingresses {
+		err := svc.SetDesiredKubeObject(ingress, ingress.Name, opts...)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/comp-functions/functions/common/ingress.go
+++ b/pkg/comp-functions/functions/common/ingress.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/utils/ptr"
 )
 
-// IngressConfig contains general information for generating an Ingress obect
+// IngressConfig contains general information for generating an Ingress object
 type IngressConfig struct {
 	AdditionalAnnotations  map[string]string // Optional
 	AdditionalIngressNames []string          // Optional

--- a/pkg/comp-functions/functions/common/ingress.go
+++ b/pkg/comp-functions/functions/common/ingress.go
@@ -145,9 +145,12 @@ func GenerateBundledIngresses(comp InfoGetter, svc *runtime.ServiceRuntime, ingr
 	ingressMap := map[bool][]string{}
 
 	ocpDefaultAppsDomain := svc.Config.Data["ocpDefaultAppsDomain"]
+	svc.Log.Info(fmt.Sprintf("ocpAppsDomain is: '%s'", ocpDefaultAppsDomain))
+
 	if ocpDefaultAppsDomain != "" {
 		for _, fqdn := range ingressConfig.FQDNs {
 			useWildcard := IsSingleSubdomainOfRefDomain(fqdn, ocpDefaultAppsDomain)
+			svc.Log.Info(fmt.Sprintf("FQDN %s will use wildcard cert: %v", fqdn, useWildcard))
 			ingressMap[useWildcard] = append(ingressMap[useWildcard], fqdn)
 		}
 	} else {

--- a/pkg/comp-functions/functions/common/ingress_test.go
+++ b/pkg/comp-functions/functions/common/ingress_test.go
@@ -1,0 +1,392 @@
+package common
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/vshn/appcat/v4/pkg/comp-functions/functions/commontest"
+	netv1 "k8s.io/api/networking/v1"
+	v1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+)
+
+const (
+	compName           = "my-service"
+	tlsCertBaseName    = "my-service"
+	svcBackendPortName = "https"
+	svcNameSuffix      = "http"
+	relativePath       = "/path"
+)
+
+// Static objects that will always be the same across tests
+var ingObjectMeta metav1.ObjectMeta = metav1.ObjectMeta{
+	Annotations: map[string]string{},
+	Name:        compName + "-ingress", // May change in tests
+	Namespace:   "vshn-" + compName,
+}
+
+var svcName string = compName + "-" + svcNameSuffix
+var expectedIngressBackend v1.IngressBackend = v1.IngressBackend{
+	Service: &v1.IngressServiceBackend{
+		Name: svcName,
+		Port: v1.ServiceBackendPort{
+			Name: svcBackendPortName,
+		},
+	},
+}
+
+// Barebones dummy composite for testing
+type baaSComposite struct {
+	metav1.TypeMeta
+	metav1.ObjectMeta
+	InfoGetter
+	Spec baaSSpec
+}
+
+type baaSSpec struct {
+	Parameters baaSParameters
+}
+
+type baaSParameters struct {
+	Service baaSServiceSpec
+}
+
+type baaSServiceSpec struct {
+	FQDN         string
+	FQDNs        []string
+	RelativePath string
+}
+
+func (b *baaSComposite) GetLabels() map[string]string {
+	return b.Labels
+}
+func (b *baaSComposite) GetName() string {
+	return b.ObjectMeta.Name
+}
+func (b *baaSComposite) GetInstanceNamespace() string {
+	return fmt.Sprintf("vshn-%s", b.GetName())
+}
+
+type args struct {
+	comp *baaSComposite
+}
+
+// Test the generation of multiple ingress objects with various configurations
+func TestGenerateMultipleIngresses(t *testing.T) {
+	ingObjectMetaLetsEncrypt := ingObjectMeta
+	ingObjectMetaLetsEncrypt.Name = compName + "-letsencrypt-ingress"
+	ingObjectMetaWildcard := ingObjectMeta
+	ingObjectMetaWildcard.Name = compName + "-wildcard-ingress"
+
+	test := struct {
+		name string
+		args args
+		want []*v1.Ingress
+	}{
+		name: "ExpectMultipleIngresses_WithSeparatedFQDNs",
+		args: struct {
+			comp *baaSComposite
+		}{
+			comp: &baaSComposite{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: compName,
+				},
+				Spec: baaSSpec{
+					Parameters: baaSParameters{
+						Service: baaSServiceSpec{
+							FQDNs:        []string{"my-domain.com", "instance.apps.example.com"},
+							RelativePath: relativePath,
+						},
+					},
+				},
+			},
+		},
+		want: []*v1.Ingress{
+			// Let's encrypt ingress
+			{
+				ObjectMeta: ingObjectMetaLetsEncrypt,
+				Spec: v1.IngressSpec{
+					Rules: []v1.IngressRule{{
+						Host: "my-domain.com",
+						IngressRuleValue: v1.IngressRuleValue{
+							HTTP: &v1.HTTPIngressRuleValue{
+								Paths: []v1.HTTPIngressPath{
+									{
+										Path:     relativePath,
+										PathType: ptr.To(v1.PathType("Prefix")),
+										Backend:  expectedIngressBackend,
+									},
+								},
+							},
+						},
+					}},
+					TLS: []v1.IngressTLS{
+						{
+							Hosts:      []string{"my-domain.com"},
+							SecretName: tlsCertBaseName + "-ingress-cert",
+						},
+					},
+				},
+			},
+			// Wildcard ingress
+			{
+				ObjectMeta: ingObjectMetaWildcard,
+				Spec: v1.IngressSpec{
+					Rules: []v1.IngressRule{{
+						Host: "instance.apps.example.com",
+						IngressRuleValue: v1.IngressRuleValue{
+							HTTP: &v1.HTTPIngressRuleValue{
+								Paths: []v1.HTTPIngressPath{
+									{
+										Path:     relativePath,
+										PathType: ptr.To(v1.PathType("Prefix")),
+										Backend:  expectedIngressBackend,
+									},
+								},
+							},
+						},
+					}},
+					TLS: []v1.IngressTLS{{}},
+				},
+			},
+		},
+	}
+
+	t.Run(test.name, func(t *testing.T) {
+		svc := commontest.LoadRuntimeFromFile(t, "common/02_ingress.yaml")
+		fqdns := test.args.comp.Spec.Parameters.Service.FQDNs
+		relPath := test.args.comp.Spec.Parameters.Service.RelativePath
+
+		ings, err := GenerateBundledIngresses(test.args.comp, svc, IngressConfig{
+			FQDNs: fqdns,
+			ServiceConfig: IngressRuleConfig{
+				RelPath:           relPath,
+				ServiceNameSuffix: svcNameSuffix,
+				ServicePortName:   svcBackendPortName,
+			},
+			TlsCertBaseName: tlsCertBaseName,
+		})
+
+		assert.NoError(t, err)
+		for i, _ := range ings {
+			fmt.Printf("Testing ingress: %s\n", ings[i].Name)
+			doMarshalledAssert(t, test.want[i], ings[i])
+		}
+	})
+}
+
+// Test the generation of a single ingress object with various configurations
+func TestGenerateSingleIngress(t *testing.T) {
+	tests := []struct {
+		name string
+		args args
+		want *v1.Ingress
+	}{
+		{
+			name: "GivenNonAppsFQDN_Then_ExpectIngress_WithPopulatedTLS",
+			args: struct {
+				comp *baaSComposite
+			}{
+				comp: &baaSComposite{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: compName,
+					},
+					Spec: baaSSpec{
+						Parameters: baaSParameters{
+							Service: baaSServiceSpec{
+								FQDN:         "my-domain.com",
+								RelativePath: relativePath,
+							},
+						},
+					},
+				},
+			},
+			want: &v1.Ingress{
+				ObjectMeta: ingObjectMeta,
+				Spec: v1.IngressSpec{
+					Rules: []v1.IngressRule{{
+						Host: "my-domain.com",
+						IngressRuleValue: v1.IngressRuleValue{
+							HTTP: &v1.HTTPIngressRuleValue{
+								Paths: []v1.HTTPIngressPath{
+									{
+										Path:     relativePath,
+										PathType: ptr.To(v1.PathType("Prefix")),
+										Backend:  expectedIngressBackend,
+									},
+								},
+							},
+						},
+					}},
+					TLS: []v1.IngressTLS{
+						{
+							Hosts:      []string{"my-domain.com"},
+							SecretName: tlsCertBaseName + "-ingress-cert",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "GivenAppsFQDN_Then_ExpectIngressWithEmptyTLS",
+			args: struct {
+				comp *baaSComposite
+			}{
+				comp: &baaSComposite{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: compName,
+					},
+					Spec: baaSSpec{
+						Parameters: baaSParameters{
+							Service: baaSServiceSpec{
+								FQDN:         "instance.apps.example.com",
+								RelativePath: relativePath,
+							},
+						},
+					},
+				},
+			},
+			want: &v1.Ingress{
+				ObjectMeta: ingObjectMeta,
+				Spec: v1.IngressSpec{
+					Rules: []v1.IngressRule{{
+						Host: "instance.apps.example.com",
+						IngressRuleValue: v1.IngressRuleValue{
+							HTTP: &v1.HTTPIngressRuleValue{
+								Paths: []v1.HTTPIngressPath{
+									{
+										Path:     relativePath,
+										PathType: ptr.To(v1.PathType("Prefix")),
+										Backend:  expectedIngressBackend,
+									},
+								},
+							},
+						},
+					}},
+					TLS: []v1.IngressTLS{{}},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := commontest.LoadRuntimeFromFile(t, "common/02_ingress.yaml")
+			fqdn := tt.args.comp.Spec.Parameters.Service.FQDN
+			relPath := tt.args.comp.Spec.Parameters.Service.RelativePath
+
+			ing, err := GenerateIngress(tt.args.comp, svc, IngressConfig{
+				FQDNs: []string{fqdn},
+				ServiceConfig: IngressRuleConfig{
+					RelPath:           relPath,
+					ServiceNameSuffix: svcNameSuffix,
+					ServicePortName:   svcBackendPortName,
+				},
+				TlsCertBaseName: tlsCertBaseName,
+			})
+
+			assert.NoError(t, err)
+			doMarshalledAssert(t, tt.want, ing)
+		})
+	}
+}
+
+func TestIngressRuleGeneration(t *testing.T) {
+	comp := &baaSComposite{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: compName,
+		},
+		Spec: baaSSpec{
+			Parameters: baaSParameters{
+				Service: baaSServiceSpec{
+					FQDNs: []string{
+						"instance.apps.example.com",
+						"another.instance.apps.example.com",
+						"epic-instance.my-domain.com",
+					},
+					RelativePath: relativePath,
+				},
+			},
+		},
+	}
+	fqdns := comp.Spec.Parameters.Service.FQDNs
+
+	t.Run("GivenFQDNs_ExpectRules", func(t *testing.T) {
+		rules, err := createIngressRule(comp, comp.Spec.Parameters.Service.FQDNs, IngressRuleConfig{
+			RelPath:           relativePath,
+			ServiceNameSuffix: svcNameSuffix,
+			ServicePortName:   svcBackendPortName,
+			ServicePortNumber: 1337,
+		})
+
+		assert.NoError(t, err)
+		assert.Len(t, rules, len(fqdns))
+
+		for i, r := range rules {
+			nameWithSuffix := comp.GetName() + "-" + svcNameSuffix
+			assert.Equal(t, nameWithSuffix, r.HTTP.Paths[0].Backend.Service.Name)
+			assert.Equal(t, relativePath, r.HTTP.Paths[0].Path)
+			assert.Equal(t, netv1.PathType("Prefix"), *r.HTTP.Paths[0].PathType)
+			assert.Equal(t, nameWithSuffix, r.HTTP.Paths[0].Backend.Service.Name)
+			assert.Equal(t, svcBackendPortName, r.HTTP.Paths[0].Backend.Service.Port.Name)
+			assert.Equal(t, fqdns[i], r.Host)
+		}
+	})
+
+	t.Run("GivenNoRelativePath_ExpectDefault", func(t *testing.T) {
+		comp.Spec.Parameters.Service.RelativePath = ""
+
+		rules, err := createIngressRule(comp, comp.Spec.Parameters.Service.FQDNs, IngressRuleConfig{
+			ServicePortName: svcBackendPortName,
+		})
+
+		assert.NoError(t, err)
+		assert.Equal(t, "/", rules[0].HTTP.Paths[0].Path)
+	})
+
+	t.Run("GivenNeitherPortNameNorPortNumber_ExpectError", func(t *testing.T) {
+		_, err := createIngressRule(comp, []string{"example.com"}, IngressRuleConfig{})
+		assert.Error(t, err)
+	})
+
+	t.Run("GivenNoFQDNs_ExpectError", func(t *testing.T) {
+		_, err := createIngressRule(comp, []string{}, IngressRuleConfig{})
+		assert.Error(t, err)
+	})
+
+	t.Run("GivenSvcPortNameAndPortNumber_ExpectPortNameToBeUsed", func(t *testing.T) {
+		rules, err := createIngressRule(comp, []string{"example.com"}, IngressRuleConfig{
+			ServicePortName:   svcBackendPortName,
+			ServicePortNumber: 1337,
+		})
+
+		assert.NoError(t, err)
+		for _, r := range rules {
+			assert.Equal(t, svcBackendPortName, r.HTTP.Paths[0].Backend.Service.Port.Name)
+			assert.Equal(t, int32(0), r.HTTP.Paths[0].Backend.Service.Port.Number)
+		}
+	})
+}
+
+func TestIngressNameGeneration(t *testing.T) {
+	t.Run("GivenAdditionalNames_ExpectIngressSuffix", func(t *testing.T) {
+		comp := &baaSComposite{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: compName,
+			},
+		}
+
+		name := generateIngressName(comp, "a", "b", "c")
+		assert.Equal(t, comp.GetName()+"-a-b-c-ingress", name)
+	})
+}
+
+func doMarshalledAssert(t *testing.T, want any, got any) {
+	// By marshalling v1.Ingress first, we can prevent assert.Equal from comparing pointer addresses and thus always failing
+	wantMarshal, _ := json.MarshalIndent(want, "", "")
+	gotMarshal, _ := json.MarshalIndent(got, "", "")
+	assert.Equal(t, string(wantMarshal), string(gotMarshal))
+}

--- a/pkg/comp-functions/functions/common/util.go
+++ b/pkg/comp-functions/functions/common/util.go
@@ -2,7 +2,6 @@ package common
 
 import (
 	"fmt"
-	"strings"
 )
 
 // SetNestedObjectValue is necessary as unstructured can't handle anything except basic values and maps.
@@ -31,15 +30,4 @@ func SetNestedObjectValue(values map[string]interface{}, path []string, val inte
 	}
 
 	return SetNestedObjectValue(tmpVals, path[1:], val)
-}
-
-// Checks if an FQDN is part of a reference FQDN, e.g. an OpenShift Apps domain; "*nextcloud*.apps.cluster.com".
-// Returns true if yes and FQDN is not a 2nd level subdomain (i.e. *sub2.sub1*.apps.cluster.com)
-func IsSingleSubdomainOfRefDomain(fqdn string, reference string) bool {
-	if !strings.Contains(fqdn, reference) || reference == "" {
-		return false
-	}
-
-	noSuffix, _ := strings.CutSuffix(fqdn, reference)
-	return len(strings.Split(noSuffix, ".")) == 2 // Handles prefixed dot of reference domain
 }

--- a/pkg/comp-functions/functions/common/util.go
+++ b/pkg/comp-functions/functions/common/util.go
@@ -36,6 +36,10 @@ func SetNestedObjectValue(values map[string]interface{}, path []string, val inte
 // Checks if an FQDN is part of a reference FQDN, e.g. an OpenShift Apps domain; "*nextcloud*.apps.cluster.com".
 // Returns true if yes and FQDN is not a 2nd level subdomain (i.e. *sub2.sub1*.apps.cluster.com)
 func IsSingleSubdomainOfRefDomain(fqdn string, reference string) bool {
+	if !strings.Contains(fqdn, reference) || reference == "" {
+		return false
+	}
+
 	noSuffix, _ := strings.CutSuffix(fqdn, reference)
 	return len(strings.Split(noSuffix, ".")) == 2 // Handles prefixed dot of reference domain<
 }

--- a/pkg/comp-functions/functions/common/util.go
+++ b/pkg/comp-functions/functions/common/util.go
@@ -1,6 +1,9 @@
 package common
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 // SetNestedObjectValue is necessary as unstructured can't handle anything except basic values and maps.
 // this is a recursive function, it will traverse the map until it reaches the last element of the path.
@@ -28,4 +31,11 @@ func SetNestedObjectValue(values map[string]interface{}, path []string, val inte
 	}
 
 	return SetNestedObjectValue(tmpVals, path[1:], val)
+}
+
+// Checks if an FQDN is part of a reference FQDN, e.g. an OpenShift Apps domain; "*nextcloud*.apps.cluster.com".
+// Returns true if yes and FQDN is not a 2nd level subdomain (i.e. *sub2.sub1*.apps.cluster.com)
+func IsSingleSubdomainOfRefDomain(fqdn string, reference string) bool {
+	noSuffix, _ := strings.CutSuffix(fqdn, reference)
+	return len(strings.Split(noSuffix, ".")) == 2 // Handles prefixed dot of reference domain<
 }

--- a/pkg/comp-functions/functions/common/util.go
+++ b/pkg/comp-functions/functions/common/util.go
@@ -41,5 +41,5 @@ func IsSingleSubdomainOfRefDomain(fqdn string, reference string) bool {
 	}
 
 	noSuffix, _ := strings.CutSuffix(fqdn, reference)
-	return len(strings.Split(noSuffix, ".")) == 2 // Handles prefixed dot of reference domain<
+	return len(strings.Split(noSuffix, ".")) == 2 // Handles prefixed dot of reference domain
 }

--- a/pkg/comp-functions/functions/vshnforgejo/deploy.go
+++ b/pkg/comp-functions/functions/vshnforgejo/deploy.go
@@ -204,11 +204,13 @@ func addForgejo(ctx context.Context, svc *runtime.ServiceRuntime, comp *vshnv1.V
 			},
 		})
 
-		err := common.SetNestedObjectValue(values, []string{"ingress", "tls"}, []map[string]any{
-			{
-				"hosts":      comp.Spec.Parameters.Service.FQDN,
-				"secretName": "forgejo-tls",
-			}})
+		tlsConfig := map[string]any{}
+		if !common.IsSingleSubdomainOfRefDomain(host, svc.Config.Data["ocpDefaultAppsDomain"]) {
+			tlsConfig["hosts"] = comp.Spec.Parameters.Service.FQDN
+			tlsConfig["secretName"] = "forgejo-tls"
+		}
+
+		err := common.SetNestedObjectValue(values, []string{"ingress", "tls"}, []map[string]any{tlsConfig})
 		if err != nil {
 			return err
 		}

--- a/pkg/comp-functions/functions/vshnkeycloak/ingress.go
+++ b/pkg/comp-functions/functions/vshnkeycloak/ingress.go
@@ -34,7 +34,7 @@ func AddIngress(_ context.Context, comp *vshnv1.VSHNKeycloak, svc *runtime.Servi
 	}
 
 	svc.Log.Info("Enable ingress for release")
-	enableIngresValues(svc, comp, values)
+	enableIngressValues(svc, comp, values)
 
 	release := &xhelmv1.Release{}
 	err = svc.GetDesiredComposedResourceByName(release, comp.GetName()+"-release")
@@ -57,7 +57,7 @@ func AddIngress(_ context.Context, comp *vshnv1.VSHNKeycloak, svc *runtime.Servi
 	return nil
 }
 
-func enableIngresValues(svc *runtime.ServiceRuntime, comp *vshnv1.VSHNKeycloak, values map[string]any) {
+func enableIngressValues(svc *runtime.ServiceRuntime, comp *vshnv1.VSHNKeycloak, values map[string]any) {
 	fqdn := comp.Spec.Parameters.Service.FQDN
 
 	relPath := `'{{ tpl .Values.http.relativePath $ | trimSuffix " / " }}/'`

--- a/pkg/comp-functions/functions/vshnkeycloak/ingress.go
+++ b/pkg/comp-functions/functions/vshnkeycloak/ingress.go
@@ -65,6 +65,13 @@ func enableIngresValues(svc *runtime.ServiceRuntime, comp *vshnv1.VSHNKeycloak, 
 		relPath = "/"
 	}
 
+	tls := map[string]any{}
+	if !common.IsSingleSubdomainOfRefDomain(fqdn, svc.Config.Data["ocpDefaultAppsDomain"]) {
+		tls["hosts"] = []string{fqdn}
+		tls["secretName"] = "keycloak-ingress-cert"
+	}
+	tlsConfig := []map[string]any{tls}
+
 	values["ingress"] = map[string]any{
 		"enabled":     true,
 		"servicePort": "https",
@@ -80,14 +87,7 @@ func enableIngresValues(svc *runtime.ServiceRuntime, comp *vshnv1.VSHNKeycloak, 
 				},
 			},
 		},
-		"tls": []map[string]any{
-			{
-				"hosts": []string{
-					fqdn,
-				},
-				"secretName": "keycloak-ingress-cert",
-			},
-		},
+		"tls": tlsConfig,
 	}
 
 	if svc.Config.Data["ingress_annotations"] != "" {

--- a/pkg/comp-functions/functions/vshnkeycloak/ingress.go
+++ b/pkg/comp-functions/functions/vshnkeycloak/ingress.go
@@ -45,11 +45,11 @@ func AddIngress(_ context.Context, comp *vshnv1.VSHNKeycloak, svc *runtime.Servi
 	})
 	if err != nil {
 		return runtime.NewWarningResult(fmt.Sprintf("cannot generate ingress: %s", err))
-	} else {
-		err = common.CreateIngresses(comp, svc, []*netv1.Ingress{ingress})
-		if err != nil {
-			return runtime.NewWarningResult(fmt.Sprintf("cannot create ingress: %s", err))
-		}
+	}
+
+	err = common.CreateIngresses(comp, svc, []*netv1.Ingress{ingress})
+	if err != nil {
+		return runtime.NewWarningResult(fmt.Sprintf("cannot create ingress: %s", err))
 	}
 
 	if svc.GetBoolFromCompositionConfig("isOpenshift") {

--- a/pkg/comp-functions/functions/vshnkeycloak/ingress.go
+++ b/pkg/comp-functions/functions/vshnkeycloak/ingress.go
@@ -10,10 +10,9 @@ import (
 	vshnv1 "github.com/vshn/appcat/v4/apis/vshn/v1"
 	"github.com/vshn/appcat/v4/pkg/comp-functions/functions/common"
 	"github.com/vshn/appcat/v4/pkg/comp-functions/runtime"
-	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
+	netv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 // AddIngress adds an inrgess to the Keycloak instance.
@@ -24,7 +23,8 @@ func AddIngress(_ context.Context, comp *vshnv1.VSHNKeycloak, svc *runtime.Servi
 		return runtime.NewFatalResult(fmt.Errorf("cannot get composite: %w", err))
 	}
 
-	if comp.Spec.Parameters.Service.FQDN == "" {
+	fqdn := comp.Spec.Parameters.Service.FQDN
+	if fqdn == "" {
 		return nil
 	}
 
@@ -33,8 +33,32 @@ func AddIngress(_ context.Context, comp *vshnv1.VSHNKeycloak, svc *runtime.Servi
 		return runtime.NewWarningResult(fmt.Sprintf("cannot get desired release values: %s", err))
 	}
 
-	svc.Log.Info("Enable ingress for release")
-	enableIngressValues(svc, comp, values)
+	svc.Log.Info("Adding ingress")
+	ingress, err := common.GenerateIngress(comp, svc, common.IngressConfig{
+		FQDNs: []string{fqdn},
+		ServiceConfig: common.IngressRuleConfig{
+			RelPath:           comp.Spec.Parameters.Service.RelativePath,
+			ServiceNameSuffix: "keycloakx-http",
+			ServicePortName:   "https",
+		},
+		TlsCertBaseName: "keycloak",
+	})
+	if err != nil {
+		return runtime.NewWarningResult(fmt.Sprintf("cannot generate ingress: %s", err))
+	} else {
+		err = common.CreateIngresses(comp, svc, []*netv1.Ingress{ingress})
+		if err != nil {
+			return runtime.NewWarningResult(fmt.Sprintf("cannot create ingress: %s", err))
+		}
+	}
+
+	if svc.GetBoolFromCompositionConfig("isOpenshift") {
+		err := addOpenShiftCa(svc, comp)
+		if err != nil {
+			svc.Log.Error(err, "cannot add openshift ca secret")
+			svc.AddResult(runtime.NewWarningResult(fmt.Sprintf("cannot add openshift ca secret: %s", err)))
+		}
+	}
 
 	release := &xhelmv1.Release{}
 	err = svc.GetDesiredComposedResourceByName(release, comp.GetName()+"-release")
@@ -55,61 +79,6 @@ func AddIngress(_ context.Context, comp *vshnv1.VSHNKeycloak, svc *runtime.Servi
 	}
 
 	return nil
-}
-
-func enableIngressValues(svc *runtime.ServiceRuntime, comp *vshnv1.VSHNKeycloak, values map[string]any) {
-	fqdn := comp.Spec.Parameters.Service.FQDN
-
-	relPath := `'{{ tpl .Values.http.relativePath $ | trimSuffix " / " }}/'`
-	if comp.Spec.Parameters.Service.RelativePath == "/" {
-		relPath = "/"
-	}
-
-	tls := map[string]any{}
-	if !common.IsSingleSubdomainOfRefDomain(fqdn, svc.Config.Data["ocpDefaultAppsDomain"]) {
-		tls["hosts"] = []string{fqdn}
-		tls["secretName"] = "keycloak-ingress-cert"
-	}
-	tlsConfig := []map[string]any{tls}
-
-	values["ingress"] = map[string]any{
-		"enabled":     true,
-		"servicePort": "https",
-
-		"rules": []map[string]any{
-			{
-				"host": fqdn,
-				"paths": []map[string]any{
-					{
-						"path":     relPath,
-						"pathType": "Prefix",
-					},
-				},
-			},
-		},
-		"tls": tlsConfig,
-	}
-
-	if svc.Config.Data["ingress_annotations"] != "" {
-		annotations := map[string]any{}
-
-		err := yaml.Unmarshal([]byte(svc.Config.Data["ingress_annotations"]), annotations)
-		if err != nil {
-			svc.Log.Error(err, "cannot unmarshal ingress annotations from input")
-			svc.AddResult(runtime.NewWarningResult(fmt.Sprintf("cannot unmarshal ingress annotations from input: %s", err)))
-		}
-
-		unstructured.SetNestedMap(values, annotations, "ingress", "annotations")
-	}
-
-	if svc.GetBoolFromCompositionConfig("isOpenshift") {
-		err := addOpenShiftCa(svc, comp)
-		if err != nil {
-			svc.Log.Error(err, "cannot add openshift ca secret")
-			svc.AddResult(runtime.NewWarningResult(fmt.Sprintf("cannot add openshift ca secret: %s", err)))
-		}
-	}
-
 }
 
 // addOpenShiftCa creates a separate secret just with the ca in it.

--- a/pkg/comp-functions/functions/vshnkeycloak/ingress_test.go
+++ b/pkg/comp-functions/functions/vshnkeycloak/ingress_test.go
@@ -65,6 +65,43 @@ func TestEnableIngresValues(t *testing.T) {
 			},
 		},
 		{
+			name: "GivenAppsFQDN_Then_ExpectIngressWithEmptyTLS",
+			args: struct {
+				comp   *vshnv1.VSHNKeycloak
+				values map[string]any
+			}{
+				comp: &vshnv1.VSHNKeycloak{
+					Spec: vshnv1.VSHNKeycloakSpec{
+						Parameters: vshnv1.VSHNKeycloakParameters{
+							Service: vshnv1.VSHNKeycloakServiceSpec{
+								FQDN:         "instance.apps.example.com",
+								RelativePath: "/path",
+							},
+						},
+					},
+				},
+				values: map[string]any{},
+			},
+			want: map[string]any{
+				"ingress": map[string]any{
+					"enabled":     true,
+					"servicePort": "https",
+					"rules": []map[string]any{
+						{
+							"host": "instance.apps.example.com",
+							"paths": []map[string]any{
+								{
+									"path":     `'{{ tpl .Values.http.relativePath $ | trimSuffix " / " }}/'`,
+									"pathType": "Prefix",
+								},
+							},
+						},
+					},
+					"tls": []map[string]any{{}},
+				},
+			},
+		},
+		{
 			name: "GivenNoFQDN_Then_ExpectNoIngress",
 			args: struct {
 				comp   *vshnv1.VSHNKeycloak

--- a/pkg/comp-functions/functions/vshnkeycloak/ingress_test.go
+++ b/pkg/comp-functions/functions/vshnkeycloak/ingress_test.go
@@ -1,34 +1,55 @@
 package vshnkeycloak
 
 import (
-	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	xhelmv1 "github.com/vshn/appcat/v4/apis/helm/release/v1beta1"
 	vshnv1 "github.com/vshn/appcat/v4/apis/vshn/v1"
 	"github.com/vshn/appcat/v4/pkg/comp-functions/functions/common"
 	"github.com/vshn/appcat/v4/pkg/comp-functions/functions/commontest"
+	v1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 )
 
-func TestEnableIngresValues(t *testing.T) {
+func TestCreateIngress(t *testing.T) {
 	type args struct {
-		comp   *vshnv1.VSHNKeycloak
-		values map[string]any
+		comp *vshnv1.VSHNKeycloak
+	}
+
+	// Static objects that will always be the same across tests
+	keycloakObjectMeta := metav1.ObjectMeta{
+		Name: "keycloak",
+	}
+
+	ingObjectMeta := metav1.ObjectMeta{
+		Annotations: map[string]string{},
+		Name:        "keycloak-ingress",
+		Namespace:   "vshn-keycloak-keycloak",
+	}
+
+	expectedIngressBackend := v1.IngressBackend{
+		Service: &v1.IngressServiceBackend{
+			Name: "keycloak-keycloakx-http",
+			Port: v1.ServiceBackendPort{
+				Name: "https",
+			},
+		},
 	}
 
 	tests := []struct {
 		name string
 		args args
-		want map[string]any
+		want *v1.Ingress
 	}{
 		{
 			name: "GivenFQDN_Then_ExpectIngress",
 			args: struct {
-				comp   *vshnv1.VSHNKeycloak
-				values map[string]any
+				comp *vshnv1.VSHNKeycloak
 			}{
 				comp: &vshnv1.VSHNKeycloak{
+					ObjectMeta: keycloakObjectMeta,
 					Spec: vshnv1.VSHNKeycloakSpec{
 						Parameters: vshnv1.VSHNKeycloakParameters{
 							Service: vshnv1.VSHNKeycloakServiceSpec{
@@ -38,27 +59,28 @@ func TestEnableIngresValues(t *testing.T) {
 						},
 					},
 				},
-				values: map[string]any{},
 			},
-			want: map[string]any{
-				"ingress": map[string]any{
-					"enabled":     true,
-					"servicePort": "https",
-					"rules": []map[string]any{
-						{
-							"host": "example.com",
-							"paths": []map[string]any{
-								{
-									"path":     `'{{ tpl .Values.http.relativePath $ | trimSuffix " / " }}/'`,
-									"pathType": "Prefix",
+			want: &v1.Ingress{
+				ObjectMeta: ingObjectMeta,
+				Spec: v1.IngressSpec{
+					Rules: []v1.IngressRule{{
+						Host: "example.com",
+						IngressRuleValue: v1.IngressRuleValue{
+							HTTP: &v1.HTTPIngressRuleValue{
+								Paths: []v1.HTTPIngressPath{
+									{
+										Path:     "/path",
+										PathType: ptr.To(v1.PathType("Prefix")),
+										Backend:  expectedIngressBackend,
+									},
 								},
 							},
 						},
-					},
-					"tls": []map[string]any{
+					}},
+					TLS: []v1.IngressTLS{
 						{
-							"hosts":      []string{"example.com"},
-							"secretName": "keycloak-ingress-cert",
+							Hosts:      []string{"example.com"},
+							SecretName: "keycloak-ingress-cert",
 						},
 					},
 				},
@@ -67,10 +89,10 @@ func TestEnableIngresValues(t *testing.T) {
 		{
 			name: "GivenAppsFQDN_Then_ExpectIngressWithEmptyTLS",
 			args: struct {
-				comp   *vshnv1.VSHNKeycloak
-				values map[string]any
+				comp *vshnv1.VSHNKeycloak
 			}{
 				comp: &vshnv1.VSHNKeycloak{
+					ObjectMeta: keycloakObjectMeta,
 					Spec: vshnv1.VSHNKeycloakSpec{
 						Parameters: vshnv1.VSHNKeycloakParameters{
 							Service: vshnv1.VSHNKeycloakServiceSpec{
@@ -80,88 +102,65 @@ func TestEnableIngresValues(t *testing.T) {
 						},
 					},
 				},
-				values: map[string]any{},
 			},
-			want: map[string]any{
-				"ingress": map[string]any{
-					"enabled":     true,
-					"servicePort": "https",
-					"rules": []map[string]any{
-						{
-							"host": "instance.apps.example.com",
-							"paths": []map[string]any{
-								{
-									"path":     `'{{ tpl .Values.http.relativePath $ | trimSuffix " / " }}/'`,
-									"pathType": "Prefix",
+			want: &v1.Ingress{
+				ObjectMeta: ingObjectMeta,
+				Spec: v1.IngressSpec{
+					Rules: []v1.IngressRule{{
+						Host: "instance.apps.example.com",
+						IngressRuleValue: v1.IngressRuleValue{
+							HTTP: &v1.HTTPIngressRuleValue{
+								Paths: []v1.HTTPIngressPath{
+									{
+										Path:     "/path",
+										PathType: ptr.To(v1.PathType("Prefix")),
+										Backend:  expectedIngressBackend,
+									},
 								},
 							},
 						},
-					},
-					"tls": []map[string]any{{}},
+					}},
+					TLS: []v1.IngressTLS{{}},
 				},
 			},
 		},
 		{
 			name: "GivenNoFQDN_Then_ExpectNoIngress",
 			args: struct {
-				comp   *vshnv1.VSHNKeycloak
-				values map[string]any
+				comp *vshnv1.VSHNKeycloak
 			}{
-				comp: &vshnv1.VSHNKeycloak{
-					Spec: vshnv1.VSHNKeycloakSpec{},
-				},
-				values: map[string]any{},
+				comp: &vshnv1.VSHNKeycloak{},
 			},
-			want: map[string]any{
-				"ingress": map[string]any{
-					"enabled":     true,
-					"servicePort": "https",
-					"rules": []map[string]any{
-						{
-							"host": "",
-							"paths": []map[string]any{
-								{
-									"path":     `'{{ tpl .Values.http.relativePath $ | trimSuffix " / " }}/'`,
-									"pathType": "Prefix",
-								},
-							},
-						},
-					},
-					"tls": []map[string]any{
-						{
-							"hosts":      []string{""},
-							"secretName": "keycloak-ingress-cert",
-						},
-					},
-				},
-			},
+			want: nil,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			svc := commontest.LoadRuntimeFromFile(t, "vshnkeycloak/01_default.yaml")
-			enableIngressValues(svc, tt.args.comp, tt.args.values)
-			assert.Equal(t, tt.want, tt.args.values)
+			fqdn := tt.args.comp.Spec.Parameters.Service.FQDN
+			relPath := tt.args.comp.Spec.Parameters.Service.RelativePath
+
+			var err error
+			var ing *v1.Ingress
+			if fqdn != "" { // Handle GivenNoFQDN_Then_ExpectNoIngress
+				ing, err = common.GenerateIngress(tt.args.comp, svc, common.IngressConfig{
+					FQDNs: []string{fqdn},
+					ServiceConfig: common.IngressRuleConfig{
+						RelPath:           relPath,
+						ServiceNameSuffix: "keycloakx-http",
+						ServicePortName:   "https",
+					},
+					TlsCertBaseName: "keycloak",
+				})
+			}
+
+			assert.NoError(t, err)
+
+			// By marshalling v1.Ingress first, we can prevent assert.Equal from comparing pointer addresses and thus always failing
+			want, _ := json.MarshalIndent(tt.want, "", "")
+			got, _ := json.MarshalIndent(ing, "", "")
+			assert.Equal(t, string(want), string(got))
 		})
 	}
-}
-
-func TestAddIngress(t *testing.T) {
-	// Given
-	svc := commontest.LoadRuntimeFromFile(t, "vshnkeycloak/02_withFQDN.yaml")
-
-	// When
-	res := AddIngress(context.TODO(), &vshnv1.VSHNKeycloak{}, svc)
-	assert.Nil(t, res)
-
-	// Then
-	release := &xhelmv1.Release{}
-	assert.NoError(t, svc.GetDesiredComposedResourceByName(release, "keycloak-app1-prod-release"))
-
-	values, err := common.GetDesiredReleaseValues(svc, "keycloak-app1-prod-release")
-	assert.NoError(t, err)
-	assert.NotEmpty(t, values)
-	assert.NotEmpty(t, values["ingress"])
-
 }

--- a/pkg/comp-functions/functions/vshnkeycloak/ingress_test.go
+++ b/pkg/comp-functions/functions/vshnkeycloak/ingress_test.go
@@ -104,7 +104,7 @@ func TestEnableIngresValues(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			svc := commontest.LoadRuntimeFromFile(t, "vshnkeycloak/01_default.yaml")
-			enableIngresValues(svc, tt.args.comp, tt.args.values)
+			enableIngressValues(svc, tt.args.comp, tt.args.values)
 			assert.Equal(t, tt.want, tt.args.values)
 		})
 	}

--- a/pkg/comp-functions/functions/vshnnextcloud/collabora_test.go
+++ b/pkg/comp-functions/functions/vshnnextcloud/collabora_test.go
@@ -2,6 +2,7 @@ package vshnnextcloud
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -49,7 +50,14 @@ func Test_addCollabora(t *testing.T) {
 	}
 
 	for _, val := range collabora_objects {
-		assert.Equal(t, "1", resources[val])
+		var check func(string) error = func(val string) error {
+			if resources[val] != "1" {
+				return fmt.Errorf("%s does not exist", val)
+			}
+			return nil
+		}
+
+		assert.NoError(t, check(val))
 	}
 
 	comp.Spec.Parameters.Service.Collabora.Enabled = false

--- a/pkg/comp-functions/functions/vshnnextcloud/ingress.go
+++ b/pkg/comp-functions/functions/vshnnextcloud/ingress.go
@@ -36,15 +36,7 @@ func AddIngress(_ context.Context, comp *vshnv1.VSHNNextcloud, svc *runtime.Serv
 		}
 	}
 
-	var ocpDefaultAppsDomain string
-	if svc.Config.Data["ocpDefaultAppsDomain"] != "" {
-		err := yaml.Unmarshal([]byte(svc.Config.Data["ocpDefaultAppsDomain"]), ocpDefaultAppsDomain)
-		if err != nil {
-			svc.Log.Error(err, "cannot unmarshal ocpDefaultAppsDomain from input")
-			svc.AddResult(runtime.NewWarningResult(fmt.Sprintf("cannot unmarshal ocpDefaultAppsDomain from input: %s", err)))
-		}
-	}
-
+	ocpDefaultAppsDomain := svc.Config.Data["ocpDefaultAppsDomain"]
 	usesDefaultAppsDomain := false
 	if ocpDefaultAppsDomain != "" {
 		for _, fqdn := range comp.Spec.Parameters.Service.FQDN {

--- a/pkg/comp-functions/functions/vshnnextcloud/ingress.go
+++ b/pkg/comp-functions/functions/vshnnextcloud/ingress.go
@@ -86,19 +86,19 @@ func AddIngress(_ context.Context, comp *vshnv1.VSHNNextcloud, svc *runtime.Serv
 			ObjectMeta: ingressBaseMeta,
 			Spec: netv1.IngressSpec{
 				Rules: createIngressRule(comp, fqdnsWildcard),
-				TLS:   []netv1.IngressTLS{},
+				TLS:   []netv1.IngressTLS{{}},
 			},
 		})
 	}
 
 	for _, ingress := range ingresses {
-		namePrefix := "-ingress-letsencrypt"
-		if len(ingress.Spec.TLS) == 0 {
-			namePrefix = "-ingress-wildcard"
+		nameSuffix := "letsencrypt"
+		if strings.HasSuffix(ingress.Name, "wildcard") {
+			nameSuffix = "wildcard"
 		}
-		err = svc.SetDesiredKubeObject(ingress, comp.GetName()+namePrefix)
+		err = svc.SetDesiredKubeObject(ingress, comp.GetName()+"-ingress-"+nameSuffix)
 		if err != nil {
-			return runtime.NewWarningResult(fmt.Sprintf("cannot set create ingress (%s): %s", namePrefix, err))
+			return runtime.NewWarningResult(fmt.Sprintf("cannot set create ingress (%s): %s", nameSuffix, err))
 		}
 	}
 

--- a/test/functions/common/02_ingress.yaml
+++ b/test/functions/common/02_ingress.yaml
@@ -1,0 +1,11 @@
+desired: {}
+input:
+  apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    annotations: {}
+    labels:
+      name: xfn-config
+    name: xfn-config
+  data:
+    ocpDefaultAppsDomain: "apps.example.com"

--- a/test/functions/vshnkeycloak/03_withFQDNAndAppsDomain.yaml
+++ b/test/functions/vshnkeycloak/03_withFQDNAndAppsDomain.yaml
@@ -1,4 +1,12 @@
-desired: {}
+desired:
+  resources:
+    keycloak-app1-prod-release:
+      resource:
+        apiVersion: helm.crossplane.io/v1beta1
+        kind: Release
+        metadata:
+          name: keycloak-app1-prod
+        spec: {}
 input:
   apiVersion: v1
   kind: ConfigMap
@@ -14,8 +22,17 @@ input:
             true, "memory": "2Gi"}}, "standard-4": {"size": {"cpu": "1", "disk": "16Gi",
             "enabled": true, "memory": "4Gi"}}, "standard-8": {"size": {"cpu": "2",
             "disk": "16Gi", "enabled": true, "memory": "8Gi"}}}'
-    ocpDefaultAppsDomain: "apps.example.com"
 observed:
+  composite:
+    resource:
+      apiVersion: vshn.appcat.vshn.io/v1
+      kind: VSHNKeycloak
+      metadata:
+        name: keycloak-app1-prod
+      spec:
+        parameters:
+          service:
+            fqdn: instance.apps.example.com
   resources:
     mycloak-pg:
       connection_details:


### PR DESCRIPTION
## Summary

* Generalize ingress creation logic
* Create separate ingresses that bundle FQDNs in the following way:
  * FQDN is part of an OCP clusters default apps domain and only has one subdomain (`sub1.apps...`)
  * FQDN is either _not_ part of said domain or has 2 or more subdomains (`sub2.sub1.apps...`)
    * Bundled ingresses will have "letsencrypt" or "wildcard" added to their name according to their TLS config
  * Services that only have one FQDN will only create a single ingress with no extra name according to those rules
* Use wildcard certs for the ingress bundling eligible FQDNs (empty TLS config)

Given an apps domain `example.com`:
```bash
❯ k get ing -o custom-columns="NAME:.metadata.name,HOSTS:.spec.rules[*].host"
NAME                               HOSTS
nextcloud-collabora-code-ingress   k-collabora.example.com
nextcloud-letsencrypt-ingress      next.nextcloud.example.com,past.nextcloud.example.com,presentcloud.my-domain.ch,nextcloud.my-domain.ch,future.tensecloud.my-domain.ch
nextcloud-wildcard-ingress         nextcloud.example.com,2-nextcloud.example.com

❯ k get ing nextcloud-letsencrypt-ingress  -o yaml | yq .spec.tls
- hosts:
    - next.nextcloud.example.com
    - past.nextcloud.example.com
    - presentcloud.my-domain.ch
    - nextcloud.my-domain.ch
    - future.tensecloud.my-domain.ch
  secretName: nextcloud-ingress-cert

❯ k get ing nextcloud-wildcard-ingress -o yaml | yq .spec.tls
- {}
```

This affects the following services:
- Nextcloud
- Keycloak
- Collabora
- Forgejo

Related PR in `component-appcat`: https://github.com/vshn/component-appcat/pull/623

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
