### PR TITLE
Add default forgejo admin email

### DIFF
--- a/pkg/comp-functions/functions/vshnforgejo/deploy.go
+++ b/pkg/comp-functions/functions/vshnforgejo/deploy.go
@@ -85,6 +85,7 @@ func addForgejo(ctx context.Context, svc *runtime.ServiceRuntime, comp *vshnv1.V
 	values := map[string]any{
 		"gitea": map[string]any{
 			"admin": map[string]any{
+				"email":          "forgejo@local.domain",
 				"username":       "forgejo_admin",
 				"existingSecret": secretName,
 			},


### PR DESCRIPTION
## Summary

* The helm chart might create the `gitea_admin` account first with the same email account as `forgejo_admin` then the pod fails during setup.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
