### PR TITLE
Re-add password for URL generation

### DIFF
--- a/pkg/comp-functions/functions/vshnpostgres/connection_details.go
+++ b/pkg/comp-functions/functions/vshnpostgres/connection_details.go
@@ -71,7 +71,7 @@ func AddConnectionDetails(ctx context.Context, comp *vshnv1.VSHNPostgreSQL, svc 
 
 	host := fmt.Sprintf("%s.vshn-postgresql-%s.svc.cluster.local", comp.GetName(), comp.GetName())
 
-	url := getPostgresURL(cd, host)
+	url := getPostgresURL(cd, host, rootPw)
 
 	svc.SetConnectionDetail(PostgresqlURL, []byte(url))
 	svc.SetConnectionDetail(PostgresqlDb, []byte(defaultDB))
@@ -87,19 +87,17 @@ func AddConnectionDetails(ctx context.Context, comp *vshnv1.VSHNPostgreSQL, svc 
 	return nil
 }
 
-func getPostgresURL(s map[string][]byte, host string) string {
-	return getPostgresURLCustomUser(s, host, defaultUser)
+func getPostgresURL(s map[string][]byte, host, pw string) string {
+	return getPostgresURLCustomUser(s, host, defaultUser, pw)
 }
 
-func getPostgresURLCustomUser(s map[string][]byte, host, userName string) string {
-	pwd := string(s[PostgresqlPassword])
-
+func getPostgresURLCustomUser(s map[string][]byte, host, userName, pw string) string {
 	// The values are still missing, wait for the next reconciliation
-	if pwd == "" {
+	if pw == "" {
 		return ""
 	}
 
-	return "postgres://" + userName + ":" + pwd + "@" + host + ":" + defaultPort + "/" + defaultDB
+	return "postgres://" + userName + ":" + pw + "@" + host + ":" + defaultPort + "/" + defaultDB
 }
 
 func addConnectionDetailsToObject(obj *xkubev1.Object, comp *vshnv1.VSHNPostgreSQL, svc *runtime.ServiceRuntime) error {

--- a/pkg/comp-functions/functions/vshnpostgres/connection_details_test.go
+++ b/pkg/comp-functions/functions/vshnpostgres/connection_details_test.go
@@ -54,6 +54,7 @@ func TestTransform(t *testing.T) {
 func TestGetPostgresURL(t *testing.T) {
 	tests := map[string]struct {
 		secret    map[string][]byte
+		password  string
 		expectURL string
 	}{
 		"WhenMissingPasswordThenReturnNoUrlInSecret": {
@@ -63,12 +64,14 @@ func TestGetPostgresURL(t *testing.T) {
 				PostgresqlUser: []byte("user"),
 				PostgresqlPort: []byte("5432"),
 			},
+			password:  "",
 			expectURL: "",
 		},
 		"WhenDataThenReturnSecretWithUrl": {
 			secret: map[string][]byte{
 				PostgresqlPassword: []byte("test"),
 			},
+			password:  "test",
 			expectURL: "postgres://postgres:test@localhost:5432/postgres",
 		},
 	}
@@ -76,7 +79,7 @@ func TestGetPostgresURL(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 
 			// When
-			url := getPostgresURL(tc.secret, "localhost")
+			url := getPostgresURL(tc.secret, "localhost", tc.password)
 
 			// Then
 			assert.Equal(t, tc.expectURL, url)

--- a/test/functions/vshn-postgres/secrets/02_input_function-io.yaml
+++ b/test/functions/vshn-postgres/secrets/02_input_function-io.yaml
@@ -138,6 +138,23 @@ observed:
       status:
         instanceNamespace: vshn-postgresql-pgsql-gc9x4
   resources:
+    pgsql-gc9x4-root-pw-observer:
+      resource:
+        apiVersion: kubernetes.crossplane.io/v1alpha1
+        kind: Object
+        metadata:
+          name: pgsql-gc9x4-root-pw-observer
+        status:
+          atProvider:
+            manifest:
+              apiVersion: v1
+              kind: Secret
+              metadata:
+                name: pgsql-gc9x4
+                namespace: vshn-postgresql-pgsql-gc9x4
+              type: Opaque
+              data:
+                superuser-password: NjM5Yi05MDc2LTRkZTYtYTM1
     connection:
       resource:
         apiVersion: kubernetes.crossplane.io/v1alpha1


### PR DESCRIPTION


## Summary

The PostgreSQL URL generator relied on the `connectionDetails` of the `Cluster` object. Since we removed that due to the deprovisioning bug, the URL was not generated correctly anymore.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
