### PR TITLE
Fix ingress using wrong service names

### DIFF
--- a/apis/vshn/v1/dbaas_vshn_forgejo.go
+++ b/apis/vshn/v1/dbaas_vshn_forgejo.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"fmt"
+	"strings"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -285,7 +286,10 @@ func (v *VSHNForgejo) GetSLA() string {
 }
 
 func (v *VSHNForgejo) GetWorkloadName() string {
-	return v.GetName() + "-forgejodeployment"
+	if strings.Contains(v.GetName(), "forgejo") {
+		return v.GetName()
+	}
+	return v.GetName() + "-forgejo"
 }
 
 func (v *VSHNForgejo) GetWorkloadPodTemplateLabelsManager() PodTemplateLabelsManager {

--- a/pkg/comp-functions/functions/vshnforgejo/deploy.go
+++ b/pkg/comp-functions/functions/vshnforgejo/deploy.go
@@ -173,11 +173,16 @@ func addForgejo(ctx context.Context, svc *runtime.ServiceRuntime, comp *vshnv1.V
 		},
 	}
 
+	svcNameSuffix := "http"
+	if !strings.Contains(comp.GetName(), "forgejo") {
+		svcNameSuffix = "forgejo-" + svcNameSuffix
+	}
+
 	svc.Log.Info("Adding ingress")
 	ingressConfig := common.IngressConfig{
 		FQDNs: comp.Spec.Parameters.Service.FQDN,
 		ServiceConfig: common.IngressRuleConfig{
-			ServiceNameSuffix: "http",
+			ServiceNameSuffix: svcNameSuffix,
 			ServicePortNumber: 3000,
 		},
 		TlsCertBaseName: "forgejo",

--- a/pkg/comp-functions/functions/vshnnextcloud/ingress.go
+++ b/pkg/comp-functions/functions/vshnnextcloud/ingress.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	xfnproto "github.com/crossplane/function-sdk-go/proto/v1"
 	vshnv1 "github.com/vshn/appcat/v4/apis/vshn/v1"
@@ -23,9 +24,15 @@ func AddIngress(_ context.Context, comp *vshnv1.VSHNNextcloud, svc *runtime.Serv
 		return runtime.NewFatalResult(fmt.Errorf("FQDN array is empty, but requires at least one entry, %w", errors.New("empty fqdn")))
 	}
 
+	var svcNameSuffix string
+	if !strings.Contains(comp.GetName(), "nextcloud") {
+		svcNameSuffix = "nextcloud"
+	}
+
 	ingressConfig := common.IngressConfig{
 		FQDNs: comp.Spec.Parameters.Service.FQDN,
 		ServiceConfig: common.IngressRuleConfig{
+			ServiceNameSuffix: svcNameSuffix,
 			ServicePortNumber: 8080,
 		},
 		TlsCertBaseName: "nextcloud",


### PR DESCRIPTION
## Summary

If a Forgejo or Nextcloud service is created without having its service name in the name, then the helm chart will add `forgejo/nextcloud` to the service name.  

For example, a `VSHNForgejo` with name `my-forgejo-instance` will create this service: `my-forgejo-instance-pcdj9-http`.  
On the other hand, one with the name `my-cool-instance` creates this service: `my-cool-instance-cgrjz-forgejo-http`.
Same with Nextcloud.

The ingress creation logic currently does not account for that.

This PR fixes this issue for:
- Forgejo & Codey
- Nextcloud

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [ ] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
