### PR TITLE
Fix certificate permissions

### DIFF
--- a/pkg/comp-functions/functions/vshnnextcloud/deploy.go
+++ b/pkg/comp-functions/functions/vshnnextcloud/deploy.go
@@ -526,7 +526,7 @@ func newValues(ctx context.Context, svc *runtime.ServiceRuntime, comp *vshnv1.VS
 					"name": "pg-cert",
 					"secret": map[string]any{
 						"secretName":  pgSecret,
-						"defaultMode": 0644,
+						"defaultMode": 0640,
 					},
 				},
 			},


### PR DESCRIPTION


## Summary

Nextcloud requires the files to have mode `0640` and not `0644`.

## Checklist

- [ ] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
