### PR TITLE
fix: bools where nil is interpreted as true can't have omitempty

### DIFF
--- a/apis/vshn/v1/common_types.go
+++ b/apis/vshn/v1/common_types.go
@@ -196,7 +196,7 @@ type Security struct {
 
 	// DeletionProtection blocks the deletion of the instance if it is enabled (enabled by default)
 	// +kubebuilder:default=true
-	DeletionProtection bool `json:"deletionProtection,omitempty"`
+	DeletionProtection bool `json:"deletionProtection"`
 
 	// AllowedGroups defines a list of Groups that have limited access to the instance namespace
 	AllowedGroups []string `json:"allowedGroups,omitempty"`

--- a/apis/vshn/v1/dbaas_vshn_postgresql.go
+++ b/apis/vshn/v1/dbaas_vshn_postgresql.go
@@ -186,7 +186,7 @@ type VSHNPostgreSQLBackup struct {
 	// DeletionProtection will protect the instance from being deleted for the given retention time.
 	// This is enabled by default.
 	// +kubebuilder:default=true
-	DeletionProtection *bool `json:"deletionProtection,omitempty"`
+	DeletionProtection *bool `json:"deletionProtection"`
 
 	// DeletionRetention specifies in days how long the instance should be kept after deletion.
 	// The default is keeping it one week.


### PR DESCRIPTION
DeletionProtection is a pointer to boolean with "omitempty" and a default of "true". This combination is broken in case the bool is set to "false", because the YAML mapper thinks that "false" is the default, thus ommitting the field; but then k8s thinks that "true" is the default (since the field is omitted). The result is that this is is always true, and it's completely impossible to set this field to "false" via the YAML mapper.

This PR fixes this by removing the "omitempty", which will make the YAML serializer also include "false" values instead of nil.

Component PR: https://github.com/vshn/component-appcat/pull/774