### PR TITLE
Add Forgejo host connection detail

### DIFF
--- a/pkg/comp-functions/functions/vshnforgejo/deploy.go
+++ b/pkg/comp-functions/functions/vshnforgejo/deploy.go
@@ -44,6 +44,7 @@ func DeployForgejo(ctx context.Context, comp *vshnv1.VSHNForgejo, svc *runtime.S
 	// "," as separator for multiple FQDNs, it's better than anything else as highlighting with mouse in terminal works well
 	// result is fqdn[0],fqdn[1],fqdn[2]
 	svc.SetConnectionDetail("FORGEJO_URL", []byte(strings.Join(comp.Spec.Parameters.Service.FQDN, ",")))
+	svc.SetConnectionDetail("FORGEJO_HOST", []byte(fmt.Sprintf("%s-http.%s.svc", comp.GetName(), comp.GetInstanceNamespace())))
 
 	svc.Log.Info("Adding forgejo release")
 	err = addForgejo(ctx, svc, comp, secretName)


### PR DESCRIPTION
## Summary

This connection detail is specified in the XRD but wasn't set until now.
It's mainly used for cluster internal connections as well as the e2e tests.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
