### PR TITLE
Fix wrong pitr configuration

### DIFF
--- a/pkg/comp-functions/functions/vshnpostgres/postgresql_deploy.go
+++ b/pkg/comp-functions/functions/vshnpostgres/postgresql_deploy.go
@@ -414,8 +414,10 @@ func createSgCluster(ctx context.Context, comp *vshnv1.VSHNPostgreSQL, svc *runt
 		initialData = &sgv1.SGClusterSpecInitialData{
 			Restore: &sgv1.SGClusterSpecInitialDataRestore{
 				FromBackup: &sgv1.SGClusterSpecInitialDataRestoreFromBackup{
-					Name:           &comp.Spec.Parameters.Restore.BackupName,
-					TargetTimeline: &comp.Spec.Parameters.Restore.RecoveryTimeStamp,
+					Name: &comp.Spec.Parameters.Restore.BackupName,
+					PointInTimeRecovery: &sgv1.SGClusterSpecInitialDataRestoreFromBackupPointInTimeRecovery{
+						RestoreToTimestamp: &comp.Spec.Parameters.Restore.RecoveryTimeStamp,
+					},
 				},
 			},
 		}

--- a/pkg/comp-functions/functions/vshnpostgres/postgresql_deploy_test.go
+++ b/pkg/comp-functions/functions/vshnpostgres/postgresql_deploy_test.go
@@ -137,6 +137,7 @@ func TestPostgreSqlDeployWithRestore(t *testing.T) {
 	cluster := &sgv1.SGCluster{}
 	assert.NoError(t, svc.GetDesiredKubeObject(cluster, "cluster"))
 	assert.Equal(t, comp.Spec.Parameters.Restore.BackupName, *cluster.Spec.InitialData.Restore.FromBackup.Name)
+	assert.Equal(t, comp.Spec.Parameters.Restore.RecoveryTimeStamp, *cluster.Spec.InitialData.Restore.FromBackup.PointInTimeRecovery.RestoreToTimestamp)
 
 	copyJob := &batchv1.Job{}
 	assert.NoError(t, svc.GetDesiredKubeObject(copyJob, "copy-job"))

--- a/test/functions/vshn-postgres/deploy/03_with_restore.yaml
+++ b/test/functions/vshn-postgres/deploy/03_with_restore.yaml
@@ -20,6 +20,7 @@ desired:
           restore:
             claimName: pgsql
             backupName: "pgsql-gc9x4-2024-06-11-16-01-02"
+            recoveryTimeStamp: "2024-06-15T22:00:00Z"
           service:
             majorVersion: "15"
           instances: 1
@@ -115,6 +116,7 @@ observed:
           restore:
             claimName: pgsql
             backupName: "pgsql-gc9x4-2024-06-11-16-01-02"
+            recoveryTimeStamp: "2024-06-15T22:00:00Z"
           service:
             majorVersion: "15"
             pgSettings:


### PR DESCRIPTION
## Summary

* The current PITR configuration can't work as we reference the wrong parameter in the `SgCluster`object.

This PR fixes that issue.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
