### PR TITLE
Hotfix clear ownerReferences when copying kube-objects

### DIFF
--- a/pkg/comp-functions/runtime/function_mgr.go
+++ b/pkg/comp-functions/runtime/function_mgr.go
@@ -630,6 +630,11 @@ func (s *ServiceRuntime) AddLabels(obj client.Object, labels map[string]string) 
 // putIntoObject adds or updates the desired resource into its kube object
 // It will inject the same labels as any managed resource gets.
 func (s *ServiceRuntime) putIntoObject(o client.Object, kon, resourceName string, refs ...xkube.Reference) (*xkube.Object, error) {
+	o.SetResourceVersion("")
+	o.SetUID("")
+	o.SetSelfLink("")
+	o.SetGeneration(0)
+	o.SetOwnerReferences(nil)
 
 	s.addOwnerReferenceAnnotation(o, false)
 
@@ -1496,14 +1501,6 @@ func (s *ServiceRuntime) CopyKubeResource(ctx context.Context, obj client.Object
 
 	instObj := obj.DeepCopyObject().(client.Object)
 	instObj.SetNamespace(toNS)
-	instObj.SetResourceVersion("")
-	instObj.SetUID("")
-	instObj.SetSelfLink("")
-	instObj.SetGeneration(0)
-
-	if metaObj, ok := instObj.(metav1.Object); ok {
-		metaObj.SetCreationTimestamp(metav1.Time{})
-	}
 
 	if err := s.SetDesiredKubeObject(instObj, resourceName); err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

* Fixes a bug when copying resources like Secrets or ConfigMaps that have ownerReferences set (e.g., those managed by Vault).
Previously, CopyKubeResource did not clear ownerReferences, which prevented the resource from being synced into the instance namespace.


<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->


Component PR: https://github.com/vshn/component-appcat/pull/787