### PR TITLE
Allow deletion of the Keycloak config apply job

### DIFF
--- a/pkg/comp-functions/functions/common/maintenance/maintenance.go
+++ b/pkg/comp-functions/functions/common/maintenance/maintenance.go
@@ -284,7 +284,7 @@ func (m *Maintenance) createMaintenanceJob(_ context.Context, cronSchedule strin
 		},
 	}
 
-	return m.svc.SetDesiredKubeObject(job, m.resource.GetName()+"-maintenancejob")
+	return m.svc.SetDesiredKubeObject(job, m.resource.GetName()+"-maintenancejob", runtime.KubeOptionAllowDeletion)
 }
 func (m *Maintenance) createMaintenanceClusterRoleBinding(_ context.Context) error {
 	name := m.svc.Config.Data["additionalMaintenanceClusterRole"]

--- a/pkg/comp-functions/functions/vshnkeycloak/deploy.go
+++ b/pkg/comp-functions/functions/vshnkeycloak/deploy.go
@@ -256,14 +256,14 @@ func handleCustomConfig(ctx context.Context, comp *vshnv1.VSHNKeycloak, svc *run
 	if err != nil {
 		l.Info("Job for new configuration not found. Creating it now", "jobName", jobName)
 		applyJob := buildConfigApplyJob(comp, adminSecret, jobName)
-		if err := svc.SetDesiredKubeObject(applyJob, jobName); err != nil {
+		if err := svc.SetDesiredKubeObject(applyJob, jobName, runtime.KubeOptionAllowDeletion); err != nil {
 			return fmt.Errorf("cannot create config apply Job: %w", err)
 		}
 		svc.SetDesiredResourceReadiness(jobName, runtime.ResourceUnReady)
 		return nil
 	}
 
-	if err := svc.SetDesiredKubeObject(observedJob, jobName); err != nil {
+	if err := svc.SetDesiredKubeObject(observedJob, jobName, runtime.KubeOptionAllowDeletion); err != nil {
 		return fmt.Errorf("cannot set desired kube object for existing job: %w", err)
 	}
 


### PR DESCRIPTION
## Summary

* After fixing https://github.com/vshn/appcat/pull/414 the Job can't be removed
* When testing before rolling out we didn't run into this
* Added `runtime.KubeOptionAllowDeletion` so the Job can be removed again


<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->


Component PR: https://github.com/vshn/component-appcat/pull/827