### PR TITLE
Permanently disable Envoy

### DIFF
--- a/apis/stackgres/v1/sgcluster.gen.go
+++ b/apis/stackgres/v1/sgcluster.gen.go
@@ -399,6 +399,9 @@ type SGClusterSpecPods struct {
 	// If set to `true`, avoids creating the Prometheus exporter sidecar. Recommended when there's no intention to use Prometheus for monitoring.
 	DisableMetricsExporter *bool `json:"disableMetricsExporter,omitempty"`
 
+	// If set to `true`, avoids creating the envoy sidecar. This sidecar is used as the endge proxy for the cluster’s Pods providing extra metrics to the monitoring layer.
+	DisableEnvoy *bool `json:"disableEnvoy,omitempty"`
+
 	// If set to `true`, avoids creating the `postgres-util` sidecar. This sidecar contains usual Postgres administration utilities *that are not present in the main (`patroni`) container*, like `psql`. Only disable if you know what you are doing.
 	DisablePostgresUtil *bool `json:"disablePostgresUtil,omitempty"`
 

--- a/pkg/comp-functions/functions/vshnpostgres/postgresql_deploy.go
+++ b/pkg/comp-functions/functions/vshnpostgres/postgresql_deploy.go
@@ -453,6 +453,7 @@ func createSgCluster(ctx context.Context, comp *vshnv1.VSHNPostgreSQL, svc *runt
 					NodeSelector: nodeSelector,
 				},
 				DisableConnectionPooling: ptr.To(comp.Spec.Parameters.Service.DisablePgBouncer),
+				DisableEnvoy:             ptr.To(true),
 			},
 			NonProductionOptions: &sgv1.SGClusterSpecNonProductionOptions{
 				EnableSetPatroniCpuRequests:    ptr.To(true),


### PR DESCRIPTION


## Summary

As of StackGres 1.16.0 it's possible to disable Envoy.

It sits in the direct data path of PostgreSQL so the performance of the database is impacted by Envoy. However the only benefit that it brings is some additional connection metrics, which are not worth the additional resource usage and the performance impact.
## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
