### PR TITLE
Add missing roles for APIServer

### DIFF
--- a/config/apiserver/role.yaml
+++ b/config/apiserver/role.yaml
@@ -26,6 +26,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - admissionregistration.k8s.io
   resources:
   - mutatingwebhookconfigurations
@@ -57,6 +65,14 @@ rules:
   - k8up.io
   resources:
   - snapshots
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - kubernetes.crossplane.io
+  resources:
+  - providerconfigs
   verbs:
   - get
   - list

--- a/pkg/apiserver/appcat/appcat.go
+++ b/pkg/apiserver/appcat/appcat.go
@@ -19,6 +19,8 @@ import (
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch;create;delete;update
 // +kubebuilder:rbac:groups="authorization.k8s.io",resources=subjectaccessreviews,verbs=get;list;watch;create;delete;update
 // +kubebuilder:rbac:groups="apiextensions.crossplane.io",resources=compositions,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
+// +kubebuilder:rbac:groups="kubernetes.crossplane.io",resources=providerconfigs,verbs=get;list;watch
 
 // New returns a new storage provider for AppCat
 func New() restbuilder.ResourceHandlerProvider {

--- a/pkg/apiserver/vshn/mariadb/get.go
+++ b/pkg/apiserver/vshn/mariadb/get.go
@@ -31,7 +31,7 @@ func (v *vshnMariaDBBackupStorage) Get(ctx context.Context, name string, _ *meta
 	for _, instance := range instances.Items {
 		client, err := v.vshnMariaDB.GetKubeClient(ctx, &instance)
 		if err != nil {
-			return nil, fmt.Errorf("cannot get KubeClient from ProviderConfig")
+			return nil, fmt.Errorf("cannot get KubeClient from ProviderConfig: %w", err)
 		}
 		ins := instance.Status.InstanceNamespace
 		snap, err := v.snapshothandler.Get(ctx, name, ins, client)

--- a/pkg/apiserver/vshn/mariadb/list.go
+++ b/pkg/apiserver/vshn/mariadb/list.go
@@ -33,7 +33,7 @@ func (v *vshnMariaDBBackupStorage) List(ctx context.Context, _ *metainternalvers
 	for _, instance := range instances.Items {
 		client, err := v.vshnMariaDB.GetKubeClient(ctx, &instance)
 		if err != nil {
-			return nil, fmt.Errorf("cannot get KubeClient from ProviderConfig")
+			return nil, fmt.Errorf("cannot get KubeClient from ProviderConfig: %w", err)
 		}
 		snapshots, err := v.snapshothandler.List(ctx, instance.Status.InstanceNamespace, client)
 		if err != nil && !apierrors.IsNotFound(err) {

--- a/pkg/apiserver/vshn/nextcloud/get.go
+++ b/pkg/apiserver/vshn/nextcloud/get.go
@@ -32,7 +32,7 @@ func (v *vshnNextcloudBackupStorage) Get(ctx context.Context, name string, _ *me
 	for _, instance := range instances.Items {
 		client, err := v.vshnNextcloud.GetKubeClient(ctx, &instance)
 		if err != nil {
-			return nil, fmt.Errorf("cannot get KubeClient from ProviderConfig")
+			return nil, fmt.Errorf("cannot get KubeClient from ProviderConfig: %w", err)
 		}
 		ins := instance.Status.InstanceNamespace
 		snap, err := v.snapshothandler.Get(ctx, name, ins, client)

--- a/pkg/apiserver/vshn/nextcloud/list.go
+++ b/pkg/apiserver/vshn/nextcloud/list.go
@@ -39,7 +39,7 @@ func (v *vshnNextcloudBackupStorage) List(ctx context.Context, options *metainte
 	for _, instance := range instances.Items {
 		client, err := v.vshnNextcloud.GetKubeClient(ctx, &instance)
 		if err != nil {
-			return nil, fmt.Errorf("cannot get KubeClient from ProviderConfig")
+			return nil, fmt.Errorf("cannot get KubeClient from ProviderConfig: %w", err)
 		}
 		snapshots, err := v.snapshothandler.List(ctx, instance.Status.InstanceNamespace, client)
 		if err != nil && !apierrors.IsNotFound(err) {

--- a/pkg/apiserver/vshn/postgres/get.go
+++ b/pkg/apiserver/vshn/postgres/get.go
@@ -31,7 +31,7 @@ func (v *vshnPostgresBackupStorage) Get(ctx context.Context, name string, _ *met
 	for _, value := range instances.Items {
 		client, err := v.vshnpostgresql.GetDynKubeClient(ctx, &value)
 		if err != nil {
-			return nil, fmt.Errorf("cannot get KubeClient from ProviderConfig")
+			return nil, fmt.Errorf("cannot get KubeClient from ProviderConfig: %w", err)
 		}
 		backupInfo, err := v.sgbackups.GetSGBackup(ctx, name, value.Status.InstanceNamespace, client)
 		if err != nil {

--- a/pkg/apiserver/vshn/postgres/list.go
+++ b/pkg/apiserver/vshn/postgres/list.go
@@ -36,7 +36,7 @@ func (v *vshnPostgresBackupStorage) List(ctx context.Context, options *metainter
 	for _, value := range instances.Items {
 		client, err := v.vshnpostgresql.GetDynKubeClient(ctx, &value)
 		if err != nil {
-			return nil, fmt.Errorf("cannot get KubeClient from ProviderConfig")
+			return nil, fmt.Errorf("cannot get KubeClient from ProviderConfig: %w", err)
 		}
 		bis, err := v.sgbackups.ListSGBackup(ctx, value.Status.InstanceNamespace, client, options)
 		if err != nil {

--- a/pkg/apiserver/vshn/redis/get.go
+++ b/pkg/apiserver/vshn/redis/get.go
@@ -31,7 +31,7 @@ func (v *vshnRedisBackupStorage) Get(ctx context.Context, name string, opts *met
 	for _, instance := range instances.Items {
 		client, err := v.vshnRedis.GetKubeClient(ctx, &instance)
 		if err != nil {
-			return nil, fmt.Errorf("cannot get KubeClient from ProviderConfig")
+			return nil, fmt.Errorf("cannot get KubeClient from ProviderConfig: %w", err)
 		}
 		ins := instance.Status.InstanceNamespace
 		snap, err := v.snapshothandler.Get(ctx, name, ins, client)

--- a/pkg/apiserver/vshn/redis/list.go
+++ b/pkg/apiserver/vshn/redis/list.go
@@ -32,7 +32,7 @@ func (v *vshnRedisBackupStorage) List(ctx context.Context, options *metainternal
 	for _, instance := range instances.Items {
 		client, err := v.vshnRedis.GetKubeClient(ctx, &instance)
 		if err != nil {
-			return nil, fmt.Errorf("cannot get KubeClient from ProviderConfig")
+			return nil, fmt.Errorf("cannot get KubeClient from ProviderConfig: %w", err)
 		}
 		snapshots, err := v.snapshothandler.List(ctx, instance.Status.InstanceNamespace, client)
 		if err != nil && !apierrors.IsNotFound(err) {


### PR DESCRIPTION
## Summary

* The APIServer needs additional permissions to get the kubeconfig on
a non-converged setup. It needs to read providerconfigs.kubernetes as
well as secrets.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [ ] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
