### PR TITLE
Remove obsolete volumeMount

### DIFF
--- a/pkg/comp-functions/functions/vshnkeycloak/deploy.go
+++ b/pkg/comp-functions/functions/vshnkeycloak/deploy.go
@@ -574,13 +574,6 @@ func newValues(ctx context.Context, svc *runtime.ServiceRuntime, comp *vshnv1.VS
 		},
 	}
 
-	if comp.Spec.Parameters.Service.CustomConfigurationRef != nil {
-		extraVolumeMountsMap = append(extraVolumeMountsMap, map[string]any{
-			"name":      "keycloak-configs",
-			"mountPath": "/opt/keycloak/setup/project",
-		})
-	}
-
 	// Custom file volumes and mounts
 	if len(comp.Spec.Parameters.Service.CustomFiles) > 0 {
 		if comp.Spec.Parameters.Service.CustomizationImage.Image == "" {


### PR DESCRIPTION


## Summary

This was re-introduced by https://github.com/vshn/appcat/pull/379/files#diff-9d57e64a014aff26a646229e449affc4afe8e96fc5238920a77758f105cddc14R577 and should be removed, as the configurations are now applied via a job and the Keycloak API, so no new mounts are necessary.

## Checklist

- [ ] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->


Component PR: https://github.com/vshn/component-appcat/pull/814