### PR TITLE
Forgejo/Codey: Set compute resources according to plans

### DIFF
--- a/pkg/comp-functions/functions/vshnforgejo/deploy.go
+++ b/pkg/comp-functions/functions/vshnforgejo/deploy.go
@@ -201,10 +201,14 @@ func addForgejo(ctx context.Context, svc *runtime.ServiceRuntime, comp *vshnv1.V
 	svc.Log.Info("Got plan", "plan", plan)
 
 	// If this is a codey abstraction, we need to refer to codey plans
-	svc.Log.Info("This comps annotations", "annotations", comp.Annotations)
 	if comp.Annotations["metadata.appcat.vshn.io/abstraction"] == "codey" {
-		svc.Log.Info("This is a codey abstraction, using codey plans")
-		svc.Config.Data["plans"] = comp.Annotations["metadata.appcat.vshn.io/codeyplans"]
+		v, ok := comp.Annotations["metadata.appcat.vshn.io/codeyplans"]
+		if !ok {
+			return fmt.Errorf("this is a codey abstraction but has no codey plans")
+		}
+
+		svc.Log.Info("This is a codey abstraction, using codey plans", "codeyplans", v)
+		svc.Config.Data["plans"] = v
 	}
 
 	resources, err := utils.FetchPlansFromConfig(ctx, svc, plan)

--- a/pkg/comp-functions/functions/vshnforgejo/deploy.go
+++ b/pkg/comp-functions/functions/vshnforgejo/deploy.go
@@ -189,6 +189,18 @@ func addForgejo(ctx context.Context, svc *runtime.ServiceRuntime, comp *vshnv1.V
 		}
 	}
 
+	// Storage size
+	size := comp.Spec.Parameters.Size.Disk
+	if size != "" {
+		if err := common.SetNestedObjectValue(
+			values,
+			[]string{"persistence", "size"},
+			size,
+		); err != nil {
+			return err
+		}
+	}
+
 	appName := comp.Spec.Parameters.Service.ForgejoSettings.AppName
 	if appName != "" {
 		common.SetNestedObjectValue(values, []string{"gitea", "config", "APP_NAME"}, appName)

--- a/pkg/comp-functions/functions/vshnforgejo/deploy.go
+++ b/pkg/comp-functions/functions/vshnforgejo/deploy.go
@@ -200,10 +200,18 @@ func addForgejo(ctx context.Context, svc *runtime.ServiceRuntime, comp *vshnv1.V
 	plan := comp.Spec.Parameters.Size.GetPlan(svc.Config.Data["defaultPlan"])
 	svc.Log.Info("Got plan", "plan", plan)
 
+	// If this is a codey abstraction, we need to refer to codey plans
+	svc.Log.Info("This comps annotations", "annotations", comp.Annotations)
+	if comp.Annotations["metadata.appcat.vshn.io/abstraction"] == "codey" {
+		svc.Log.Info("This is a codey abstraction, using codey plans")
+		svc.Config.Data["plans"] = comp.Annotations["metadata.appcat.vshn.io/codeyplans"]
+	}
+
 	resources, err := utils.FetchPlansFromConfig(ctx, svc, plan)
 	if err != nil {
 		return fmt.Errorf("cannot fetch plans from config: %w", err)
 	}
+	svc.Log.Info("Got resources from config", "resources", resources)
 
 	res, errs := common.GetResources(&comp.Spec.Parameters.Size, resources)
 	if len(errs) > 0 {

--- a/pkg/comp-functions/functions/vshnforgejo/deploy.go
+++ b/pkg/comp-functions/functions/vshnforgejo/deploy.go
@@ -184,7 +184,8 @@ func addForgejo(ctx context.Context, svc *runtime.ServiceRuntime, comp *vshnv1.V
 		},
 		// This will be overwritten by setResources() later
 		"resources": map[string]any{
-			"limits": map[string]any{},
+			"limits":   map[string]any{},
+			"requests": map[string]any{},
 		},
 	}
 
@@ -298,10 +299,18 @@ func setResources(values map[string]any, resources common.Resources) error {
 	if err != nil {
 		return fmt.Errorf("cannot set cpu limits: %w", err)
 	}
+	err = common.SetNestedObjectValue(values, []string{"resources", "requests", "cpu"}, resources.ReqCPU.String())
+	if err != nil {
+		return fmt.Errorf("cannot set cpu requests: %w", err)
+	}
 
 	err = common.SetNestedObjectValue(values, []string{"resources", "limits", "memory"}, resources.Mem.String())
 	if err != nil {
 		return fmt.Errorf("cannot set memory limits: %w", err)
+	}
+	err = common.SetNestedObjectValue(values, []string{"resources", "requests", "memory"}, resources.ReqMem.String())
+	if err != nil {
+		return fmt.Errorf("cannot set memory requests: %w", err)
 	}
 
 	err = common.SetNestedObjectValue(values, []string{"persistence", "size"}, resources.Disk.String())

--- a/pkg/comp-functions/functions/vshnforgejo/deploy.go
+++ b/pkg/comp-functions/functions/vshnforgejo/deploy.go
@@ -3,11 +3,13 @@ package vshnforgejo
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
 	xfnproto "github.com/crossplane/function-sdk-go/proto/v1"
 	vshnv1 "github.com/vshn/appcat/v4/apis/vshn/v1"
+	"github.com/vshn/appcat/v4/pkg/common/utils"
 	"github.com/vshn/appcat/v4/pkg/comp-functions/functions/common"
 	"github.com/vshn/appcat/v4/pkg/comp-functions/functions/common/maintenance"
 	"github.com/vshn/appcat/v4/pkg/comp-functions/runtime"
@@ -180,6 +182,11 @@ func addForgejo(ctx context.Context, svc *runtime.ServiceRuntime, comp *vshnv1.V
 		"strategy": map[string]any{
 			"type": "Recreate",
 		},
+		// This will be overwritten by setResources() later
+		"resources": map[string]any{
+			"requests": map[string]any{},
+			"limits":   map[string]any{},
+		},
 	}
 
 	if svc.Config.Data["imageRegistry"] == "" {
@@ -189,18 +196,35 @@ func addForgejo(ctx context.Context, svc *runtime.ServiceRuntime, comp *vshnv1.V
 		}
 	}
 
-	// Storage size
-	size := comp.Spec.Parameters.Size.Disk
-	if size != "" {
-		if err := common.SetNestedObjectValue(
-			values,
-			[]string{"persistence", "size"},
-			size,
-		); err != nil {
-			return err
-		}
+	// Resources
+	plan := comp.Spec.Parameters.Size.GetPlan(svc.Config.Data["defaultPlan"])
+
+	// Debug
+	o, _ := json.Marshal(plan)
+	fmt.Printf("Got plan: %s\n", string(o))
+
+	resources, err := utils.FetchPlansFromConfig(ctx, svc, plan)
+	if err != nil {
+		return fmt.Errorf("cannot fetch plans from config: %w", err)
 	}
 
+	o, _ = json.Marshal(resources)
+	fmt.Printf("Got resources: %s\n", string(o))
+
+	res, errs := common.GetResources(&comp.Spec.Parameters.Size, resources)
+	if len(errs) > 0 {
+		svc.Log.Error(fmt.Errorf("could not get resources"), "errors", errors.Join(errs...))
+	}
+
+	o, _ = json.Marshal(res)
+	fmt.Printf("Got res: %s\n", string(o))
+
+	err = setResources(values, res)
+	if err != nil {
+		return fmt.Errorf("cannot set resources: %w", err)
+	}
+
+	// App name
 	appName := comp.Spec.Parameters.Service.ForgejoSettings.AppName
 	if appName != "" {
 		common.SetNestedObjectValue(values, []string{"gitea", "config", "APP_NAME"}, appName)
@@ -208,7 +232,7 @@ func addForgejo(ctx context.Context, svc *runtime.ServiceRuntime, comp *vshnv1.V
 
 	// Automagically inject the entirety of VSHNForgejoConfig into values
 	var objmap map[string]any
-	o, err := json.Marshal(comp.Spec.Parameters.Service.ForgejoSettings.Config)
+	o, err = json.Marshal(comp.Spec.Parameters.Service.ForgejoSettings.Config)
 	if err != nil {
 		return err
 	}
@@ -220,6 +244,7 @@ func addForgejo(ctx context.Context, svc *runtime.ServiceRuntime, comp *vshnv1.V
 		}
 	}
 
+	// Ingress
 	svcNameSuffix := "http"
 	if !strings.Contains(comp.GetName(), "forgejo") {
 		svcNameSuffix = "forgejo-" + svcNameSuffix
@@ -272,4 +297,24 @@ func addForgejo(ctx context.Context, svc *runtime.ServiceRuntime, comp *vshnv1.V
 	}
 
 	return svc.SetDesiredComposedResource(release)
+}
+
+// Set compute resources in the values map
+func setResources(values map[string]any, resources common.Resources) error {
+	err := common.SetNestedObjectValue(values, []string{"resources", "limits", "cpu"}, resources.CPU.String())
+	if err != nil {
+		return fmt.Errorf("cannot set cpu limits: %w", err)
+	}
+
+	err = common.SetNestedObjectValue(values, []string{"resources", "limits", "memory"}, resources.Mem.String())
+	if err != nil {
+		return fmt.Errorf("cannot set memory limits: %w", err)
+	}
+
+	err = common.SetNestedObjectValue(values, []string{"persistence", "size"}, resources.Disk.String())
+	if err != nil {
+		return fmt.Errorf("cannot set disk size: %w", err)
+	}
+
+	return nil
 }

--- a/pkg/comp-functions/functions/vshnforgejo/deploy_test.go
+++ b/pkg/comp-functions/functions/vshnforgejo/deploy_test.go
@@ -108,9 +108,6 @@ func getReleaseValues(t *testing.T, release xhelmv1.Release) map[string]any {
 func bootstrapTest(t *testing.T) (*runtime.ServiceRuntime, *vshnv1.VSHNForgejo, string) {
 	svc := commontest.LoadRuntimeFromFile(t, "vshnforgejo/01_default.yaml")
 
-	o, _ := json.MarshalIndent(svc.Config, "", "  ")
-	t.Logf("Loaded config: %s", o)
-
 	comp := &vshnv1.VSHNForgejo{}
 	err := svc.GetObservedComposite(comp)
 	assert.NoError(t, err)

--- a/pkg/comp-functions/functions/vshnforgejo/deploy_test.go
+++ b/pkg/comp-functions/functions/vshnforgejo/deploy_test.go
@@ -48,6 +48,20 @@ func TestDeployment(t *testing.T) {
 		values := getReleaseValues(t, *release)
 		assert.Equal(t, appName, values["gitea"].(map[string]any)["config"].(map[string]any)["APP_NAME"])
 	})
+
+	t.Run("Ensure_DiskSizeCanBeSet", func(t *testing.T) {
+		const diskSize = "15Gi"
+
+		svc, comp, secretName := bootstrapTest(t)
+		comp.Spec.Parameters.Size.Disk = diskSize
+		assert.NoError(t, addForgejo(context.TODO(), svc, comp, secretName))
+
+		release := &xhelmv1.Release{}
+		assert.NoError(t, svc.GetDesiredComposedResourceByName(release, comp.GetName()))
+
+		values := getReleaseValues(t, *release)
+		assert.Equal(t, diskSize, values["persistence"].(map[string]any)["size"])
+	})
 }
 
 func getReleaseValues(t *testing.T, release xhelmv1.Release) map[string]any {

--- a/pkg/comp-functions/functions/vshnforgejo/deploy_test.go
+++ b/pkg/comp-functions/functions/vshnforgejo/deploy_test.go
@@ -49,7 +49,7 @@ func TestDeployment(t *testing.T) {
 		assert.Equal(t, appName, values["gitea"].(map[string]any)["config"].(map[string]any)["APP_NAME"])
 	})
 
-	t.Run("GivenPlan_ExpectAppropriateResources", func(t *testing.T) {
+	t.Run("GivenPlan_ExpectPlanResources", func(t *testing.T) {
 		const (
 			plan = "small"
 			cpu  = "1"
@@ -65,8 +65,34 @@ func TestDeployment(t *testing.T) {
 		assert.NoError(t, svc.GetDesiredComposedResourceByName(release, comp.GetName()))
 
 		values := getReleaseValues(t, *release)
+		// We explect plan resources
 		assert.Equal(t, cpu, values["resources"].(map[string]any)["limits"].(map[string]any)["cpu"])
 		assert.Equal(t, mem, values["resources"].(map[string]any)["limits"].(map[string]any)["memory"])
+		assert.Equal(t, disk, values["persistence"].(map[string]any)["size"])
+	})
+
+	t.Run("GivenPlanAndExplicitSizeObj_ExpectSizeObjValues", func(t *testing.T) {
+		const (
+			plan   = "large"
+			cpu    = "2"
+			memory = "1337Gi"
+			disk   = "123Gi"
+		)
+
+		svc, comp, secretName := bootstrapTest(t)
+		svc.Config.Data["defaultPlan"] = plan
+		comp.Spec.Parameters.Size.CPU = cpu
+		comp.Spec.Parameters.Size.Memory = memory
+		comp.Spec.Parameters.Size.Disk = disk
+		assert.NoError(t, addForgejo(context.TODO(), svc, comp, secretName))
+
+		release := &xhelmv1.Release{}
+		assert.NoError(t, svc.GetDesiredComposedResourceByName(release, comp.GetName()))
+
+		values := getReleaseValues(t, *release)
+		// We expect our own values instead of plan values
+		assert.Equal(t, cpu, values["resources"].(map[string]any)["limits"].(map[string]any)["cpu"])
+		assert.Equal(t, memory, values["resources"].(map[string]any)["limits"].(map[string]any)["memory"])
 		assert.Equal(t, disk, values["persistence"].(map[string]any)["size"])
 	})
 }

--- a/pkg/controller/webhooks/codey.go
+++ b/pkg/controller/webhooks/codey.go
@@ -2,7 +2,6 @@ package webhooks
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -124,10 +123,6 @@ func isCodeyFqdnUnique(fqdn, compositeName string, cl client.Client) error {
 	if err != nil {
 		return fmt.Errorf("failed listing ingresses: %v", err)
 	}
-
-	// Debug
-	o, _ := json.MarshalIndent(ingressList, "", "  ")
-	fmt.Printf("IngressList: %s\n", string(o))
 
 	for _, ingress := range ingressList.Items {
 		// Additional filtering to check if the Ingress is actually an ACME solver

--- a/pkg/controller/webhooks/codey.go
+++ b/pkg/controller/webhooks/codey.go
@@ -130,6 +130,11 @@ func isCodeyFqdnUnique(fqdn, compositeName string, cl client.Client) error {
 	fmt.Printf("IngressList: %s\n", string(o))
 
 	for _, ingress := range ingressList.Items {
+		// Additional filtering to check if the Ingress is actually an ACME solver
+		if _, exists := ingress.Labels["acme.cert-manager.io/http01-solver"]; exists {
+			continue
+		}
+
 		for _, rule := range ingress.Spec.Rules {
 			if rule.Host == fqdn {
 				return field.Invalid(

--- a/pkg/controller/webhooks/codey.go
+++ b/pkg/controller/webhooks/codey.go
@@ -2,6 +2,7 @@ package webhooks
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -123,6 +124,10 @@ func isCodeyFqdnUnique(fqdn, compositeName string, cl client.Client) error {
 	if err != nil {
 		return fmt.Errorf("failed listing ingresses: %v", err)
 	}
+
+	// Debug
+	o, _ := json.MarshalIndent(ingressList, "", "  ")
+	fmt.Printf("IngressList: %s\n", string(o))
 
 	for _, ingress := range ingressList.Items {
 		for _, rule := range ingress.Spec.Rules {

--- a/pkg/controller/webhooks/forgejo.go
+++ b/pkg/controller/webhooks/forgejo.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	vshnv1 "github.com/vshn/appcat/v4/apis/vshn/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -71,10 +70,6 @@ func (n *ForgejoWebhookHandler) ValidateCreate(ctx context.Context, obj runtime.
 		return nil, err
 	}
 
-	if _, err := resource.ParseQuantity(forgejo.Spec.Parameters.Size.Disk); err != nil {
-		return nil, err
-	}
-
 	if err := validateForgejoConfig(forgejo.Spec.Parameters.Service.ForgejoSettings); err != nil {
 		return nil, err
 	}
@@ -94,10 +89,6 @@ func (p *ForgejoWebhookHandler) ValidateUpdate(ctx context.Context, oldObj, newO
 	}
 
 	if err := validateFQDNs(newForgejo.Spec.Parameters.Service.FQDN); err != nil {
-		return nil, err
-	}
-
-	if _, err := resource.ParseQuantity(newForgejo.Spec.Parameters.Size.Disk); err != nil {
 		return nil, err
 	}
 

--- a/pkg/controller/webhooks/forgejo.go
+++ b/pkg/controller/webhooks/forgejo.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	vshnv1 "github.com/vshn/appcat/v4/apis/vshn/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -70,6 +71,10 @@ func (n *ForgejoWebhookHandler) ValidateCreate(ctx context.Context, obj runtime.
 		return nil, err
 	}
 
+	if _, err := resource.ParseQuantity(forgejo.Spec.Parameters.Size.Disk); err != nil {
+		return nil, err
+	}
+
 	if err := validateForgejoConfig(forgejo.Spec.Parameters.Service.ForgejoSettings); err != nil {
 		return nil, err
 	}
@@ -89,6 +94,10 @@ func (p *ForgejoWebhookHandler) ValidateUpdate(ctx context.Context, oldObj, newO
 	}
 
 	if err := validateFQDNs(newForgejo.Spec.Parameters.Service.FQDN); err != nil {
+		return nil, err
+	}
+
+	if _, err := resource.ParseQuantity(newForgejo.Spec.Parameters.Size.Disk); err != nil {
 		return nil, err
 	}
 

--- a/test/functions/vshnforgejo/01_default.yaml
+++ b/test/functions/vshnforgejo/01_default.yaml
@@ -8,12 +8,10 @@ input:
       name: xfn-config
     name: xfn-config
   data:
-    defaultPlan: standard-2
+    defaultPlan: mini
     controlNamespace: appcat-control
-    plans: '{"standard-2": {"size": {"cpu": "500m", "disk": "16Gi", "enabled":
-            true, "memory": "2Gi"}}, "standard-4": {"size": {"cpu": "1", "disk": "16Gi",
-            "enabled": true, "memory": "4Gi"}}, "standard-8": {"size": {"cpu": "2",
-            "disk": "16Gi", "enabled": true, "memory": "8Gi"}}}'
+    plans: |
+      {"large": {"size": {"cpu": "4", "disk": "500Gi", "enabled": true, "memory": "16Gi"}}, "medium": {"size": {"cpu": "2", "disk": "200Gi", "enabled": true, "memory": "8Gi"}}, "mini": {"size": {"cpu": "500m", "disk": "10Gi", "enabled": true, "memory": "2Gi"}}, "small": {"size": {"cpu": "1", "disk": "50Gi", "enabled": true, "memory": "4Gi"}}}
 observed:
   composite:
     resource:


### PR DESCRIPTION
## Summary

* Forgejo and Codey instances will now use compute resources according to their selected plans (CPU, Memory limits and PVC size).  
* Fix a bug in the webhooks Codey FQDN check logic where the (temporary) ACME solver ingress was triggering false positives.
  * The ACME solver ingress uses the same hostname as the wildcard/let's encrypt ingress.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
