### PR TITLE
Fix postgres webhook to allow major upgrade when non HA

### DIFF
--- a/pkg/controller/webhooks/postgresql.go
+++ b/pkg/controller/webhooks/postgresql.go
@@ -316,7 +316,7 @@ func validateMajorVersionUpgrade(newPg *vshnv1.VSHNPostgreSQL, oldPg *vshnv1.VSH
 				))
 			}
 		}
-		if newPg.Spec.Parameters.Instances != 0 {
+		if newPg.Spec.Parameters.Instances > 1 {
 			errList = append(errList, field.Forbidden(
 				field.NewPath("spec.parameters.instances"),
 				"major upgrades are not supported for HA instances",

--- a/pkg/controller/webhooks/postgresql_test.go
+++ b/pkg/controller/webhooks/postgresql_test.go
@@ -627,6 +627,36 @@ func TestPostgreSQLWebhookHandler_ValidateMajorVersionUpgrade(t *testing.T) {
 				),
 			},
 		},
+		{
+			name: "GivenNonHA_ThenNoError",
+			new: &vshnv1.VSHNPostgreSQL{
+				Spec: vshnv1.VSHNPostgreSQLSpec{
+					Parameters: vshnv1.VSHNPostgreSQLParameters{
+						Instances: 1,
+						Service: vshnv1.VSHNPostgreSQLServiceSpec{
+							MajorVersion: "16",
+						},
+					},
+				},
+				Status: vshnv1.VSHNPostgreSQLStatus{
+					CurrentVersion: "15",
+				},
+			},
+			old: &vshnv1.VSHNPostgreSQL{
+				Spec: vshnv1.VSHNPostgreSQLSpec{
+					Parameters: vshnv1.VSHNPostgreSQLParameters{
+						Instances: 1,
+						Service: vshnv1.VSHNPostgreSQLServiceSpec{
+							MajorVersion: "15",
+						},
+					},
+				},
+				Status: vshnv1.VSHNPostgreSQLStatus{
+					CurrentVersion: "15",
+				},
+			},
+			expectErrList: nil,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

* When services has explicitly set instances to 1 then allow major upgrade

## Checklist

- [ ] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [ ] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
