### PR TITLE
Fix wrong permissions for the pg certificates in the nextcloud pod

### DIFF
--- a/pkg/comp-functions/functions/vshnnextcloud/deploy.go
+++ b/pkg/comp-functions/functions/vshnnextcloud/deploy.go
@@ -526,7 +526,7 @@ func newValues(ctx context.Context, svc *runtime.ServiceRuntime, comp *vshnv1.VS
 					"name": "pg-cert",
 					"secret": map[string]any{
 						"secretName":  pgSecret,
-						"defaultMode": 0600,
+						"defaultMode": 0644,
 					},
 				},
 			},


### PR DESCRIPTION
## Summary

* The certificates are mounted in as root user. However, nextcloud runs as www-data user. With the mode 0600, nextcloud can't access the certificate to connect to postgresql

## Checklist

- [ ] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
