### PR TITLE
Remove unused redis 6.2 version

### DIFF
--- a/apis/vshn/v1/dbaas_vshn_redis.go
+++ b/apis/vshn/v1/dbaas_vshn_redis.go
@@ -81,7 +81,7 @@ type VSHNRedisParameters struct {
 
 // VSHNRedisServiceSpec contains Redis DBaaS specific properties
 type VSHNRedisServiceSpec struct {
-	// +kubebuilder:validation:Enum="6.2";"7.0"
+	// +kubebuilder:validation:Enum="7.0"
 	// +kubebuilder:default="7.0"
 
 	// Version contains supported version of Redis.

--- a/crds/vshn.appcat.vshn.io_vshnredis.yaml
+++ b/crds/vshn.appcat.vshn.io_vshnredis.yaml
@@ -4611,7 +4611,6 @@ spec:
                             Version contains supported version of Redis.
                             Multiple versions are supported. The latest version "7.0" is the default version.
                           enum:
-                            - "6.2"
                             - "7.0"
                           type: string
                       type: object

--- a/crds/vshn.appcat.vshn.io_xvshnredis.yaml
+++ b/crds/vshn.appcat.vshn.io_xvshnredis.yaml
@@ -5336,7 +5336,6 @@ spec:
                           Version contains supported version of Redis.
                           Multiple versions are supported. The latest version "7.0" is the default version.
                         enum:
-                        - "6.2"
                         - "7.0"
                         type: string
                     type: object


### PR DESCRIPTION
## Summary

* Remove unused and EOL Redis 6.2 from VSHNRedis service

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [ ] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
