### PR TITLE
Fix 'open-pr-component' action

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -89,6 +89,7 @@ jobs:
         with:
           repository: ${{ env.COMPONENT_REPO }}
           token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
 
       - name: Extract branch name
         shell: bash


### PR DESCRIPTION
## Summary

When a new PR is opened in this repo, an equivalent PR in `component-appcat` cannot be created as the action `open-pr-component` fails:  
The checkout action is not fetching tags, which makes the `hack/getversions.sh` script [fail](https://github.com/vshn/appcat/actions/runs/15391133221/job/43364259083#step:5:93) as `git rev-list --tags` returns nothing.

This is basically the same as https://github.com/vshn/appcat/pull/367

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
