### PR TITLE
Keycloak metrics. Appcat's Own ServiceMonitor.

### DIFF
--- a/pkg/comp-functions/functions/vshnkeycloak/deploy.go
+++ b/pkg/comp-functions/functions/vshnkeycloak/deploy.go
@@ -13,6 +13,7 @@ import (
 	xkubev1 "github.com/vshn/appcat/v4/apis/kubernetes/v1alpha2"
 
 	xfnproto "github.com/crossplane/function-sdk-go/proto/v1"
+	prom "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	xhelmv1 "github.com/vshn/appcat/v4/apis/helm/release/v1beta1"
 	vshnv1 "github.com/vshn/appcat/v4/apis/vshn/v1"
 	"github.com/vshn/appcat/v4/pkg/common/utils"
@@ -149,6 +150,11 @@ func DeployKeycloak(ctx context.Context, comp *vshnv1.VSHNKeycloak, svc *runtime
 	if err != nil {
 		svc.Log.Error(err, "cannot set connection details")
 		svc.AddResult(runtime.NewWarningResult(fmt.Sprintf("cannot set connection details: %s", err)))
+	}
+
+	err = addServiceMonitor(comp, svc)
+	if err != nil {
+		return runtime.NewWarningResult(fmt.Sprintf("cannot add service monitor: %s", err))
 	}
 
 	return nil
@@ -744,4 +750,37 @@ func copyKeycloakCredentials(comp *vshnv1.VSHNKeycloak, svc *runtime.ServiceRunt
 	}
 
 	return nil
+}
+
+func addServiceMonitor(comp *vshnv1.VSHNKeycloak, svc *runtime.ServiceRuntime) error {
+
+	serviceMonitor := prom.ServiceMonitor{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      comp.GetName() + "-service-monitor",
+			Namespace: comp.GetInstanceNamespace(),
+		},
+		Spec: prom.ServiceMonitorSpec{
+			Selector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app.kubernetes.io/component": "http",
+					"app.kubernetes.io/instance":  comp.GetName(),
+					"app.kubernetes.io/name":      "keycloakx",
+				},
+			},
+			Endpoints: []prom.Endpoint{
+				{
+					Port:     "http-internal",
+					Path:     "/metrics",
+					Interval: "15s",
+					Scheme:   "https",
+					TLSConfig: &prom.TLSConfig{
+						SafeTLSConfig: prom.SafeTLSConfig{
+							InsecureSkipVerify: true,
+						},
+					},
+				},
+			},
+		},
+	}
+	return svc.SetDesiredKubeObject(&serviceMonitor, comp.GetName()+"-service-monitor")
 }


### PR DESCRIPTION
## Summary

* enabling metrics for Keycloak
* adding ServiceMonitor that supports self signed certificates and scraping over https (this is necessary, as helm chart doesn't support such scenario)

## Checklist

- [x] Update tests.
- [x] Link this PR to related issues.



Component PR: https://github.com/vshn/component-appcat/pull/777