### PR TITLE
Add hotfix release job

### DIFF
--- a/cmd/hotfixreleaser.go
+++ b/cmd/hotfixreleaser.go
@@ -1,0 +1,179 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/crossplane/crossplane-runtime/pkg/fieldpath"
+	"github.com/go-logr/logr"
+	"github.com/spf13/cobra"
+	"github.com/vshn/appcat/v4/pkg"
+	"github.com/vshn/appcat/v4/pkg/maintenance/release"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var HotfixerCMD = newHotfixer()
+
+type hotfixer struct {
+}
+
+func newHotfixer() cobra.Command {
+	h := hotfixer{}
+
+	return cobra.Command{
+		Use:   "hotfixer",
+		Short: "Hotfixer",
+		Long:  "Run the Hotfixer",
+		RunE:  h.runHotfixer,
+	}
+}
+
+func (h *hotfixer) runHotfixer(cmd *cobra.Command, _ []string) error {
+	ctx := cmd.Context()
+
+	log := logr.FromContextOrDiscard(ctx)
+
+	dynClient, err := dynamic.NewForConfig(ctrl.GetConfigOrDie())
+	if err != nil {
+		return fmt.Errorf("failed to initialize kube client: %w", err)
+	}
+
+	kubeClient, err := client.New(ctrl.GetConfigOrDie(), client.Options{
+		Scheme: pkg.SetupScheme(),
+	})
+	if err != nil {
+		return err
+	}
+
+	xrds, err := dynClient.Resource(schema.GroupVersionResource{
+		Group:    "apiextensions.crossplane.io",
+		Version:  "v1",
+		Resource: "compositeresourcedefinitions",
+	}).List(ctx, metav1.ListOptions{})
+
+	if err != nil {
+		return err
+	}
+
+	// collect all installed xrds
+	// and then loop over every single composite
+	for _, xrd := range xrds.Items {
+
+		// objectbuckets get ignored
+		if xrd.GetName() == "xobjectbuckets.appcat.vshn.io" {
+			continue
+		}
+
+		p := fieldpath.Pave(xrd.Object)
+
+		XRDLabels := xrd.GetLabels()
+
+		if XRDLabels[release.ServiceIDLabel] == "" {
+			return fmt.Errorf("xrd does not have the required label " + xrd.GetName())
+		}
+
+		compositeResource, err := p.GetString("spec.names.plural")
+		if err != nil {
+			return err
+		}
+
+		// TODO: currently we only have v1, but that might change at some point...
+		compositeVersion := "v1"
+		compositeGroup, err := p.GetString("spec.group")
+		if err != nil {
+			return err
+		}
+
+		foundGVK := schema.GroupVersionResource{
+			Resource: compositeResource,
+			Version:  compositeVersion,
+			Group:    compositeGroup,
+		}
+
+		l, err := dynClient.Resource(foundGVK).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return err
+		}
+
+		for _, composite := range l.Items {
+			p := fieldpath.Pave(composite.Object)
+			log := log.WithValues("xrd", compositeResource, "composite", composite.GetName())
+
+			log.Info("checking for new compositionrevision")
+
+			claimRef, err := p.GetStringObject("spec.claimRef")
+			if err != nil {
+				if !fieldpath.IsNotFound(err) {
+					return err
+				}
+
+				err := h.handleComposite(ctx, composite, XRDLabels[release.ServiceIDLabel], log, kubeClient)
+				if err != nil {
+					return err
+				}
+			} else {
+				err = h.handleClaimRef(ctx, claimRef, log, kubeClient, XRDLabels, composite.GetName())
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func (h *hotfixer) handleComposite(ctx context.Context, comp unstructured.Unstructured, serviceID string, log logr.Logger, kubeClient client.Client) error {
+
+	gv, err := schema.ParseGroupVersion(comp.GetAPIVersion())
+	if err != nil {
+		return err
+	}
+
+	opts := release.ReleaserOpts{
+		Composite: comp.GetName(),
+		Group:     gv.Group,
+		Kind:      comp.GetKind(),
+		Version:   gv.Version,
+		ServiceID: serviceID,
+	}
+
+	r := release.NewDefaultVersionHandler(
+		kubeClient,
+		log,
+		opts,
+	)
+
+	return r.ReleaseLatest(ctx)
+}
+
+func (h *hotfixer) handleClaimRef(ctx context.Context, ref map[string]string, log logr.Logger, kubeClient client.Client, labels map[string]string, compName string) error {
+
+	gv, err := schema.ParseGroupVersion(ref["apiVersion"])
+	if err != nil {
+		return err
+	}
+
+	opts := release.ReleaserOpts{
+		ClaimName:      ref["name"],
+		Composite:      compName,
+		ClaimNamespace: ref["namespace"],
+		Group:          gv.Group,
+		Version:        gv.Version,
+		Kind:           ref["kind"],
+		ServiceID:      labels[release.ServiceIDLabel],
+	}
+
+	r := release.NewDefaultVersionHandler(
+		kubeClient,
+		log,
+		opts,
+	)
+
+	return r.ReleaseLatest(ctx)
+}

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ func init() {
 		cmd.MaintenanceCMD,
 		cmd.SlareportCMD,
 		cmd.APIServerCMD,
+		&cmd.HotfixerCMD,
 	)
 }
 

--- a/pkg/comp-functions/functions/common/maintenance/maintenance.go
+++ b/pkg/comp-functions/functions/common/maintenance/maintenance.go
@@ -3,6 +3,8 @@ package maintenance
 import (
 	"context"
 	"fmt"
+	"regexp"
+
 	"github.com/blang/semver/v4"
 	xfnproto "github.com/crossplane/function-sdk-go/proto/v1"
 	xkubev1 "github.com/vshn/appcat/v4/apis/kubernetes/v1alpha2"
@@ -14,7 +16,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/utils/ptr"
-	"regexp"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )

--- a/pkg/maintenance/release/release_test.go
+++ b/pkg/maintenance/release/release_test.go
@@ -2,9 +2,10 @@ package release_test
 
 import (
 	"context"
+	"testing"
+
 	"github.com/crossplane/function-sdk-go/resource/composite"
 	"github.com/vshn/appcat/v4/pkg/maintenance/release"
-	"testing"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/claim"
@@ -33,7 +34,16 @@ func TestGetLatestRevision_NoRevisions(t *testing.T) {
 	// When: No composition revisions exist
 	fakeClient := setupFakeClient()
 	logger := testr.New(t)
-	vh := release.NewDefaultVersionHandler(fakeClient, logger, "test-claim", "test-composite", "default", "test.group", "TestKind", "v1", "service-123")
+	opts := release.ReleaserOpts{
+		ClaimName:      "test-claim",
+		Composite:      "test-composite",
+		ClaimNamespace: "default",
+		Group:          "test.group",
+		Kind:           "TestKind",
+		Version:        "v1",
+		ServiceID:      "service-123",
+	}
+	vh := release.NewDefaultVersionHandler(fakeClient, logger, opts)
 
 	// Do
 	err := vh.ReleaseLatest(context.Background())
@@ -92,7 +102,16 @@ func TestLatestVersion_UpdateClaim(t *testing.T) {
 
 	fakeClient := setupFakeClient(claimObj, cr1, cr2, cr3)
 	logger := testr.New(t)
-	vh := release.NewDefaultVersionHandler(fakeClient, logger, "test-claim", "composite", "default", "test.group", "XTestKind", "v1", "service-123")
+	opts := release.ReleaserOpts{
+		ClaimName:      "test-claim",
+		Composite:      "composite",
+		ClaimNamespace: "default",
+		Group:          "test.group",
+		Kind:           "XTestKind",
+		Version:        "v1",
+		ServiceID:      "service-123",
+	}
+	vh := release.NewDefaultVersionHandler(fakeClient, logger, opts)
 
 	// Do
 	err := vh.ReleaseLatest(context.Background())
@@ -163,7 +182,14 @@ func TestLatestVersion_UpdateComposite(t *testing.T) {
 
 	fakeClient := setupFakeClient(comp, cr1, cr2, cr3)
 	logger := testr.New(t)
-	vh := release.NewDefaultVersionHandler(fakeClient, logger, "test-claim", "composite", "default", "test.group", "XTestKind", "v1", "service-123")
+	opts := release.ReleaserOpts{
+		Composite: "composite",
+		Group:     "test.group",
+		Kind:      "XTestKind",
+		Version:   "v1",
+		ServiceID: "service-123",
+	}
+	vh := release.NewDefaultVersionHandler(fakeClient, logger, opts)
 
 	// Do
 	err := vh.ReleaseLatest(context.Background())
@@ -209,7 +235,16 @@ func TestLatestVersion_MissingRevisionLabel(t *testing.T) {
 
 	fakeClient := setupFakeClient(claimObj, cr)
 	logger := testr.New(t)
-	vh := release.NewDefaultVersionHandler(fakeClient, logger, "test-claim", "composite", "default", "test.group", "TestKind", "v1", "service-123")
+	opts := release.ReleaserOpts{
+		ClaimName:      "test-claim",
+		Composite:      "composite",
+		ClaimNamespace: "default",
+		Group:          "test.group",
+		Kind:           "TestKind",
+		Version:        "v1",
+		ServiceID:      "service-123",
+	}
+	vh := release.NewDefaultVersionHandler(fakeClient, logger, opts)
 
 	// Do
 	err := vh.ReleaseLatest(context.Background())


### PR DESCRIPTION
## Summary

This commit adds a new cmd for AppCat which will discover all composites on a given cluster.
    
It will then loop over them and switch over to the latest composition revision using the logic already engineered for the maintenance.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
