### PR TITLE
Fix backup scripts

### DIFF
--- a/pkg/comp-functions/functions/vshnmariadb/script/backup.sh
+++ b/pkg/comp-functions/functions/vshnmariadb/script/backup.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 
+MARIADB_ROOT_PASSWORD=$(cat "${MARIADB_ROOT_PASSWORD_FILE}")
+
 mariadb-backup --user=root --password="$MARIADB_ROOT_PASSWORD" --backup --stream=xbstream

--- a/pkg/comp-functions/functions/vshnredis/script/backup.sh
+++ b/pkg/comp-functions/functions/vshnredis/script/backup.sh
@@ -4,8 +4,10 @@
 # are no AOF rewritings happening at the time of backup. If there's a dump file
 # it will also backup that one.
 
+REDIS_PASSWORD=$(cat "${REDIS_PASSWORD_FILE}")
+
 redis_cmd() {
-  if [ -z "$REDIS_TLS_CERT_FILE" ]; then 
+  if [ -z "$REDIS_TLS_CERT_FILE" ]; then
     redis-cli -a "${REDIS_PASSWORD}" "$@"
   else
     redis-cli -a "${REDIS_PASSWORD}" --cacert "${REDIS_TLS_CA_FILE}" --cert "${REDIS_TLS_CERT_FILE}" --key "${REDIS_TLS_KEY_FILE}" --tls "$@"


### PR DESCRIPTION


## Summary

Looks like bitnami removed the `$SERVICE_PASSWORD` variables from their pods.

This breaks the backups for Redis and MariaDB as they depend on that. Passwords are now read from the `$SERVICE_PASSWORD_FILE` file.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
