### PR TITLE
Protect the certificate by the cluster

### DIFF
--- a/pkg/comp-functions/functions/vshnpostgres/postgresql_deploy.go
+++ b/pkg/comp-functions/functions/vshnpostgres/postgresql_deploy.go
@@ -122,7 +122,7 @@ func createCerts(comp *vshnv1.VSHNPostgreSQL, svc *runtime.ServiceRuntime) error
 		},
 	}
 
-	err := svc.SetDesiredKubeObjectWithName(selfSignedIssuer, comp.GetName()+"-localca", "local-ca")
+	err := svc.SetDesiredKubeObjectWithName(selfSignedIssuer, comp.GetName()+"-localca", "local-ca", runtime.KubeOptionProtectedBy("cluster"))
 	if err != nil {
 		err = fmt.Errorf("cannot create local ca object: %w", err)
 		return err
@@ -165,7 +165,7 @@ func createCerts(comp *vshnv1.VSHNPostgreSQL, svc *runtime.ServiceRuntime) error
 		},
 	}
 
-	err = svc.SetDesiredKubeObjectWithName(certificate, comp.GetName()+"-certificate", "certificate")
+	err = svc.SetDesiredKubeObjectWithName(certificate, comp.GetName()+"-certificate", "certificate", runtime.KubeOptionProtectedBy("cluster"))
 	if err != nil {
 		err = fmt.Errorf("cannot create local ca object: %w", err)
 		return err


### PR DESCRIPTION


## Summary

The cluster object references the certificates as connection details. To make sure the deprovisioning works, we now deploy additional usages that ensure the certs will be removed after the cluster object.

This can sometimes lead to raceconditions during the de-provisioning as `provider-kubernetes` will not reconcile the object anymore if the referenced object doesn't exist anymore.

See upstream bug: https://github.com/crossplane-contrib/provider-kubernetes/issues/345

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
