### PR TITLE
Ensure to fetch whole git history

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -203,6 +203,7 @@ jobs:
           repository: ${{ env.COMPONENT_REPO }}
           token: ${{ secrets.COMPONENT_ACCESS_TOKEN }}
           ref: "${{ env.APP_NAME }}/${{ github.event.pull_request.number }}/${{ steps.extract_branch.outputs.branch }}"
+          fetch-depth: 0
 
       - name: Update tag and run golden
         run: |


### PR DESCRIPTION

## Summary

In order for the function version generation script to work as expected the whole git history has to be available.

By default the checkout action will only shallow fetch the repo. This change ensures that we always have the full history.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
