### PR TITLE
Forgejo: Fix backup

### DIFF
--- a/pkg/comp-functions/functions/vshnforgejo/script/backup.sh
+++ b/pkg/comp-functions/functions/vshnforgejo/script/backup.sh
@@ -1,3 +1,6 @@
 #!/bin/bash -xef
 
+# If the path below doesn't exist, forgejo dump will return exit code 1
+[ ! -d /data/git/repositories ] && mkdir -p /data/git/repositories
+
 /usr/local/bin/forgejo dump --type tar -t /tmp/backup -V -f -


### PR DESCRIPTION
## Summary

* `forgejo dump` exits if `/data/git/repositories` is missing, causing backup failure.
  Now, before a backup starts, this directory will be created if it's missing, ensuring that the backup doesn't fail.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
