### PR TITLE
Enable HA for MariaDB in SLI exporter

### DIFF
--- a/pkg/sliexporter/vshnmariadb_controller/vshnmariadb_controller.go
+++ b/pkg/sliexporter/vshnmariadb_controller/vshnmariadb_controller.go
@@ -95,10 +95,11 @@ func (r VSHNMariaDBReconciler) fetchProberFor(ctx context.Context, obj slireconc
 	if sla == "" {
 		sla = vshnv1.BestEffort
 	}
+	ha := inst.Spec.Parameters.Instances > 1
 
 	dsn := fmt.Sprintf("%s:%s@tcp(%s:%s)/%s", credSecret.Data["MARIADB_USERNAME"], credSecret.Data["MARIADB_PASSWORD"], credSecret.Data["MARIADB_HOST"], credSecret.Data["MARIADB_PORT"], "mysql")
 
-	probe, err := r.MariaDBDialer(vshnMariadbServiceKey, inst.Name, inst.GetLabels()[slireconciler.ClaimNamespaceLabel], dsn, org, string(credSecret.Data["ca.crt"]), string(sla), false, inst.Spec.Parameters.TLS.TLSEnabled)
+	probe, err := r.MariaDBDialer(vshnMariadbServiceKey, inst.Name, inst.GetLabels()[slireconciler.ClaimNamespaceLabel], dsn, org, string(credSecret.Data["ca.crt"]), string(sla), ha, inst.Spec.Parameters.TLS.TLSEnabled)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sliexporter/vshnpostgresql_controller/vshnpostgresql_controller.go
+++ b/pkg/sliexporter/vshnpostgresql_controller/vshnpostgresql_controller.go
@@ -110,10 +110,7 @@ func (r VSHNPostgreSQLReconciler) fetchProberFor(ctx context.Context, obj slirec
 		sla = vshnv1.BestEffort
 	}
 
-	ha := true
-	if inst.Spec.Parameters.Instances == 1 {
-		ha = false
-	}
+	ha := inst.Spec.Parameters.Instances > 1
 
 	sslmode := "verify-ca"
 	if !inst.Spec.Parameters.Service.TLS.Enabled {


### PR DESCRIPTION
## Summary

* Enable HA in MariaDB SLI Exporter. It was set to always false.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
