### PR TITLE
Ignore Changelog for merge to master

### DIFF
--- a/.github/changelog-configuration.json
+++ b/.github/changelog-configuration.json
@@ -32,5 +32,8 @@
       ]
     }
   ],
-  "template": "${{CATEGORIZED_COUNT}} changes since ${{FROM_TAG}}\n\n${{CHANGELOG}}"
+  "template": "${{CATEGORIZED_COUNT}} changes since ${{FROM_TAG}}\n\n${{CHANGELOG}}",
+  "ignore_labels": [
+    "ignoreChangelog"
+  ]
 }

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -35,6 +35,12 @@ jobs:
     name: Check labels
     runs-on: ubuntu-latest
     steps:
+      - name: Ignore from Changelog if merge to master
+        uses: actions-ecosystem/action-add-labels@v1
+        if: github.base_ref == 'master'
+        with:
+          labels: ignoreChangelog
+
       - uses: docker://agilepathway/pull-request-label-checker:v1.6.51
         with:
           one_of: major,minor,patch,documentation,dependency


### PR DESCRIPTION

## Summary

When the PR is merged from develop to master the changelog will also create an entry for that PR as well.

Which will clutter the changelog with "useless" PRs for the merges to master.

This commit fixes that by adding an ignore label and instruct the changelog builder to ignore all PRs with the label.

## Checklist

- [ ] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
