### PR TITLE
Helm Chart updates May 2025

### DIFF
--- a/apis/vshn/v1/dbaas_vshn_redis.go
+++ b/apis/vshn/v1/dbaas_vshn_redis.go
@@ -81,8 +81,8 @@ type VSHNRedisParameters struct {
 
 // VSHNRedisServiceSpec contains Redis DBaaS specific properties
 type VSHNRedisServiceSpec struct {
-	// +kubebuilder:validation:Enum="6.2";"7.0"
-	// +kubebuilder:default="7.0"
+	// +kubebuilder:validation:Enum="7.0";"7.2";"8.0"
+	// +kubebuilder:default="7.2"
 
 	// Version contains supported version of Redis.
 	// Multiple versions are supported. The latest version "7.0" is the default version.

--- a/crds/vshn.appcat.vshn.io_vshnredis.yaml
+++ b/crds/vshn.appcat.vshn.io_vshnredis.yaml
@@ -4606,13 +4606,14 @@ spec:
                             - guaranteed
                           type: string
                         version:
-                          default: "7.0"
+                          default: "7.2"
                           description: |-
                             Version contains supported version of Redis.
                             Multiple versions are supported. The latest version "7.0" is the default version.
                           enum:
-                            - "6.2"
                             - "7.0"
+                            - "7.2"
+                            - "8.0"
                           type: string
                       type: object
                       default: {}

--- a/crds/vshn.appcat.vshn.io_xvshnredis.yaml
+++ b/crds/vshn.appcat.vshn.io_xvshnredis.yaml
@@ -5331,13 +5331,14 @@ spec:
                         - guaranteed
                         type: string
                       version:
-                        default: "7.0"
+                        default: "7.2"
                         description: |-
                           Version contains supported version of Redis.
                           Multiple versions are supported. The latest version "7.0" is the default version.
                         enum:
-                        - "6.2"
                         - "7.0"
+                        - "7.2"
+                        - "8.0"
                         type: string
                     type: object
                   size:

--- a/pkg/comp-functions/functions/vshnkeycloak/deploy.go
+++ b/pkg/comp-functions/functions/vshnkeycloak/deploy.go
@@ -378,18 +378,8 @@ func newValues(ctx context.Context, svc *runtime.ServiceRuntime, comp *vshnv1.VS
 		"livenessProbe":  "{\"httpGet\": {\"path\": \"/health/live\", \"port\": \"http-internal\", \"scheme\": \"HTTPS\"}, \"initialDelaySeconds\": 0, \"timeoutSeconds\": 5}",
 		"readinessProbe": "{\"httpGet\": {\"path\": \"/health/ready\", \"port\": \"http-internal\", \"scheme\": \"HTTPS\"}, \"initialDelaySeconds\": 10, \"timeoutSeconds\": 1}",
 		"startupProbe":   "{\"httpGet\": {\"path\": \"/health\", \"port\": \"http-internal\", \"scheme\": \"HTTPS\"}, \"initialDelaySeconds\": 15, \"timeoutSeconds\": 1, \"failureThreshold\": 60, \"periodSeconds\": 5}",
-		"service": map[string]any{
-			"extraPorts": []map[string]any{
-				{
-					"name":       "http-internal",
-					"port":       9000,
-					"targetPort": 9000,
-				},
-			},
-		},
 		"http": map[string]any{
 			"relativePath": comp.Spec.Parameters.Service.RelativePath,
-			//	"internalPort": "http-internal",
 		},
 		"podSecurityContext": nil,
 		"podAnnotations":     podAnnotations,

--- a/pkg/comp-functions/functions/vshnmariadb/mariadb_deploy.go
+++ b/pkg/comp-functions/functions/vshnmariadb/mariadb_deploy.go
@@ -172,6 +172,13 @@ func newValues(ctx context.Context, svc *runtime.ServiceRuntime, comp *vshnv1.VS
 	}
 
 	values = map[string]interface{}{
+		// Otherwise we can't use our mirror
+		// https://github.com/bitnami/charts/issues/30850
+		"global": map[string]any{
+			"security": map[string]any{
+				"allowInsecureImages": true,
+			},
+		},
 		"existingSecret":   secretName,
 		"fullnameOverride": comp.GetName(),
 		"replicaCount":     comp.GetInstances(),
@@ -231,7 +238,6 @@ func newValues(ctx context.Context, svc *runtime.ServiceRuntime, comp *vshnv1.VS
 	}
 
 	if registry := svc.Config.Data["imageRegistry"]; registry != "" {
-		values["global"] = map[string]any{}
 		err := common.SetNestedObjectValue(values, []string{"global", "imageRegistry"}, registry)
 		if err != nil {
 			return nil, err

--- a/pkg/comp-functions/functions/vshnminio/minio_deploy.go
+++ b/pkg/comp-functions/functions/vshnminio/minio_deploy.go
@@ -117,6 +117,8 @@ func createObjectHelmRelease(ctx context.Context, comp *vshnv1.VSHNMinio, svc *r
 		"fullnameOverride": comp.GetName(),
 		"mode":             comp.Spec.Parameters.Service.Mode,
 		"replicas":         comp.Spec.Parameters.Instances,
+		// Disable creation of "console" user
+		"users": "",
 		"deploymentUpdate": map[string]interface{}{
 			"type": "Recreate",
 		},


### PR DESCRIPTION
## Summary

- With the latest version of the keycloak chart, the port definition isn't necessary anymore, as it's already in the chart and will generate a duplicate error while applying.
- The latest Redis chart seems to work fine with older versions as well, so we will allow a broader selection of open source Redis versions

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
