### PR TITLE
disabling majorVersionUpgrades

### DIFF
--- a/apis/vshn/v1/dbaas_vshn_postgresql.go
+++ b/apis/vshn/v1/dbaas_vshn_postgresql.go
@@ -132,6 +132,7 @@ type VSHNPostgreSQLServiceSpec struct {
 
 	// MajorVersion contains supported version of PostgreSQL.
 	// Multiple versions are supported. The latest version "15" is the default version.
+	// Currently it's impossible to change the version of an existing instance - we're working on it.
 	MajorVersion string `json:"majorVersion,omitempty"`
 
 	// PGSettings contains additional PostgreSQL settings.

--- a/crds/vshn.appcat.vshn.io_vshnkeycloaks.yaml
+++ b/crds/vshn.appcat.vshn.io_vshnkeycloaks.yaml
@@ -9335,6 +9335,7 @@ spec:
                                   description: |-
                                     MajorVersion contains supported version of PostgreSQL.
                                     Multiple versions are supported. The latest version "15" is the default version.
+                                    Currently it's impossible to change the version of an existing instance - we're working on it.
                                   enum:
                                     - "12"
                                     - "13"

--- a/crds/vshn.appcat.vshn.io_vshnnextclouds.yaml
+++ b/crds/vshn.appcat.vshn.io_vshnnextclouds.yaml
@@ -9325,6 +9325,7 @@ spec:
                                   description: |-
                                     MajorVersion contains supported version of PostgreSQL.
                                     Multiple versions are supported. The latest version "15" is the default version.
+                                    Currently it's impossible to change the version of an existing instance - we're working on it.
                                   enum:
                                     - "12"
                                     - "13"

--- a/crds/vshn.appcat.vshn.io_vshnpostgresqls.yaml
+++ b/crds/vshn.appcat.vshn.io_vshnpostgresqls.yaml
@@ -4773,6 +4773,7 @@ spec:
                           description: |-
                             MajorVersion contains supported version of PostgreSQL.
                             Multiple versions are supported. The latest version "15" is the default version.
+                            Currently it's impossible to change the version of an existing instance - we're working on it.
                           enum:
                             - "12"
                             - "13"

--- a/crds/vshn.appcat.vshn.io_xvshnkeycloaks.yaml
+++ b/crds/vshn.appcat.vshn.io_xvshnkeycloaks.yaml
@@ -11119,6 +11119,7 @@ spec:
                                 description: |-
                                   MajorVersion contains supported version of PostgreSQL.
                                   Multiple versions are supported. The latest version "15" is the default version.
+                                  Currently it's impossible to change the version of an existing instance - we're working on it.
                                 enum:
                                 - "12"
                                 - "13"

--- a/crds/vshn.appcat.vshn.io_xvshnnextclouds.yaml
+++ b/crds/vshn.appcat.vshn.io_xvshnnextclouds.yaml
@@ -11112,6 +11112,7 @@ spec:
                                 description: |-
                                   MajorVersion contains supported version of PostgreSQL.
                                   Multiple versions are supported. The latest version "15" is the default version.
+                                  Currently it's impossible to change the version of an existing instance - we're working on it.
                                 enum:
                                 - "12"
                                 - "13"

--- a/crds/vshn.appcat.vshn.io_xvshnpostgresqls.yaml
+++ b/crds/vshn.appcat.vshn.io_xvshnpostgresqls.yaml
@@ -5460,6 +5460,7 @@ spec:
                         description: |-
                           MajorVersion contains supported version of PostgreSQL.
                           Multiple versions are supported. The latest version "15" is the default version.
+                          Currently it's impossible to change the version of an existing instance - we're working on it.
                         enum:
                         - "12"
                         - "13"

--- a/pkg/comp-functions/functions/vshnpostgres/register.go
+++ b/pkg/comp-functions/functions/vshnpostgres/register.go
@@ -84,10 +84,6 @@ func init() {
 				Name:    "custom-exporter-configs",
 				Execute: PgExporterConfig,
 			},
-			{
-				Name:    "major-version-upgrade",
-				Execute: MajorVersionUpgrade,
-			},
 		},
 	})
 }

--- a/pkg/controller/webhooks/postgresql.go
+++ b/pkg/controller/webhooks/postgresql.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
+
 	"github.com/vshn/appcat/v4/pkg/common/quotas"
 	"github.com/vshn/appcat/v4/pkg/common/utils"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
-	"strconv"
 
 	vshnv1 "github.com/vshn/appcat/v4/apis/vshn/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -298,6 +299,15 @@ func validateMajorVersionUpgrade(newPg *vshnv1.VSHNPostgreSQL, oldPg *vshnv1.VSH
 				fmt.Sprintf("invalid major version: %s", err.Error()),
 			))
 		}
+	}
+
+	if newVersion != oldVersion {
+		errList = append(errList, field.Invalid(
+			field.NewPath("spec.parameters.service.majorVersion"),
+			newPg.Spec.Parameters.Service.MajorVersion,
+			"major version upgrade is not allowed.",
+		))
+		return errList
 	}
 
 	// Check if the upgrade is allowed

--- a/pkg/controller/webhooks/postgresql_test.go
+++ b/pkg/controller/webhooks/postgresql_test.go
@@ -2,7 +2,6 @@ package webhooks
 
 import (
 	"context"
-	"k8s.io/apimachinery/pkg/util/validation/field"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -498,170 +497,171 @@ func TestPostgreSQLWebhookHandler_ValidateDelete(t *testing.T) {
 
 }
 
-func TestPostgreSQLWebhookHandler_ValidateMajorVersionUpgrade(t *testing.T) {
-	tests := []struct {
-		name          string
-		new           *vshnv1.VSHNPostgreSQL
-		old           *vshnv1.VSHNPostgreSQL
-		expectErrList field.ErrorList
-	}{
-		{
-			name: "GivenSameMajorVersion_ThenNoError",
-			new: &vshnv1.VSHNPostgreSQL{
-				Spec: vshnv1.VSHNPostgreSQLSpec{
-					Parameters: vshnv1.VSHNPostgreSQLParameters{
-						Service: vshnv1.VSHNPostgreSQLServiceSpec{
-							MajorVersion: "15",
-						},
-					},
-				},
-				Status: vshnv1.VSHNPostgreSQLStatus{
-					CurrentVersion: "15",
-				},
-			},
-			old: &vshnv1.VSHNPostgreSQL{
-				Spec: vshnv1.VSHNPostgreSQLSpec{
-					Parameters: vshnv1.VSHNPostgreSQLParameters{
-						Service: vshnv1.VSHNPostgreSQLServiceSpec{
-							MajorVersion: "15",
-						},
-					},
-				},
-				Status: vshnv1.VSHNPostgreSQLStatus{
-					CurrentVersion: "15",
-				},
-			},
-			expectErrList: nil,
-		},
-		{
-			name: "GivenOneMajorVersionUpdate_ThenNoError",
-			new: &vshnv1.VSHNPostgreSQL{
-				Spec: vshnv1.VSHNPostgreSQLSpec{
-					Parameters: vshnv1.VSHNPostgreSQLParameters{
-						Service: vshnv1.VSHNPostgreSQLServiceSpec{
-							MajorVersion: "16",
-						},
-					},
-				},
-				Status: vshnv1.VSHNPostgreSQLStatus{
-					CurrentVersion: "15",
-				},
-			},
-			old: &vshnv1.VSHNPostgreSQL{
-				Spec: vshnv1.VSHNPostgreSQLSpec{
-					Parameters: vshnv1.VSHNPostgreSQLParameters{
-						Service: vshnv1.VSHNPostgreSQLServiceSpec{
-							MajorVersion: "15",
-						},
-					},
-				},
-				Status: vshnv1.VSHNPostgreSQLStatus{
-					CurrentVersion: "15",
-				},
-			},
-			expectErrList: nil,
-		},
-		{
-			name: "GivenTwoMajorVersionsUpdate_ThenError",
-			new: &vshnv1.VSHNPostgreSQL{
-				Spec: vshnv1.VSHNPostgreSQLSpec{
-					Parameters: vshnv1.VSHNPostgreSQLParameters{
-						Service: vshnv1.VSHNPostgreSQLServiceSpec{
-							MajorVersion: "17",
-						},
-					},
-				},
-				Status: vshnv1.VSHNPostgreSQLStatus{
-					CurrentVersion: "15",
-				},
-			},
-			old: &vshnv1.VSHNPostgreSQL{
-				Spec: vshnv1.VSHNPostgreSQLSpec{
-					Parameters: vshnv1.VSHNPostgreSQLParameters{
-						Service: vshnv1.VSHNPostgreSQLServiceSpec{
-							MajorVersion: "15",
-						},
-					},
-				},
-				Status: vshnv1.VSHNPostgreSQLStatus{
-					CurrentVersion: "15",
-				},
-			},
-			expectErrList: field.ErrorList{
-				field.Forbidden(
-					field.NewPath("spec.parameters.service.majorVersion"),
-					"only one major version upgrade at a time is allowed",
-				),
-			},
-		},
-		{
-			name: "GivenOneMajorVersionsBehind_ThenError",
-			new: &vshnv1.VSHNPostgreSQL{
-				Spec: vshnv1.VSHNPostgreSQLSpec{
-					Parameters: vshnv1.VSHNPostgreSQLParameters{
-						Service: vshnv1.VSHNPostgreSQLServiceSpec{
-							MajorVersion: "14",
-						},
-					},
-				},
-				Status: vshnv1.VSHNPostgreSQLStatus{
-					CurrentVersion: "15",
-				},
-			},
-			old: &vshnv1.VSHNPostgreSQL{
-				Spec: vshnv1.VSHNPostgreSQLSpec{
-					Parameters: vshnv1.VSHNPostgreSQLParameters{
-						Service: vshnv1.VSHNPostgreSQLServiceSpec{
-							MajorVersion: "15",
-						},
-					},
-				},
-				Status: vshnv1.VSHNPostgreSQLStatus{
-					CurrentVersion: "15",
-				},
-			},
-			expectErrList: field.ErrorList{
-				field.Forbidden(
-					field.NewPath("spec.parameters.service.majorVersion"),
-					"only one major version upgrade at a time is allowed",
-				),
-			},
-		},
-		{
-			name: "GivenNonHA_ThenNoError",
-			new: &vshnv1.VSHNPostgreSQL{
-				Spec: vshnv1.VSHNPostgreSQLSpec{
-					Parameters: vshnv1.VSHNPostgreSQLParameters{
-						Instances: 1,
-						Service: vshnv1.VSHNPostgreSQLServiceSpec{
-							MajorVersion: "16",
-						},
-					},
-				},
-				Status: vshnv1.VSHNPostgreSQLStatus{
-					CurrentVersion: "15",
-				},
-			},
-			old: &vshnv1.VSHNPostgreSQL{
-				Spec: vshnv1.VSHNPostgreSQLSpec{
-					Parameters: vshnv1.VSHNPostgreSQLParameters{
-						Instances: 1,
-						Service: vshnv1.VSHNPostgreSQLServiceSpec{
-							MajorVersion: "15",
-						},
-					},
-				},
-				Status: vshnv1.VSHNPostgreSQLStatus{
-					CurrentVersion: "15",
-				},
-			},
-			expectErrList: nil,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := validateMajorVersionUpgrade(tt.new, tt.old)
-			assert.Equal(t, tt.expectErrList, err)
-		})
-	}
-}
+// disabling this temporarily
+// func TestPostgreSQLWebhookHandler_ValidateMajorVersionUpgrade(t *testing.T) {
+// 	tests := []struct {
+// 		name          string
+// 		new           *vshnv1.VSHNPostgreSQL
+// 		old           *vshnv1.VSHNPostgreSQL
+// 		expectErrList field.ErrorList
+// 	}{
+// 		{
+// 			name: "GivenSameMajorVersion_ThenNoError",
+// 			new: &vshnv1.VSHNPostgreSQL{
+// 				Spec: vshnv1.VSHNPostgreSQLSpec{
+// 					Parameters: vshnv1.VSHNPostgreSQLParameters{
+// 						Service: vshnv1.VSHNPostgreSQLServiceSpec{
+// 							MajorVersion: "15",
+// 						},
+// 					},
+// 				},
+// 				Status: vshnv1.VSHNPostgreSQLStatus{
+// 					CurrentVersion: "15",
+// 				},
+// 			},
+// 			old: &vshnv1.VSHNPostgreSQL{
+// 				Spec: vshnv1.VSHNPostgreSQLSpec{
+// 					Parameters: vshnv1.VSHNPostgreSQLParameters{
+// 						Service: vshnv1.VSHNPostgreSQLServiceSpec{
+// 							MajorVersion: "15",
+// 						},
+// 					},
+// 				},
+// 				Status: vshnv1.VSHNPostgreSQLStatus{
+// 					CurrentVersion: "15",
+// 				},
+// 			},
+// 			expectErrList: nil,
+// 		},
+// 		{
+// 			name: "GivenOneMajorVersionUpdate_ThenNoError",
+// 			new: &vshnv1.VSHNPostgreSQL{
+// 				Spec: vshnv1.VSHNPostgreSQLSpec{
+// 					Parameters: vshnv1.VSHNPostgreSQLParameters{
+// 						Service: vshnv1.VSHNPostgreSQLServiceSpec{
+// 							MajorVersion: "16",
+// 						},
+// 					},
+// 				},
+// 				Status: vshnv1.VSHNPostgreSQLStatus{
+// 					CurrentVersion: "15",
+// 				},
+// 			},
+// 			old: &vshnv1.VSHNPostgreSQL{
+// 				Spec: vshnv1.VSHNPostgreSQLSpec{
+// 					Parameters: vshnv1.VSHNPostgreSQLParameters{
+// 						Service: vshnv1.VSHNPostgreSQLServiceSpec{
+// 							MajorVersion: "15",
+// 						},
+// 					},
+// 				},
+// 				Status: vshnv1.VSHNPostgreSQLStatus{
+// 					CurrentVersion: "15",
+// 				},
+// 			},
+// 			expectErrList: nil,
+// 		},
+// 		{
+// 			name: "GivenTwoMajorVersionsUpdate_ThenError",
+// 			new: &vshnv1.VSHNPostgreSQL{
+// 				Spec: vshnv1.VSHNPostgreSQLSpec{
+// 					Parameters: vshnv1.VSHNPostgreSQLParameters{
+// 						Service: vshnv1.VSHNPostgreSQLServiceSpec{
+// 							MajorVersion: "17",
+// 						},
+// 					},
+// 				},
+// 				Status: vshnv1.VSHNPostgreSQLStatus{
+// 					CurrentVersion: "15",
+// 				},
+// 			},
+// 			old: &vshnv1.VSHNPostgreSQL{
+// 				Spec: vshnv1.VSHNPostgreSQLSpec{
+// 					Parameters: vshnv1.VSHNPostgreSQLParameters{
+// 						Service: vshnv1.VSHNPostgreSQLServiceSpec{
+// 							MajorVersion: "15",
+// 						},
+// 					},
+// 				},
+// 				Status: vshnv1.VSHNPostgreSQLStatus{
+// 					CurrentVersion: "15",
+// 				},
+// 			},
+// 			expectErrList: field.ErrorList{
+// 				field.Forbidden(
+// 					field.NewPath("spec.parameters.service.majorVersion"),
+// 					"only one major version upgrade at a time is allowed",
+// 				),
+// 			},
+// 		},
+// 		{
+// 			name: "GivenOneMajorVersionsBehind_ThenError",
+// 			new: &vshnv1.VSHNPostgreSQL{
+// 				Spec: vshnv1.VSHNPostgreSQLSpec{
+// 					Parameters: vshnv1.VSHNPostgreSQLParameters{
+// 						Service: vshnv1.VSHNPostgreSQLServiceSpec{
+// 							MajorVersion: "14",
+// 						},
+// 					},
+// 				},
+// 				Status: vshnv1.VSHNPostgreSQLStatus{
+// 					CurrentVersion: "15",
+// 				},
+// 			},
+// 			old: &vshnv1.VSHNPostgreSQL{
+// 				Spec: vshnv1.VSHNPostgreSQLSpec{
+// 					Parameters: vshnv1.VSHNPostgreSQLParameters{
+// 						Service: vshnv1.VSHNPostgreSQLServiceSpec{
+// 							MajorVersion: "15",
+// 						},
+// 					},
+// 				},
+// 				Status: vshnv1.VSHNPostgreSQLStatus{
+// 					CurrentVersion: "15",
+// 				},
+// 			},
+// 			expectErrList: field.ErrorList{
+// 				field.Forbidden(
+// 					field.NewPath("spec.parameters.service.majorVersion"),
+// 					"only one major version upgrade at a time is allowed",
+// 				),
+// 			},
+// 		},
+// 		{
+// 			name: "GivenNonHA_ThenNoError",
+// 			new: &vshnv1.VSHNPostgreSQL{
+// 				Spec: vshnv1.VSHNPostgreSQLSpec{
+// 					Parameters: vshnv1.VSHNPostgreSQLParameters{
+// 						Instances: 1,
+// 						Service: vshnv1.VSHNPostgreSQLServiceSpec{
+// 							MajorVersion: "16",
+// 						},
+// 					},
+// 				},
+// 				Status: vshnv1.VSHNPostgreSQLStatus{
+// 					CurrentVersion: "15",
+// 				},
+// 			},
+// 			old: &vshnv1.VSHNPostgreSQL{
+// 				Spec: vshnv1.VSHNPostgreSQLSpec{
+// 					Parameters: vshnv1.VSHNPostgreSQLParameters{
+// 						Instances: 1,
+// 						Service: vshnv1.VSHNPostgreSQLServiceSpec{
+// 							MajorVersion: "15",
+// 						},
+// 					},
+// 				},
+// 				Status: vshnv1.VSHNPostgreSQLStatus{
+// 					CurrentVersion: "15",
+// 				},
+// 			},
+// 			expectErrList: nil,
+// 		},
+// 	}
+// 	for _, tt := range tests {
+// 		t.Run(tt.name, func(t *testing.T) {
+// 			err := validateMajorVersionUpgrade(tt.new, tt.old)
+// 			assert.Equal(t, tt.expectErrList, err)
+// 		})
+// 	}
+// }


### PR DESCRIPTION
## Summary

* We need to disable MajorVersion Upgrade feature, as it's not yet production ready

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [x] Link this PR to related issues.

