### PR TITLE
reenabling Keycloak service monitors

### DIFF
--- a/pkg/comp-functions/functions/vshnkeycloak/deploy.go
+++ b/pkg/comp-functions/functions/vshnkeycloak/deploy.go
@@ -343,10 +343,10 @@ func newValues(ctx context.Context, svc *runtime.ServiceRuntime, comp *vshnv1.VS
 			"enabled": true,
 		},
 		"extraServiceMonitor": map[string]any{
-			"enabled": false,
+			"enabled": true,
 		},
 		"serviceMonitor": map[string]any{
-			"enabled": false,
+			"enabled": true,
 		},
 		"resources": map[string]any{
 			"requests": map[string]any{


### PR DESCRIPTION
## Summary

* For reasons I don't remember, we disabled Keycloak metrics, now they're required, so this change is reenabling monitors in helm values

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [x] Link this PR to related issues.

