### PR TITLE
Fix wrong mailgun secret ref for patching secret

### DIFF
--- a/pkg/comp-functions/functions/common/mailgun_alerting.go
+++ b/pkg/comp-functions/functions/common/mailgun_alerting.go
@@ -116,9 +116,12 @@ func deployAlertmanagerConfig(ctx context.Context, name, email, instanceNamespac
 	patchSecretWithOtherSecret := xkube.Reference{
 		PatchesFrom: &xkube.PatchesFrom{
 			DependsOn: xkube.DependsOn{
-				Name: alertManagerConfigSecretName,
+				APIVersion: "v1",
+				Kind:       "Secret",
+				Namespace:  svc.Config.Data["emailAlertingSecretNamespace"],
+				Name:       svc.Config.Data["emailAlertingSecretName"],
 			},
-			FieldPath: ptr.To("status.atProvider.manifest.data.password"),
+			FieldPath: ptr.To("data.password"),
 		},
 		ToFieldPath: ptr.To("data.password"),
 	}


### PR DESCRIPTION
## Summary

* This PR fixes a bug we introduced by referencing the correct secret for the mailgun credentials.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [ ] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
