### PR TITLE
VSHNKeycloak: Fix bug with custom files

### DIFF
--- a/pkg/comp-functions/functions/vshnkeycloak/deploy.go
+++ b/pkg/comp-functions/functions/vshnkeycloak/deploy.go
@@ -930,7 +930,7 @@ exit 0`,
 
 func addCustomFileCopyInitContainer(comp *vshnv1.VSHNKeycloak, extraInitContainersMap []map[string]any) ([]map[string]any, error) {
 	if len(comp.Spec.Parameters.Service.CustomFiles) < 1 {
-		return nil, nil
+		return extraInitContainersMap, nil
 	}
 
 	files := []map[string]string{}

--- a/pkg/comp-functions/functions/vshnkeycloak/deploy_test.go
+++ b/pkg/comp-functions/functions/vshnkeycloak/deploy_test.go
@@ -203,6 +203,20 @@ func Test_addCustomFiles(t *testing.T) {
 		_, err = addCustomFileCopyInitContainer(comp, []map[string]any{})
 		assert.Error(t, err)
 	}
+
+	// No custom files added
+	t.Log("Testing no custom files")
+	comp.Spec.Parameters.Service.CustomFiles = []vshnv1.VSHNKeycloakCustomFile{}
+	comp.Spec.Parameters.Service.CustomizationImage = vshnv1.VSHNKeycloakCustomizationImage{}
+	assert.NoError(t, addRelease(context.TODO(), svc, comp, "mysecret", "mysecret"))
+	release := &xhelmv1.Release{}
+	assert.NoError(t, svc.GetDesiredComposedResourceByName(release, comp.GetName()+"-release"))
+	values = map[string]any{}
+	assert.NoError(t, json.Unmarshal(release.Spec.ForProvider.Values.Raw, &values))
+
+	v, exists := values["extraInitContainers"].(string)
+	assert.True(t, exists, "extraInitContainers should exist in values")
+	assert.NotEqual(t, "null\n", v, "extraInitContainers should not be 'null\\n' when no custom files are added")
 }
 
 func Test_configOrEnvChanged(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes a bug where the Keycloaks helm chart values are rendered out as `extraInitContainers: null` if `customFiles` has no length.  
The release fails to install in such a case because the STS template renders out invalid YAML.

Component PR: https://github.com/vshn/component-appcat/pull/802