### PR TITLE
Revert back to try'n error approach for maintenance

### DIFF
--- a/cmd/hotfixreleaser.go
+++ b/cmd/hotfixreleaser.go
@@ -138,11 +138,13 @@ func (h *hotfixer) handleComposite(ctx context.Context, comp unstructured.Unstru
 	}
 
 	opts := release.ReleaserOpts{
-		Composite: comp.GetName(),
-		Group:     gv.Group,
-		Kind:      comp.GetKind(),
-		Version:   gv.Version,
-		ServiceID: serviceID,
+		Composite:      comp.GetName(),
+		ClaimName:      comp.GetLabels()["crossplane.io/claim-name"],
+		ClaimNamespace: comp.GetLabels()["crossplane.io/claim-namespace"],
+		Group:          gv.Group,
+		Kind:           comp.GetKind(),
+		Version:        gv.Version,
+		ServiceID:      serviceID,
 	}
 
 	r := release.NewDefaultVersionHandler(


### PR DESCRIPTION


## Summary

Previously the version update logic for each instances was changed to check for an empty namespace and decide that way if it has to patch the claim or the composite. This was an "improvement" over the previous try'n error approach, as it made things more explicit.

However, provider-kubernetes is currently not able to remove existing fields without switching to server-side-apply:
https://github.com/crossplane-contrib/provider-kubernetes/issues/242#issuecomment-2577579544

So this reverts the logic back to first try for a claim and the fall back to the composite.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
