### PR TITLE
Also check for non empty value when waiting for connection details

### DIFF
--- a/pkg/comp-functions/runtime/function_mgr.go
+++ b/pkg/comp-functions/runtime/function_mgr.go
@@ -1080,7 +1080,7 @@ func (s *ServiceRuntime) WaitForDesiredDependencies(mainResource string, depende
 }
 
 // WaitForObservedDependenciesWithConnectionDetails does the same as WaitForDependencies but additionally also checks the given list of fields against the
-// available connection details.
+// available connection details. It checks whether the field exists and has a non-empty value.
 // objectCDMap should contain a map where the key is the name of the dependeny and the string slice the necessary connection detail fields.
 func (s *ServiceRuntime) WaitForObservedDependenciesWithConnectionDetails(mainResource string, objectCDMap map[string][]string) (bool, error) {
 	// If the main resource already exists we're done here
@@ -1100,7 +1100,7 @@ func (s *ServiceRuntime) WaitForObservedDependenciesWithConnectionDetails(mainRe
 		}
 
 		for _, field := range cds {
-			if _, ok := cd[field]; !ok {
+			if val, ok := cd[field]; !ok || len(val) == 0 {
 				return false, nil
 			}
 		}


### PR DESCRIPTION

## Summary

Even thought the field in a connectionDetail map might already be populated, it might happen that it still contains an empty value.

This commit adds an additional check to the waiting logic to also make sure that the value is not empty.

This will fix a racecondition where a pod can start with an empty value on the very first provisioning.
## Checklist

- [ ] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [ ] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
