### PR TITLE
Fix no client returned for APIserver on converged setups

### DIFF
--- a/pkg/apiserver/common.go
+++ b/pkg/apiserver/common.go
@@ -119,7 +119,7 @@ func New(client client.WithWatch) *KubeClient {
 // for the remote cluster (non-converged) or nil for the local cluster
 func (k *KubeClient) GetKubeClient(ctx context.Context, instance client.Object) (client.WithWatch, error) {
 	if instance.GetLabels()[appcatruntime.ProviderConfigLabel] == "" {
-		return nil, nil
+		return k.WithWatch, nil
 	}
 
 	kubeconfig, err := k.getKubeConfig(ctx, instance)


### PR DESCRIPTION
There was a bug that didn't return a client on a converged setup. This PR fixes that issue

## Summary

* Short summary of what's included in the PR
* Give special note to breaking changes

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [ ] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
