### PR TITLE
Switch backups to use the default region

### DIFF
--- a/apis/v1/objectstorage_types.go
+++ b/apis/v1/objectstorage_types.go
@@ -50,11 +50,9 @@ type ObjectBucketParameters struct {
 	// Be aware that S3 providers may require a unique name across the platform or region.
 	BucketName string `json:"bucketName"`
 
-	// +kubebuilder:validation:Required
-
 	// Region is the name of the region where the bucket shall be created.
 	// The region must be available in the S3 endpoint.
-	Region string `json:"region"`
+	Region string `json:"region,omitempty"`
 
 	// +kubebuilder:default=DeleteAll
 

--- a/crds/appcat.vshn.io_objectbuckets.yaml
+++ b/crds/appcat.vshn.io_objectbuckets.yaml
@@ -107,7 +107,6 @@ spec:
                       default: {}
                   required:
                     - bucketName
-                    - region
                   type: object
                 writeConnectionSecretToRef:
                   description: WriteConnectionSecretToRef references a secret to which the connection details will be written.

--- a/crds/appcat.vshn.io_xobjectbuckets.yaml
+++ b/crds/appcat.vshn.io_xobjectbuckets.yaml
@@ -138,7 +138,6 @@ spec:
                     type: object
                 required:
                 - bucketName
-                - region
                 type: object
               providerConfigRef:
                 default:

--- a/pkg/comp-functions/functions/common/backup/backup.go
+++ b/pkg/comp-functions/functions/common/backup/backup.go
@@ -66,7 +66,6 @@ func createObjectBucket(ctx context.Context, comp common.InfoGetter, svc *runtim
 		Spec: appcatv1.XObjectBucketSpec{
 			Parameters: appcatv1.ObjectBucketParameters{
 				BucketName: comp.GetName() + "-backup",
-				Region:     svc.Config.Data["bucketRegion"],
 			},
 			ResourceSpec: xpv1.ResourceSpec{
 				WriteConnectionSecretToReference: &xpv1.SecretReference{


### PR DESCRIPTION
## Summary

With this change it's now possible to select the default region/zone for the backups.
    
This enables us to deliver true off-site backups, so in case of a whole datacenter not being available anymore it's possible to restore.

This PR also fixes an annoying issue with Exoscale IAM name clashes. It was previously not possible to provision the buckets for nested services where both of them need a bucket (currently only Nextcloud). Also due to our billing re-creating the same instance in the same claim-namespace also failed.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
