### PR TITLE
Improve responsiveness with high poll interval

### DIFF
--- a/pkg/comp-functions/functions/vshnpostgres/restart.go
+++ b/pkg/comp-functions/functions/vshnpostgres/restart.go
@@ -16,7 +16,7 @@ import (
 	controllerruntime "sigs.k8s.io/controller-runtime"
 )
 
-var sgDbOpsRestartRetention time.Duration = 30 * 24 * time.Hour
+var sgDbOpsRestartRetention time.Duration = 10 * time.Minute
 
 // TransformRestart triggers a restart of the postgreqsql instance if there is a pending restart and the composite is configured to restart on update.
 func TransformRestart(ctx context.Context, comp *vshnv1.VSHNPostgreSQL, svc *runtime.ServiceRuntime) *xfnproto.Result {

--- a/pkg/comp-functions/runtime/function_mgr.go
+++ b/pkg/comp-functions/runtime/function_mgr.go
@@ -428,12 +428,19 @@ func (s *ServiceRuntime) SetDesiredComposedResourceWithName(obj xpresource.Manag
 		opt(obj)
 	}
 
+	dr, found := s.desiredResources[resource.Name(name)]
+	if !found {
+		dr = &resource.DesiredComposed{}
+	}
+
 	unstructuredObj, err := composed.From(obj)
 	if err != nil {
 		return err
 	}
 
-	s.desiredResources[resource.Name(name)] = &resource.DesiredComposed{Resource: unstructuredObj}
+	dr.Resource = unstructuredObj
+
+	s.desiredResources[resource.Name(name)] = dr
 	return nil
 }
 
@@ -509,6 +516,13 @@ func KubeOptionAddLabels(labels map[string]string) KubeObjectOption {
 func KubeOptionAddRefs(refs ...xkube.Reference) KubeObjectOption {
 	return func(obj *xkube.Object) {
 		obj.Spec.References = refs
+	}
+}
+
+// KubeOptionCustomReadiness sets the readiness of the object to the given readiness
+func KubeOptionCustomReadiness(readines xkube.Readiness) KubeObjectOption {
+	return func(obj *xkube.Object) {
+		obj.Spec.Readiness = readines
 	}
 }
 

--- a/test/functions/vshn-postgres/restart/03-KeepRecentReboots.yaml
+++ b/test/functions/vshn-postgres/restart/03-KeepRecentReboots.yaml
@@ -228,7 +228,7 @@ observed:
                 namespace: vshn-postgresql-psql-gc9x4
               spec:
                 op: restart
-                runAt: "2023-04-26T07:22:22Z"
+                runAt: "2023-04-27T10:00:22Z"
                 sgCluster: psql-gc9x4
               status: {}
         status:
@@ -241,7 +241,7 @@ observed:
                 namespace: vshn-postgresql-psql-gc9x4
               spec:
                 op: restart
-                runAt: "2023-04-26T07:22:22Z"
+                runAt: "2023-04-27T10:00:22Z"
                 sgCluster: psql-gc9x4
               status: {}
     pgsql-gc9x4-pg-restart-1682587342:
@@ -273,7 +273,6 @@ observed:
                 namespace: vshn-postgresql-psql-gc9x4
               spec:
                 op: restart
-                runAt: "2023-04-27T09:22:22Z"
+                runAt: "2023-04-27T10:02:22Z"
                 sgCluster: psql-gc9x4
               status: {}
-


### PR DESCRIPTION
## Summary

This change will make Crossplane react much quicker to changes in PostgreSQL that will trigger a restart.
    
The reason this will take long if the poll interval for Crossplane is set to a high value is because of the asnc restart method we employ.
    
If a restart is needed for PostgreSQL then Stackgres will set a`PendingRestart` condition to true on the sgcluster object. With the default poll rate of 1 minute it will then take about 1 minute for the restart to actually trigger.
    
With a poll rate of 1h it would then take 1 hour for the restart to trigger, because Crossplane will then only poll the latest state of the sgcluster object every 60 minutes.
    
The default poll rate does not apply to Managed Resources that are not marked as ready. Then it will reconcile much quicker.
    
So if there's a change between the observed and desired state of the `profile` object we explicitly set the managed resource of the sgcluster to unready. This will then trigger the actualy restart even quicker than before.

A higher poll rate in Crossplane will massively reduce the load on the Kubernetes API.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
