### PR TITLE
Add appcat release management in maintenance

### DIFF
--- a/pkg/comp-functions/functions/common/maintenance/maintenance_test.go
+++ b/pkg/comp-functions/functions/common/maintenance/maintenance_test.go
@@ -115,6 +115,7 @@ func TestAddMaintenanceJob(t *testing.T) {
 			in := "vshn-postgresql-" + comp.GetName()
 			m := New(comp, svc, comp.Spec.Parameters.Maintenance, in, "postgresql").
 				WithPolicyRules([]rbacv1.PolicyRule{}).
+				WithAdditionalClusterRoleBinding("cluster-role-binding").
 				WithRole("crossplane:appcat:job:postgres:maintenance").
 				WithExtraResources(createMaintenanceSecretTest(in, svc.Config.Data["sgNamespace"], comp.GetName()+"-maintenance-secret"))
 

--- a/pkg/comp-functions/functions/vshnmariadb/maintenance.go
+++ b/pkg/comp-functions/functions/vshnmariadb/maintenance.go
@@ -11,8 +11,6 @@ import (
 	"github.com/vshn/appcat/v4/pkg/comp-functions/runtime"
 )
 
-var service = "mariadb"
-
 // AddMaintenanceJob will add a job to do the maintenance for the instance
 func AddMaintenanceJob(ctx context.Context, comp *vshnv1.VSHNMariaDB, svc *runtime.ServiceRuntime) *xfnproto.Result {
 
@@ -26,7 +24,7 @@ func AddMaintenanceJob(ctx context.Context, comp *vshnv1.VSHNMariaDB, svc *runti
 	instanceNamespace := comp.GetInstanceNamespace()
 	schedule := comp.GetFullMaintenanceSchedule()
 
-	return maintenance.New(comp, svc, schedule, instanceNamespace, service).
+	return maintenance.New(comp, svc, schedule, instanceNamespace, comp.GetServiceName()).
 		WithHelmBasedService().
 		Run(ctx)
 }

--- a/pkg/comp-functions/functions/vshnminio/maintenance.go
+++ b/pkg/comp-functions/functions/vshnminio/maintenance.go
@@ -11,8 +11,6 @@ import (
 	"github.com/vshn/appcat/v4/pkg/comp-functions/runtime"
 )
 
-var service = "minio"
-
 // AddMaintenanceJob will add a job to do the maintenance for the instance
 func AddMaintenanceJob(ctx context.Context, comp *vshnv1.VSHNMinio, svc *runtime.ServiceRuntime) *xfnproto.Result {
 
@@ -33,7 +31,7 @@ func AddMaintenanceJob(ctx context.Context, comp *vshnv1.VSHNMinio, svc *runtime
 	instanceNamespace := getInstanceNamespace(comp)
 	schedule := comp.GetFullMaintenanceSchedule()
 
-	return maintenance.New(comp, svc, schedule, instanceNamespace, service).
+	return maintenance.New(comp, svc, schedule, instanceNamespace, comp.GetServiceName()).
 		WithHelmBasedService().
 		Run(ctx)
 }

--- a/pkg/comp-functions/functions/vshnpostgres/maintenance.go
+++ b/pkg/comp-functions/functions/vshnpostgres/maintenance.go
@@ -53,18 +53,6 @@ var (
 				"get",
 			},
 		},
-		{
-			APIGroups: []string{
-				"vshn.appcat.vshn.io",
-			},
-			Resources: []string{
-				"vshnpostgresqls",
-			},
-			Verbs: []string{
-				"get",
-				"update",
-			},
-		},
 	}
 
 	extraEnvVars = []corev1.EnvVar{
@@ -153,6 +141,7 @@ func addSchedules(ctx context.Context, comp *vshnv1.VSHNPostgreSQL, svc *runtime
 
 	return maintenance.New(comp, svc, schedule, instanceNamespace, service).
 		WithRole(maintRolename).
+		WithAdditionalClusterRoleBinding(fmt.Sprintf("%s:%s", maintRolename, comp.GetName())).
 		WithPolicyRules(policyRules).
 		WithExtraEnvs(additionalVars...).
 		WithExtraResources(createMaintenanceSecret(instanceNamespace, sgNamespace, comp.GetName()+"-maintenance-secret", comp.GetName())).

--- a/pkg/comp-functions/functions/vshnredis/maintenance.go
+++ b/pkg/comp-functions/functions/vshnredis/maintenance.go
@@ -11,8 +11,6 @@ import (
 	"github.com/vshn/appcat/v4/pkg/comp-functions/runtime"
 )
 
-var service = "redis"
-
 // AddMaintenanceJob will add a job to do the maintenance for the instance
 func AddMaintenanceJob(ctx context.Context, comp *vshnv1.VSHNRedis, svc *runtime.ServiceRuntime) *xfnproto.Result {
 
@@ -26,7 +24,7 @@ func AddMaintenanceJob(ctx context.Context, comp *vshnv1.VSHNRedis, svc *runtime
 	instanceNamespace := getInstanceNamespace(comp)
 	schedule := comp.GetFullMaintenanceSchedule()
 
-	return maintenance.New(comp, svc, schedule, instanceNamespace, service).
+	return maintenance.New(comp, svc, schedule, instanceNamespace, comp.GetServiceName()).
 		WithHelmBasedService().
 		Run(ctx)
 }

--- a/pkg/maintenance/forgejo.go
+++ b/pkg/maintenance/forgejo.go
@@ -2,6 +2,7 @@ package maintenance
 
 import (
 	"context"
+	"github.com/vshn/appcat/v4/pkg/maintenance/release"
 	"net/http"
 
 	"github.com/go-logr/logr"
@@ -18,22 +19,22 @@ type Forgejo struct {
 	k8sClient  client.Client
 	httpClient *http.Client
 	log        logr.Logger
+	release.VersionHandler
 }
 
 // NewForgejo returns a new Forgejo object
-func NewForgejo(c client.Client, hc *http.Client) *Forgejo {
+func NewForgejo(c client.Client, hc *http.Client, vh release.VersionHandler, logger logr.Logger) *Forgejo {
 	return &Forgejo{
-		k8sClient:  c,
-		httpClient: hc,
+		k8sClient:      c,
+		httpClient:     hc,
+		log:            logger,
+		VersionHandler: vh,
 	}
 }
 
 // DoMaintenance will run forgejo's maintenance script.
-func (m *Forgejo) DoMaintenance(ctx context.Context) error {
-	m.log = logr.FromContextOrDiscard(ctx).WithValues("type", "forgejo")
-	patcher := helm.NewImagePatcher(m.k8sClient, m.httpClient, m.log)
-
+func (f *Forgejo) DoMaintenance(ctx context.Context) error {
+	patcher := helm.NewImagePatcher(f.k8sClient, f.httpClient, f.log)
 	valuesPath := helm.NewValuePath("image", "tag")
-
 	return patcher.DoMaintenance(ctx, forgejoURL, valuesPath, helm.SemVerPatchesOnly(true))
 }

--- a/pkg/maintenance/helm/helmpatcher.go
+++ b/pkg/maintenance/helm/helmpatcher.go
@@ -121,13 +121,7 @@ type VersionComparisonStrategy func(VersionLister, string) (string, error)
 // tagPath should be the specific path in the helm values where the tag is specified. It must not be nil and needs to be initialized at least with an empty string.
 // versionComp contains the function to compare if a given list of versions actually contains a valid new version or not.
 func (h *ImagePatcher) DoMaintenance(ctx context.Context, tagURL string, tagPath ValuePath, versionComp VersionComparisonStrategy) error {
-	err := h.configure()
-	if err != nil {
-		return fmt.Errorf("cannot configure job to run: %v", err)
-	}
-
-	h.log = h.log.WithValues("instanceNamespace", h.instanceNamespace)
-
+	h.instanceNamespace = viper.GetString("INSTANCE_NAMESPACE")
 	h.log.Info("Starting maintenance on instance")
 
 	h.log.Info("Getting current versions")
@@ -276,15 +270,6 @@ func (h *ImagePatcher) getHubVersions(imageURL string) (VersionLister, error) {
 	}
 
 	return &Payload{Results: results}, nil
-}
-
-func (h *ImagePatcher) configure() error {
-	errString := "missing environment variable: %s"
-	h.instanceNamespace = viper.GetString("INSTANCE_NAMESPACE")
-	if h.instanceNamespace == "" {
-		return fmt.Errorf(errString, "INSTANCE_NAMESPACE")
-	}
-	return nil
 }
 
 // SemVerPatchesOnly is a VersionComparisonStrategy that will determine if the latest version as long as it adheres to semver

--- a/pkg/maintenance/redis_test.go
+++ b/pkg/maintenance/redis_test.go
@@ -3,6 +3,8 @@ package maintenance
 import (
 	"context"
 	"encoding/json"
+	"github.com/go-logr/logr"
+	"github.com/vshn/appcat/v4/pkg/maintenance/release"
 	"net/http"
 	"testing"
 
@@ -72,7 +74,7 @@ func TestRedis_DoMaintenance(t *testing.T) {
 				WithObjects(tt.givenReleases...).
 				Build()
 
-			r := NewRedis(fClient, http.DefaultClient)
+			r := NewRedis(fClient, http.DefaultClient, &release.DefaultVersionHandler{}, logr.FromContextOrDiscard(context.Background()))
 			ctx := context.Background()
 
 			// WHEN

--- a/pkg/maintenance/release/release.go
+++ b/pkg/maintenance/release/release.go
@@ -1,0 +1,196 @@
+package release
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
+	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/claim"
+	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
+	"github.com/crossplane/function-sdk-go/resource/composite"
+	"github.com/go-logr/logr"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"strings"
+)
+
+// Interface for both Claim and Composite objects
+type compositionObject interface {
+	SetCompositionUpdatePolicy(*xpv1.UpdatePolicy)
+	SetCompositionRevisionSelector(*metav1.LabelSelector)
+}
+
+// VersionHandler is an interface for handling AppCat versions
+type VersionHandler interface {
+	ReleaseLatest(ctx context.Context) error
+}
+
+// DefaultVersionHandler handles AppCat version change for a claim using composition revisions.
+type DefaultVersionHandler struct {
+	client         client.Client
+	log            logr.Logger
+	claimName      string
+	compositeName  string
+	claimNamespace string
+	ownerGroup     string
+	ownerKind      string
+	ownerVersion   string
+	serviceId      string
+}
+
+func NewDefaultVersionHandler(k8sClient client.Client, l logr.Logger, name, composite, namespace, group, kind, version, service string) VersionHandler {
+	return &DefaultVersionHandler{
+		client:         k8sClient,
+		log:            l,
+		claimName:      name,
+		compositeName:  composite,
+		claimNamespace: namespace,
+		ownerGroup:     group,
+		ownerKind:      kind,
+		ownerVersion:   version,
+		serviceId:      service,
+	}
+}
+
+// ReleaseLatest function releases the latest AppCat version for a given claim via latest composition revision
+func (vh *DefaultVersionHandler) ReleaseLatest(ctx context.Context) error {
+	vh.log.Info("Releasing latest version of AppCat")
+
+	// Get latest revision
+	revision, err := vh.getLatestRevisionLabel(ctx)
+	if err != nil || revision == "" {
+		return err
+	}
+
+	// Try to update claim first
+	if err := vh.updateClaim(ctx, revision); err != nil {
+		if apierrors.IsNotFound(err) {
+			// If claim is not found, fallback to updating composite
+			return vh.updateComposite(ctx, revision)
+		}
+		return fmt.Errorf("failed to update claim %s/%s: %w", vh.claimNamespace, vh.claimName, err)
+	}
+
+	vh.log.Info("Claim updated successfully", "revision", revision)
+	return nil
+}
+
+// Helper function to fetch the latest revision label
+func (vh *DefaultVersionHandler) getLatestRevisionLabel(ctx context.Context) (string, error) {
+	cr, err := vh.getLatestRevision(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch latest revision: %w", err)
+	}
+
+	revision, exists := cr.GetLabels()["metadata.appcat.vshn.io/revision"]
+	if !exists || revision == "" {
+		vh.log.Info("Label metadata.appcat.vshn.io/revision is missing from composition revision")
+		return "", nil
+		//TODO return this error when CI/CD is enabled
+		//return errors.New("missing metadata.appcat.vshn.io/revision label in composition revision")
+	}
+
+	return revision, nil
+}
+
+func (vh *DefaultVersionHandler) getLatestRevision(ctx context.Context) (*v1.CompositionRevision, error) {
+	vh.log.Info("Filtering composition revisions by service id")
+	crl := &v1.CompositionRevisionList{}
+	if err := vh.client.List(ctx, crl, client.MatchingLabelsSelector{
+		Selector: labels.SelectorFromSet(labels.Set{"metadata.appcat.vshn.io/serviceID": vh.serviceId}),
+	}); err != nil {
+		return nil, fmt.Errorf("failed to list composition revisions: %w", err)
+	}
+
+	if len(crl.Items) == 0 {
+		return nil, errors.New("no composition revisions found")
+	}
+	vh.log.V(1).Info("Found", "composition revisions", crl.Items)
+	latestRevision := crl.Items[0]
+	for _, item := range crl.Items[1:] {
+		if item.Spec.Revision > latestRevision.Spec.Revision {
+			latestRevision = item
+		}
+	}
+	vh.log.Info("Found latest resource", "composition revision", latestRevision.GetName())
+
+	return &latestRevision, nil
+}
+
+func (vh *DefaultVersionHandler) updateClaim(ctx context.Context, revision string) error {
+	c := claim.New()
+	c.SetGroupVersionKind(vh.getClaimGVK())
+
+	err := vh.client.Get(ctx, types.NamespacedName{
+		Name:      vh.claimName,
+		Namespace: vh.claimNamespace,
+	}, c)
+
+	if err != nil {
+		return err
+	}
+
+	vh.applyUpdatePolicy(c, revision)
+
+	if err = vh.client.Update(ctx, c); err != nil {
+		return fmt.Errorf("failed to update claim: %w", err)
+	}
+
+	return nil
+}
+
+func (vh *DefaultVersionHandler) updateComposite(ctx context.Context, revision string) error {
+	comp := composite.New()
+	comp.SetGroupVersionKind(vh.getCompositeGVK())
+
+	if err := vh.client.Get(ctx, client.ObjectKey{Name: vh.compositeName}, comp); err != nil {
+		return fmt.Errorf("failed to get composite %s of type %s: %w", vh.compositeName, vh.ownerKind, err)
+	}
+
+	vh.applyUpdatePolicy(comp, revision)
+
+	if err := vh.client.Update(ctx, comp); err != nil {
+		return fmt.Errorf("failed to update composite %s: %w", vh.compositeName, err)
+	}
+
+	vh.log.Info("Composite updated successfully", "revision", revision)
+	return nil
+}
+
+// Helper function to apply update policies
+func (vh *DefaultVersionHandler) applyUpdatePolicy(obj compositionObject, revision string) {
+	obj.SetCompositionUpdatePolicy(UpdatePolicyPtr(xpv1.UpdateAutomatic))
+	obj.SetCompositionRevisionSelector(&metav1.LabelSelector{
+		MatchLabels: map[string]string{"metadata.appcat.vshn.io/revision": revision},
+	})
+}
+
+// Helper function to get the GVK for claims
+func (vh *DefaultVersionHandler) getClaimGVK() schema.GroupVersionKind {
+	return schema.GroupVersionKind{
+		Group:   vh.ownerGroup,
+		Version: vh.ownerVersion,
+		Kind:    removeLeadingX(vh.ownerKind),
+	}
+}
+
+// Helper function to get the GVK for composites
+func (vh *DefaultVersionHandler) getCompositeGVK() schema.GroupVersionKind {
+	return schema.GroupVersionKind{
+		Group:   vh.ownerGroup,
+		Version: vh.ownerVersion,
+		Kind:    vh.ownerKind,
+	}
+}
+
+func UpdatePolicyPtr(s xpv1.UpdatePolicy) *xpv1.UpdatePolicy {
+	return &s
+}
+
+func removeLeadingX(s string) string {
+	return strings.TrimLeft(s, "Xx")
+}

--- a/pkg/maintenance/release/release_test.go
+++ b/pkg/maintenance/release/release_test.go
@@ -1,0 +1,219 @@
+package release_test
+
+import (
+	"context"
+	"github.com/crossplane/function-sdk-go/resource/composite"
+	"github.com/vshn/appcat/v4/pkg/maintenance/release"
+	"testing"
+
+	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
+	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/claim"
+	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
+	"github.com/go-logr/logr/testr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func setupFakeClient(objects ...client.Object) client.Client {
+	scheme := runtime.NewScheme()
+	_ = v1.AddToScheme(scheme) // Register Crossplane APIs
+
+	return fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objects...).
+		Build()
+}
+
+func TestGetLatestRevision_NoRevisions(t *testing.T) {
+	// When: No composition revisions exist
+	fakeClient := setupFakeClient()
+	logger := testr.New(t)
+	vh := release.NewDefaultVersionHandler(fakeClient, logger, "test-claim", "test-composite", "default", "test.group", "TestKind", "v1", "service-123")
+
+	// Do
+	err := vh.ReleaseLatest(context.Background())
+
+	// Then
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no composition revisions found")
+}
+
+func TestLatestVersion_UpdateClaim(t *testing.T) {
+	// When: Set up a claim and composition revisions
+	claimObj := claim.New(claim.WithGroupVersionKind(schema.GroupVersionKind{
+		Group:   "test.group",
+		Version: "v1",
+		Kind:    "TestKind",
+	}))
+	claimObj.SetName("test-claim")
+	claimObj.SetNamespace("default")
+	claimObj.SetCompositionUpdatePolicy(release.UpdatePolicyPtr(xpv1.UpdateManual))
+
+	cr1 := &v1.CompositionRevision{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "revision-42",
+			Namespace: "default",
+			Labels: map[string]string{
+				"metadata.appcat.vshn.io/serviceID": "service-123",
+				"metadata.appcat.vshn.io/revision":  "42",
+			},
+		},
+		Spec: v1.CompositionRevisionSpec{Revision: 42},
+	}
+
+	cr2 := &v1.CompositionRevision{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "revision-43",
+			Namespace: "default",
+			Labels: map[string]string{
+				"metadata.appcat.vshn.io/serviceID": "service-123",
+				"metadata.appcat.vshn.io/revision":  "43",
+			},
+		},
+		Spec: v1.CompositionRevisionSpec{Revision: 43},
+	}
+
+	cr3 := &v1.CompositionRevision{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "revision-45",
+			Namespace: "default",
+			Labels: map[string]string{
+				"metadata.appcat.vshn.io/serviceID": "another-service",
+				"metadata.appcat.vshn.io/revision":  "45",
+			},
+		},
+		Spec: v1.CompositionRevisionSpec{Revision: 45},
+	}
+
+	fakeClient := setupFakeClient(claimObj, cr1, cr2, cr3)
+	logger := testr.New(t)
+	vh := release.NewDefaultVersionHandler(fakeClient, logger, "test-claim", "composite", "default", "test.group", "XTestKind", "v1", "service-123")
+
+	// Do
+	err := vh.ReleaseLatest(context.Background())
+
+	// Then
+	require.NoError(t, err)
+
+	// Verify claim was updated
+	updatedClaim := claim.New(claim.WithGroupVersionKind(schema.GroupVersionKind{
+		Group:   "test.group",
+		Version: "v1",
+		Kind:    "TestKind",
+	}))
+	err = fakeClient.Get(context.Background(), client.ObjectKey{Name: "test-claim", Namespace: "default"}, updatedClaim)
+	require.NoError(t, err)
+
+	// Check if update policy and label selector were set
+	assert.Equal(t, xpv1.UpdateAutomatic, *updatedClaim.GetCompositionUpdatePolicy())
+	assert.Equal(t, "43", updatedClaim.GetCompositionRevisionSelector().MatchLabels["metadata.appcat.vshn.io/revision"])
+}
+
+func TestLatestVersion_UpdateComposite(t *testing.T) {
+	// When: Set up a composite and composition revisions
+	comp := composite.New()
+	comp.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "test.group",
+		Version: "v1",
+		Kind:    "XTestKind",
+	})
+	comp.SetName("composite")
+	comp.SetCompositionUpdatePolicy(release.UpdatePolicyPtr(xpv1.UpdateManual))
+
+	cr1 := &v1.CompositionRevision{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "revision-42",
+			Namespace: "default",
+			Labels: map[string]string{
+				"metadata.appcat.vshn.io/serviceID": "service-123",
+				"metadata.appcat.vshn.io/revision":  "42",
+			},
+		},
+		Spec: v1.CompositionRevisionSpec{Revision: 42},
+	}
+
+	cr2 := &v1.CompositionRevision{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "revision-43",
+			Namespace: "default",
+			Labels: map[string]string{
+				"metadata.appcat.vshn.io/serviceID": "service-123",
+				"metadata.appcat.vshn.io/revision":  "44",
+			},
+		},
+		Spec: v1.CompositionRevisionSpec{Revision: 43},
+	}
+
+	cr3 := &v1.CompositionRevision{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "revision-45",
+			Namespace: "default",
+			Labels: map[string]string{
+				"metadata.appcat.vshn.io/serviceID": "another-service",
+				"metadata.appcat.vshn.io/revision":  "45",
+			},
+		},
+		Spec: v1.CompositionRevisionSpec{Revision: 45},
+	}
+
+	fakeClient := setupFakeClient(comp, cr1, cr2, cr3)
+	logger := testr.New(t)
+	vh := release.NewDefaultVersionHandler(fakeClient, logger, "test-claim", "composite", "default", "test.group", "XTestKind", "v1", "service-123")
+
+	// Do
+	err := vh.ReleaseLatest(context.Background())
+
+	// Then
+	require.NoError(t, err)
+
+	// Verify composite was updated
+	updatedComposite := composite.New()
+	updatedComposite.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "test.group",
+		Version: "v1",
+		Kind:    "XTestKind",
+	})
+	err = fakeClient.Get(context.Background(), client.ObjectKey{Name: "composite"}, updatedComposite)
+	require.NoError(t, err)
+
+	// Check if update policy and label selector were set
+	assert.Equal(t, xpv1.UpdateAutomatic, *updatedComposite.GetCompositionUpdatePolicy())
+	assert.Equal(t, "44", updatedComposite.GetCompositionRevisionSelector().MatchLabels["metadata.appcat.vshn.io/revision"])
+}
+
+func TestLatestVersion_MissingRevisionLabel(t *testing.T) {
+	// When: Create a claim and a revision without the label
+	claimObj := claim.New(claim.WithGroupVersionKind(schema.GroupVersionKind{
+		Group:   "test.group",
+		Version: "v1",
+		Kind:    "TestKind",
+	}))
+	claimObj.SetName("test-claim")
+	claimObj.SetNamespace("default")
+
+	cr := &v1.CompositionRevision{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "revision-latest",
+			Namespace: "default",
+			Labels: map[string]string{
+				"metadata.appcat.vshn.io/serviceID": "service-123",
+			},
+		},
+		Spec: v1.CompositionRevisionSpec{Revision: 42},
+	}
+
+	fakeClient := setupFakeClient(claimObj, cr)
+	logger := testr.New(t)
+	vh := release.NewDefaultVersionHandler(fakeClient, logger, "test-claim", "composite", "default", "test.group", "TestKind", "v1", "service-123")
+
+	// Do
+	err := vh.ReleaseLatest(context.Background())
+
+	// Then: No error, but log message should indicate missing label
+	require.NoError(t, err) // Function should return nil instead of error, to be changed to expect error when CI/CD is done
+}

--- a/pkg/scheme.go
+++ b/pkg/scheme.go
@@ -4,7 +4,8 @@ import (
 	"github.com/vshn/appcat/v4/apis/codey"
 	xhelm "github.com/vshn/appcat/v4/apis/helm/release/v1beta1"
 
-	apix "github.com/crossplane/crossplane/apis/apiextensions/v1alpha1"
+	apixv1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
+	apixalphav1 "github.com/crossplane/crossplane/apis/apiextensions/v1alpha1"
 
 	managedupgradev1beta1 "github.com/appuio/openshift-upgrade-controller/api/v1beta1"
 	cmv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
@@ -61,7 +62,8 @@ func AddToScheme(s *runtime.Scheme) {
 	_ = netv1.AddToScheme(s)
 	_ = managedupgradev1beta1.AddToScheme(s)
 	_ = pgv1alpha1.SchemeBuilder.AddToScheme(s)
-	_ = apix.AddToScheme(s)
+	_ = apixalphav1.AddToScheme(s)
+	_ = apixv1.AddToScheme(s)
 	_ = pdbv1.AddToScheme(s)
 	_ = cloudscalev1.SchemeBuilder.AddToScheme(s)
 	_ = exoscalev1.SchemeBuilder.AddToScheme(s)

--- a/test/functions/vshn-postgres/deploy/01_default.yaml
+++ b/test/functions/vshn-postgres/deploy/01_default.yaml
@@ -65,6 +65,7 @@ desired:
 input:
   apiVersion: v1
   data:
+    additionalMaintenanceClusterRole: role
     defaultPlan: standard-1
     controlNamespace: appcat-control
     plans:

--- a/test/functions/vshn-postgres/maintenance/01-GivenSchedule.yaml
+++ b/test/functions/vshn-postgres/maintenance/01-GivenSchedule.yaml
@@ -24,6 +24,7 @@ input:
   data:
     imageTag: v4.1.0
     sgNamespace: stackgres
+    additionalMaintenanceClusterRole: role
   kind: ConfigMap
   metadata:
     annotations: {}

--- a/test/functions/vshn-postgres/maintenance/02-GivenNoSchedule.yaml
+++ b/test/functions/vshn-postgres/maintenance/02-GivenNoSchedule.yaml
@@ -24,6 +24,7 @@ input:
   data:
     imageTag: v4.1.0
     sgNamespace: stackgres
+    additionalMaintenanceClusterRole: role
   kind: ConfigMap
   metadata:
     annotations: {}


### PR DESCRIPTION
## Summary

* Add release management in the maintenance of each service instance for our CI/CD pipeline.

We already assume that the composition revisions have _metadata.appcat.vshn.io/revision_ label set. Going through all service type composition revision, pick revisoins with the highest revision number and get the above revision label to pass it to the claim's _compositionRevisionSelector_.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
