### PR TITLE
fixing label selector for our loadbalancer services in vshnpostgresql

### DIFF
--- a/pkg/comp-functions/functions/vshnpostgres/loadBalancer.go
+++ b/pkg/comp-functions/functions/vshnpostgres/loadBalancer.go
@@ -44,7 +44,7 @@ func AddPrimaryService(ctx context.Context, comp *vshnv1.VSHNPostgreSQL, svc *ru
 		},
 		Spec: v1.ServiceSpec{
 			Selector: map[string]string{
-				"role": "master",
+				"role": "primary",
 			},
 			Ports: []v1.ServicePort{
 				{


### PR DESCRIPTION
## Summary

* `role=master` label is never set. We need it to point to `primary` 
* probably Stackgres changed that while ago and we didn't realize

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog


