### PR TITLE
Fix Nextcloud default PG settings

### DIFF
--- a/pkg/comp-functions/functions/common/postgresql.go
+++ b/pkg/comp-functions/functions/common/postgresql.go
@@ -34,7 +34,7 @@ func NewPostgreSQLDependencyBuilder(svc *runtime.ServiceRuntime, comp InfoGetter
 	}
 }
 
-func (a *PostgreSQLDependencyBuilder) SetSize(size string) *PostgreSQLDependencyBuilder {
+func (a *PostgreSQLDependencyBuilder) SetDiskSize(size string) *PostgreSQLDependencyBuilder {
 	if a.psqlParams == nil {
 		a.psqlParams = &vshnv1.VSHNPostgreSQLParameters{}
 	}
@@ -74,29 +74,25 @@ func (a *PostgreSQLDependencyBuilder) CreateDependency() (string, error) {
 
 	pgBouncerRaw := k8sruntime.RawExtension{}
 	if a.pgBouncerConfig != nil {
-		if a.pgBouncerConfig != nil {
 
-			pgBouncerConfigBytes, err := json.Marshal(a.pgBouncerConfig)
-			if err != nil {
-				return "", err
-			}
-			pgBouncerRaw = k8sruntime.RawExtension{
-				Raw: pgBouncerConfigBytes,
-			}
+		pgBouncerConfigBytes, err := json.Marshal(a.pgBouncerConfig)
+		if err != nil {
+			return "", err
+		}
+		pgBouncerRaw = k8sruntime.RawExtension{
+			Raw: pgBouncerConfigBytes,
 		}
 	}
 
 	pgSettingsRaw := k8sruntime.RawExtension{}
 	if a.pgSettings != nil {
-		if a.pgSettings != nil {
 
-			pgSettingsBytes, err := json.Marshal(a.pgSettings)
-			if err != nil {
-				return "", err
-			}
-			pgSettingsRaw = k8sruntime.RawExtension{
-				Raw: pgSettingsBytes,
-			}
+		pgSettingsBytes, err := json.Marshal(a.pgSettings)
+		if err != nil {
+			return "", err
+		}
+		pgSettingsRaw = k8sruntime.RawExtension{
+			Raw: pgSettingsBytes,
 		}
 	}
 

--- a/pkg/comp-functions/functions/vshnnextcloud/deploy.go
+++ b/pkg/comp-functions/functions/vshnnextcloud/deploy.go
@@ -3,12 +3,14 @@ package vshnnextcloud
 import (
 	"context"
 	_ "embed"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strconv"
 	"strings"
 	"time"
 
+	"dario.cat/mergo"
 	xfnproto "github.com/crossplane/function-sdk-go/proto/v1"
 	xhelmv1 "github.com/vshn/appcat/v4/apis/helm/release/v1beta1"
 	vshnv1 "github.com/vshn/appcat/v4/apis/vshn/v1"
@@ -18,7 +20,6 @@ import (
 	"github.com/vshn/appcat/v4/pkg/comp-functions/functions/vshnpostgres"
 	"github.com/vshn/appcat/v4/pkg/comp-functions/runtime"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
@@ -67,13 +68,26 @@ func DeployNextcloud(ctx context.Context, comp *vshnv1.VSHNNextcloud, svc *runti
 	var pgTime vshnv1.TimeOfDay
 	pgTime.SetTime(comp.GetMaintenanceTimeOfDay().GetTime().Add(20 * time.Minute))
 
+	pgBouncerConfig, pgSettings, pgDiskSize, err := getObservedPostgresSettings(svc, comp)
+	if err != nil {
+		return runtime.NewWarningResult(fmt.Sprintf("cannot get observed postgres settings: %s", err))
+	}
+
 	pgSecret := ""
 	if comp.Spec.Parameters.Service.UseExternalPostgreSQL {
 		svc.Log.Info("Adding postgresql instance")
-		pgSecret, err = common.NewPostgreSQLDependencyBuilder(svc, comp).
+
+		pgBuilder := common.NewPostgreSQLDependencyBuilder(svc, comp).
 			AddParameters(comp.Spec.Parameters.Service.PostgreSQLParameters).
-			SetCustomMaintenanceSchedule(pgTime).
-			CreateDependency()
+			AddPGBouncerConfig(pgBouncerConfig).
+			AddPGSettings(pgSettings).
+			SetCustomMaintenanceSchedule(pgTime)
+
+		if pgDiskSize != "" {
+			pgBuilder.SetSize(pgDiskSize)
+		}
+
+		pgSecret, err = pgBuilder.CreateDependency()
 		if err != nil {
 			return runtime.NewWarningResult(fmt.Sprintf("cannot create postgresql instance: %s", err))
 		}
@@ -141,6 +155,104 @@ func DeployNextcloud(ctx context.Context, comp *vshnv1.VSHNNextcloud, svc *runti
 	}
 
 	return nil
+}
+
+func getObservedPostgresSettings(svc *runtime.ServiceRuntime, comp *vshnv1.VSHNNextcloud) (map[string]string, map[string]string, string, error) {
+	pgBouncerConfig := map[string]string{
+		"max_client_conn": "1000",
+	}
+	pgSettings := map[string]string{
+		"max_connections": "1000",
+	}
+	pgDiskSize := ""
+
+	if !comp.Spec.Parameters.Service.UseExternalPostgreSQL {
+		return pgBouncerConfig, pgSettings, pgDiskSize, nil
+	}
+
+	existing := &vshnv1.XVSHNPostgreSQL{}
+	err := svc.GetObservedComposedResource(existing, comp.GetName()+pgInstanceNameSuffix)
+	if err == nil {
+		if existing.Spec.Parameters.Size.Disk != "" {
+			pgDiskSize = existing.Spec.Parameters.Size.Disk
+		}
+
+		if existing.Spec.Parameters.Service.PgBouncerSettings != nil {
+			if bouncer := existing.Spec.Parameters.Service.PgBouncerSettings.Pgbouncer.Raw; len(bouncer) > 0 {
+				var rawBouncer map[string]interface{}
+				if err := json.Unmarshal(bouncer, &rawBouncer); err != nil {
+					return nil, nil, "", fmt.Errorf("cannot unmarshal existing pgbouncersettings: %w", err)
+				}
+
+				bouncerSettings := make(map[string]string)
+				for k, v := range rawBouncer {
+					bouncerSettings[k] = fmt.Sprint(v)
+				}
+
+				if err := mergo.Merge(&pgBouncerConfig, bouncerSettings, mergo.WithOverride); err != nil {
+					return nil, nil, "", fmt.Errorf("cannot merge existing pgbouncerconfig: %w", err)
+				}
+			}
+		}
+
+		if settings := existing.Spec.Parameters.Service.PostgreSQLSettings.Raw; len(settings) > 0 {
+			var rawSettings map[string]interface{}
+			if err := json.Unmarshal(settings, &rawSettings); err != nil {
+				return nil, nil, "", fmt.Errorf("cannot unmarshal existing pgsettings: %w", err)
+			}
+
+			pgSettingsMap := make(map[string]string)
+			for k, v := range rawSettings {
+				pgSettingsMap[k] = fmt.Sprint(v)
+			}
+
+			if err := mergo.Merge(&pgSettings, pgSettingsMap, mergo.WithOverride); err != nil {
+				return nil, nil, "", fmt.Errorf("cannot merge existing pgsettings: %w", err)
+			}
+		}
+	} else if err == runtime.ErrNotFound {
+		pgDiskSize = "10Gi"
+	}
+
+	if params := comp.Spec.Parameters.Service.PostgreSQLParameters; params != nil {
+		if params.Size.Disk != "" && !(pgDiskSize == "10Gi" && params.Size.Disk < pgDiskSize) {
+			pgDiskSize = params.Size.Disk
+		}
+
+		if params.Service.PgBouncerSettings != nil && len(params.Service.PgBouncerSettings.Pgbouncer.Raw) > 0 {
+			var rawBouncer map[string]interface{}
+			if err := json.Unmarshal(params.Service.PgBouncerSettings.Pgbouncer.Raw, &rawBouncer); err != nil {
+				return nil, nil, "", fmt.Errorf("cannot unmarshal user pgbouncersettings: %w", err)
+			}
+
+			bouncerSettings := make(map[string]string)
+			for k, v := range rawBouncer {
+				bouncerSettings[k] = fmt.Sprint(v)
+			}
+
+			if err := mergo.Merge(&pgBouncerConfig, bouncerSettings, mergo.WithOverride); err != nil {
+				return nil, nil, "", fmt.Errorf("cannot merge user pgbouncerconfig: %w", err)
+			}
+		}
+
+		if len(params.Service.PostgreSQLSettings.Raw) > 0 {
+			var rawSettings map[string]interface{}
+			if err := json.Unmarshal(params.Service.PostgreSQLSettings.Raw, &rawSettings); err != nil {
+				return nil, nil, "", fmt.Errorf("cannot unmarshal user pgsettings: %w", err)
+			}
+
+			pgSettingsMap := make(map[string]string)
+			for k, v := range rawSettings {
+				pgSettingsMap[k] = fmt.Sprint(v)
+			}
+
+			if err := mergo.Merge(&pgSettings, pgSettingsMap, mergo.WithOverride); err != nil {
+				return nil, nil, "", fmt.Errorf("cannot merge user pgsettings: %w", err)
+			}
+		}
+	}
+
+	return pgBouncerConfig, pgSettings, pgDiskSize, nil
 }
 
 func createInstallCollaboraConfigMap(comp *vshnv1.VSHNNextcloud, svc *runtime.ServiceRuntime) error {
@@ -480,7 +592,7 @@ func configureCronSidecar(values map[string]interface{}, version string, svc *ru
 
 func addApacheConfig(svc *runtime.ServiceRuntime, comp *vshnv1.VSHNNextcloud) error {
 
-	cm := &v1.ConfigMap{
+	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "apache-config",
 			Namespace: comp.GetInstanceNamespace(),
@@ -500,7 +612,7 @@ func addApacheConfig(svc *runtime.ServiceRuntime, comp *vshnv1.VSHNNextcloud) er
 
 func addNextcloudHooks(svc *runtime.ServiceRuntime, comp *vshnv1.VSHNNextcloud) error {
 
-	cm := &v1.ConfigMap{
+	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "nextcloud-hooks",
 			Namespace: comp.GetInstanceNamespace(),


### PR DESCRIPTION
## Summary

We discovered that the disk for the embedded PostgreSQL will be set to the same size as the Nextcloud disk.
This PR improves the default configuration and reconciliation behavior for Nextcloud's PostgreSQL dependency.

* Default disk size for the PostgreSQL dependency is set to `10GiB` if not specified by the user.  
* Existing instances will not be downsized if they already use more than `10GiB`.  
* If the current disk size is below `10GiB` and no user-defined value is set, it will be updated to the new default.  
* Adds and enforces `max_connections: "1000"` in PostgreSQL settings.  
* Adds and enforces `max_client_conn: "1000"` in pgBouncer settings.  
* These settings will be reconciled on existing instances unless explicitly overridden by the user.

## Checklist

- [ ] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [ ] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
