### PR TITLE
Helm Chart updates June 2025

### DIFF
--- a/apis/vshn/v1/dbaas_vshn_forgejo.go
+++ b/apis/vshn/v1/dbaas_vshn_forgejo.go
@@ -99,8 +99,8 @@ type VSHNForgejoServiceSpec struct {
 	ServiceLevel VSHNDBaaSServiceLevel `json:"serviceLevel,omitempty"`
 
 	// Version contains supported version of Forgejo.
-	// Multiple versions are supported. Defaults to 10.0.0 if not set.
-	// +kubebuilder:default="10.0.0"
+	// Multiple versions are supported. Defaults to 11.0.0 if not set.
+	// +kubebuilder:default="11.0.0"
 	MajorVersion string `json:"majorVersion,omitempty"`
 }
 

--- a/apis/vshn/v1/vshn_nextcloud.go
+++ b/apis/vshn/v1/vshn_nextcloud.go
@@ -117,10 +117,10 @@ type VSHNNextcloudServiceSpec struct {
 	// +kubebuilder:default="/"
 	RelativePath string `json:"relativePath,omitempty"`
 
-	// +kubebuilder:default="29"
+	// +kubebuilder:default="30"
 
 	// Version contains supported version of nextcloud.
-	// Multiple versions are supported. The latest version 29 is the default version.
+	// Multiple versions are supported. The latest version 30 is the default version.
 	Version string `json:"version,omitempty"`
 
 	// +kubebuilder:validation:Enum="besteffort";"guaranteed"

--- a/crds/vshn.appcat.vshn.io_vshnforgejoes.yaml
+++ b/crds/vshn.appcat.vshn.io_vshnforgejoes.yaml
@@ -4645,10 +4645,10 @@ spec:
                           minItems: 1
                           type: array
                         majorVersion:
-                          default: 10.0.0
+                          default: 11.0.0
                           description: |-
                             Version contains supported version of Forgejo.
-                            Multiple versions are supported. Defaults to 10.0.0 if not set.
+                            Multiple versions are supported. Defaults to 11.0.0 if not set.
                           type: string
                         serviceLevel:
                           default: besteffort

--- a/crds/vshn.appcat.vshn.io_vshnnextclouds.yaml
+++ b/crds/vshn.appcat.vshn.io_vshnnextclouds.yaml
@@ -9457,10 +9457,10 @@ spec:
                             the build-in SQLite database is being used.
                           type: boolean
                         version:
-                          default: "29"
+                          default: "30"
                           description: |-
                             Version contains supported version of nextcloud.
-                            Multiple versions are supported. The latest version 29 is the default version.
+                            Multiple versions are supported. The latest version 30 is the default version.
                           type: string
                       required:
                         - fqdn

--- a/crds/vshn.appcat.vshn.io_xvshnforgejoes.yaml
+++ b/crds/vshn.appcat.vshn.io_xvshnforgejoes.yaml
@@ -5371,10 +5371,10 @@ spec:
                         minItems: 1
                         type: array
                       majorVersion:
-                        default: 10.0.0
+                        default: 11.0.0
                         description: |-
                           Version contains supported version of Forgejo.
-                          Multiple versions are supported. Defaults to 10.0.0 if not set.
+                          Multiple versions are supported. Defaults to 11.0.0 if not set.
                         type: string
                       serviceLevel:
                         default: besteffort

--- a/crds/vshn.appcat.vshn.io_xvshnnextclouds.yaml
+++ b/crds/vshn.appcat.vshn.io_xvshnnextclouds.yaml
@@ -11259,10 +11259,10 @@ spec:
                           the build-in SQLite database is being used.
                         type: boolean
                       version:
-                        default: "29"
+                        default: "30"
                         description: |-
                           Version contains supported version of nextcloud.
-                          Multiple versions are supported. The latest version 29 is the default version.
+                          Multiple versions are supported. The latest version 30 is the default version.
                         type: string
                     required:
                     - fqdn

--- a/test/functions/vshnforgejo/01_default.yaml
+++ b/test/functions/vshnforgejo/01_default.yaml
@@ -45,7 +45,7 @@ observed:
                   ENABLED: "true"
                   PROTOCOL: sendmail # Field should be removed due to bad value
             fqdn: ["forgejo.example.com"]
-            majorVersion: "10.0.0"
+            majorVersion: "11.0.0"
         claimRef:
           apiVersion: vshn.appcat.vshn.io/v1
           kind: VSHNForgejo


### PR DESCRIPTION
## Summary

* Updated charts: Redis, MariaDB, Nextcloud, Forgejo
* New default versions for  Nextcloud and Forgejo
* Updated Crossplane to v1.20.0 and adedd flags `--enable-realtime-compositions=false` and `--registry=xpkg.upbound.io` to [preserve](https://github.com/crossplane/crossplane/releases/tag/v1.20.0) the previous behavior 

## Checklist

- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->


Component PR: https://github.com/vshn/component-appcat/pull/784

Component PR: