### PR TITLE
Only set ignore label when opening the PR

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/vshn/appcat-cookiecutter",
-  "commit": "9e29b2c7a3cf60e3817dff61b8f39bbc811c64e7",
+  "commit": "d038cfcdc063f5ee8f11b8225e0eda68f24605d5",
   "checkout": "master",
   "context": {
     "cookiecutter": {
@@ -14,7 +14,7 @@
         ".github/changelog-configuration.json"
       ],
       "_template": "https://github.com/vshn/appcat-cookiecutter",
-      "_commit": "9e29b2c7a3cf60e3817dff61b8f39bbc811c64e7"
+      "_commit": "d038cfcdc063f5ee8f11b8225e0eda68f24605d5"
     }
   },
   "directory": null

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -159,7 +159,7 @@ jobs:
 
       - name: Ignore from Changelog if merge to master
         uses: actions-ecosystem/action-add-labels@v1
-        if: github.base_ref == 'master'
+        if: github.base_ref == 'master' && github.event.action == 'opened'
         with:
           labels: ignoreChangelog
 


### PR DESCRIPTION
## Summary

Otherwise it will set the label again every time something gets pushed. Which will break the changelog for hotfixes.

## Checklist

- [ ] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->


Component PR: https://github.com/vshn/component-appcat/pull/818