### PR TITLE
Make AppCat realtime compatible

### DIFF
--- a/pkg/comp-functions/runtime/function_mgr.go
+++ b/pkg/comp-functions/runtime/function_mgr.go
@@ -438,6 +438,12 @@ func (s *ServiceRuntime) SetDesiredComposedResourceWithName(obj xpresource.Manag
 		return err
 	}
 
+	// We need to remove some fields to make realtime compositions work.
+	// CreationTimestamp is set to nil due to our marshalling, but this will cause the object to go into an endless loop
+	unstructured.RemoveNestedField(unstructuredObj.Object, "spec", "forProvider", "manifest", "metadata", "creationTimestamp")
+	// We need to remove the managedFields, because realtime compositions use server-side-apply
+	unstructured.RemoveNestedField(unstructuredObj.Object, "spec", "forProvider", "manifest", "metadata", "managedFields")
+
 	dr.Resource = unstructuredObj
 
 	s.desiredResources[resource.Name(name)] = dr


### PR DESCRIPTION
## Summary

Crossplane will soon make the realtime mode the default. See https://github.com/crossplane/crossplane/issues/6453

The way we serializse the `Object`s leaves a `creationDate: null` in the inner manifests.

However, this will cause a reconcile loop when the realtime mode is enabled. While not apparante there might also be a reduction in reconciles with Crossplane in poll mode.

In either case, the values that get removed by this commit are garbage and can cause issues down the line.


## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
