### PR TITLE
Fix number of instances function for minio

### DIFF
--- a/apis/vshn/v1/vshn_minio.go
+++ b/apis/vshn/v1/vshn_minio.go
@@ -245,6 +245,10 @@ func (v *VSHNMinio) GetMonitoring() VSHNMonitoring {
 }
 
 func (v *VSHNMinio) GetInstances() int {
+	// mode supersedes the instances field
+	if v.Spec.Parameters.Service.Mode == "standalone" {
+		return 1
+	}
 	return v.Spec.Parameters.Instances
 }
 

--- a/pkg/comp-functions/functions/common/pdb.go
+++ b/pkg/comp-functions/functions/common/pdb.go
@@ -13,7 +13,7 @@ import (
 	"github.com/vshn/appcat/v4/pkg/comp-functions/runtime"
 )
 
-func AddPDBSettings[T client.Object](ctx context.Context, obj T, svc *runtime.ServiceRuntime) *fnproto.Result {
+func AddPDBSettings[T client.Object](_ context.Context, obj T, svc *runtime.ServiceRuntime) *fnproto.Result {
 
 	log := svc.Log
 


### PR DESCRIPTION
## Summary

* Since mode field supersedes instances, it means that whenever we have a standalone MinIO service we still check on the number of instances instead looking into the mode.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
