### PR TITLE
Fix a bug where unmanaged objects aren't protected

### DIFF
--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -23,9 +23,11 @@ complete -F __start_kubectl k
   ./"${KREW}" install krew
 )
 
-ln -s "$HOME/.krew/bin/kubectl-krew" /usr/local/bin/kubectl-krew
+sudo ln -s "$HOME/.krew/bin/kubectl-krew" /usr/local/bin/kubectl-krew
 
 kubectl krew install view-serviceaccount-kubeconfig
+
+sudo ln -s "$HOME/.krew/bin/kubectl-view_serviceaccount_kubeconfig" /usr/local/bin/kubectl-view_serviceaccount_kubeconfig
 
 make setup-kindev
 

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -13,6 +13,20 @@ source <(kubectl completion zsh)
 complete -F __start_kubectl k
 " >> $HOME/.zshrc
 
+(
+  set -x; cd "$(mktemp -d)" &&
+  OS="$(uname | tr '[:upper:]' '[:lower:]')" &&
+  ARCH="$(uname -m | sed -e 's/x86_64/amd64/' -e 's/\(arm\)\(64\)\?.*/\1\2/' -e 's/aarch64$/arm64/')" &&
+  KREW="krew-${OS}_${ARCH}" &&
+  curl -fsSLO "https://github.com/kubernetes-sigs/krew/releases/latest/download/${KREW}.tar.gz" &&
+  tar zxvf "${KREW}.tar.gz" &&
+  ./"${KREW}" install krew
+)
+
+ln -s "$HOME/.krew/bin/kubectl-krew" /usr/local/bin/kubectl-krew
+
+kubectl krew install view-serviceaccount-kubeconfig
+
 make setup-kindev
 
 cp .kind/.kind/kind-config ~/.kube/config

--- a/Makefile
+++ b/Makefile
@@ -230,8 +230,7 @@ render-diff: ## Render diff between the cluster in KUBECONF and the local branch
 
 setup-kindev: ## Setup kindev in the .kind folder, will always create a new instance
 	rm -rf .kind && \
-	git clone --depth=1 https://github.com/vshn/kindev .kind && \
+	git clone https://github.com/vshn/kindev .kind && \
 	cd .kind && \
-	rm -rf .git && \
 	make clean && \
 	make vshnall

--- a/pkg/controller/webhooks/deletionprotection.go
+++ b/pkg/controller/webhooks/deletionprotection.go
@@ -120,11 +120,8 @@ func checkManagedObject(ctx context.Context, obj client.Object, c client.Client,
 func checkUnmanagedObject(ctx context.Context, obj client.Object, c client.Client, cpClient client.Client, l logr.Logger) (compositeInfo, error) {
 	namespace := &corev1.Namespace{}
 
-	if cpClient == nil {
-		cpClient = c
-	}
-
-	err := cpClient.Get(ctx, client.ObjectKey{Name: obj.GetNamespace()}, namespace)
+	// we need to check namespaces against the local service cluster, otherwise they are never actually found
+	err := c.Get(ctx, client.ObjectKey{Name: obj.GetNamespace()}, namespace)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return compositeInfo{Exists: false}, nil


### PR DESCRIPTION
## Summary

The controller used the control-plane client to check for the existance of the instance namespace. However the instance namespaces only reside on the service clusters.

This lead to an issue that PVCs and other unmanaged objects weren't actually protected in a non-converged setup.

This PR also contains some minor devcontainer optimizations in a separate commit.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
