### PR TITLE
Ensure Keycloak Config Apply Job Executes on Initial Install

### DIFF
--- a/apis/vshn/v1/dbaas_vshn_keycloak.go
+++ b/apis/vshn/v1/dbaas_vshn_keycloak.go
@@ -136,11 +136,15 @@ type VSHNKeycloakServiceSpec struct {
 	// The referenced configmap, must have the configuration in a field called `keycloak-config.json`
 	CustomConfigurationRef *string `json:"customConfigurationRef,omitempty"`
 
-	// CustomEnvVariablesRef can be used to provide custom environment variables from a
-	// provided secret for the keycloak instance. The environment variables provided
+	// CustomEnvVariablesRef can be used to provide custom environment variables from a Secret
+	// for the keycloak instance. This field is deprecated, use 'envFrom' instead.
+	CustomEnvVariablesRef *string `json:"customEnvVariablesRef,omitempty"`
+
+	// EnvFrom can be used to provide custom environment variables from either
+	// a ConfigMap or a Secret for the keycloak instance. The environment variables provided
 	// can for example be used in the custom JSON configuration provided in the `Configuration`
 	// field with `$(env:<ENV_VAR_NAME>:-<some_default_value>)`
-	CustomEnvVariablesRef *string `json:"customEnvVariablesRef,omitempty"`
+	EnvFrom *[]corev1.EnvFromSource `json:"envFrom,omitempty"`
 
 	// CustomMounts is a list of Secrets/ConfigMaps that get observed and copied into the Keycloak instance namespace.
 	// Once copied, they will be mounted under /custom/secrets/<name> or /custom/configs/<name>.

--- a/apis/vshn/v1/zz_generated.deepcopy.go
+++ b/apis/vshn/v1/zz_generated.deepcopy.go
@@ -8,6 +8,7 @@ import (
 	commonv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
 	stackgresv1 "github.com/vshn/appcat/v4/apis/stackgres/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -635,6 +636,17 @@ func (in *VSHNKeycloakServiceSpec) DeepCopyInto(out *VSHNKeycloakServiceSpec) {
 		in, out := &in.CustomEnvVariablesRef, &out.CustomEnvVariablesRef
 		*out = new(string)
 		**out = **in
+	}
+	if in.EnvFrom != nil {
+		in, out := &in.EnvFrom, &out.EnvFrom
+		*out = new([]corev1.EnvFromSource)
+		if **in != nil {
+			in, out := *in, *out
+			*out = make([]corev1.EnvFromSource, len(*in))
+			for i := range *in {
+				(*in)[i].DeepCopyInto(&(*out)[i])
+			}
+		}
 	}
 	if in.CustomMounts != nil {
 		in, out := &in.CustomMounts, &out.CustomMounts

--- a/crds/vshn.appcat.vshn.io_vshnkeycloaks.yaml
+++ b/crds/vshn.appcat.vshn.io_vshnkeycloaks.yaml
@@ -4620,10 +4620,8 @@ spec:
                           type: string
                         customEnvVariablesRef:
                           description: |-
-                            CustomEnvVariablesRef can be used to provide custom environment variables from a
-                            provided secret for the keycloak instance. The environment variables provided
-                            can for example be used in the custom JSON configuration provided in the `Configuration`
-                            field with `$(env:<ENV_VAR_NAME>:-<some_default_value>)`
+                            CustomEnvVariablesRef can be used to provide custom environment variables from a Secret
+                            for the keycloak instance. This field is deprecated, use 'envFrom' instead.
                           type: string
                         customFiles:
                           description: |-
@@ -4684,6 +4682,54 @@ spec:
                               type: object
                               x-kubernetes-map-type: atomic
                           type: object
+                        envFrom:
+                          description: |-
+                            EnvFrom can be used to provide custom environment variables from either
+                            a ConfigMap or a Secret for the keycloak instance. The environment variables provided
+                            can for example be used in the custom JSON configuration provided in the `Configuration`
+                            field with `$(env:<ENV_VAR_NAME>:-<some_default_value>)`
+                          items:
+                            description: EnvFromSource represents the source of a set of ConfigMaps
+                            properties:
+                              configMapRef:
+                                description: The ConfigMap to select from
+                                properties:
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap must be defined
+                                    type: boolean
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              prefix:
+                                description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                type: string
+                              secretRef:
+                                description: The Secret to select from
+                                properties:
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret must be defined
+                                    type: boolean
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                          type: array
                         fqdn:
                           description: |-
                             FQDN contains the FQDN which will be used for the ingress.

--- a/crds/vshn.appcat.vshn.io_xvshnkeycloaks.yaml
+++ b/crds/vshn.appcat.vshn.io_xvshnkeycloaks.yaml
@@ -5344,10 +5344,8 @@ spec:
                         type: string
                       customEnvVariablesRef:
                         description: |-
-                          CustomEnvVariablesRef can be used to provide custom environment variables from a
-                          provided secret for the keycloak instance. The environment variables provided
-                          can for example be used in the custom JSON configuration provided in the `Configuration`
-                          field with `$(env:<ENV_VAR_NAME>:-<some_default_value>)`
+                          CustomEnvVariablesRef can be used to provide custom environment variables from a Secret
+                          for the keycloak instance. This field is deprecated, use 'envFrom' instead.
                         type: string
                       customFiles:
                         description: |-
@@ -5415,6 +5413,58 @@ spec:
                             type: object
                             x-kubernetes-map-type: atomic
                         type: object
+                      envFrom:
+                        description: |-
+                          EnvFrom can be used to provide custom environment variables from either
+                          a ConfigMap or a Secret for the keycloak instance. The environment variables provided
+                          can for example be used in the custom JSON configuration provided in the `Configuration`
+                          field with `$(env:<ENV_VAR_NAME>:-<some_default_value>)`
+                        items:
+                          description: EnvFromSource represents the source of a set
+                            of ConfigMaps
+                          properties:
+                            configMapRef:
+                              description: The ConfigMap to select from
+                              properties:
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap must
+                                    be defined
+                                  type: boolean
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            prefix:
+                              description: An optional identifier to prepend to each
+                                key in the ConfigMap. Must be a C_IDENTIFIER.
+                              type: string
+                            secretRef:
+                              description: The Secret to select from
+                              properties:
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret must be
+                                    defined
+                                  type: boolean
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        type: array
                       fqdn:
                         description: |-
                           FQDN contains the FQDN which will be used for the ingress.

--- a/pkg/comp-functions/functions/vshnkeycloak/deploy.go
+++ b/pkg/comp-functions/functions/vshnkeycloak/deploy.go
@@ -236,24 +236,6 @@ func handleCustomConfig(ctx context.Context, comp *vshnv1.VSHNKeycloak, svc *run
 	lastConfigHash := comp.GetLastConfigHash()
 	lastEnvHash := comp.GetLastEnvHash()
 
-	// If we just created the instance, then the last hashes will be empty and thus trigger configOrEnvChanged().
-	// This will result in a race condition where two keycloak setups could run in parallel and clash with each other.
-	// Therefore, we'll check if those hashes are empty and set them to the current hashes.
-	if (lastConfigHash == "" && currentConfigHash != "") || (lastEnvHash == "" && currentEnvHash != "") {
-		if lastConfigHash == "" && currentConfigHash != "" {
-			comp.SetLastConfigHash(currentConfigHash)
-		}
-		if lastEnvHash == "" && currentEnvHash != "" {
-			comp.SetLastEnvHash(currentEnvHash)
-		}
-
-		l.Info("Setting initial configuration hashes")
-		if err := svc.SetDesiredCompositeStatus(comp); err != nil {
-			return fmt.Errorf("cannot set composite status with new hashes: %w", err)
-		}
-		return nil
-	}
-
 	if !configOrEnvChanged(currentConfigHash, lastConfigHash, currentEnvHash, lastEnvHash) {
 		return nil
 	}

--- a/pkg/comp-functions/functions/vshnkeycloak/deploy.go
+++ b/pkg/comp-functions/functions/vshnkeycloak/deploy.go
@@ -23,6 +23,7 @@ import (
 	"github.com/vshn/appcat/v4/pkg/comp-functions/functions/common/maintenance"
 	"github.com/vshn/appcat/v4/pkg/comp-functions/functions/vshnpostgres"
 	"github.com/vshn/appcat/v4/pkg/comp-functions/runtime"
+	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
@@ -235,11 +236,47 @@ func handleCustomConfig(ctx context.Context, comp *vshnv1.VSHNKeycloak, svc *run
 	lastConfigHash := comp.GetLastConfigHash()
 	lastEnvHash := comp.GetLastEnvHash()
 
+	// If we just created the instance, then the last hashes will be empty and thus trigger configOrEnvChanged().
+	// This will result in a race condition where two keycloak setups could run in parallel and clash with each other.
+	// Therefore, we'll check if those hashes are empty and set them to the current hashes.
+	if (lastConfigHash == "" && currentConfigHash != "") || (lastEnvHash == "" && currentEnvHash != "") {
+		if lastConfigHash == "" && currentConfigHash != "" {
+			comp.SetLastConfigHash(currentConfigHash)
+		}
+		if lastEnvHash == "" && currentEnvHash != "" {
+			comp.SetLastEnvHash(currentEnvHash)
+		}
+
+		l.Info("Setting initial configuration hashes")
+		if err := svc.SetDesiredCompositeStatus(comp); err != nil {
+			return fmt.Errorf("cannot set composite status with new hashes: %w", err)
+		}
+		return nil
+	}
+
 	if !configOrEnvChanged(currentConfigHash, lastConfigHash, currentEnvHash, lastEnvHash) {
 		return nil
 	}
 
 	l.Info("Detected configuration change, managing job lifecycle")
+
+	// Only create job if/once STS is healthy.
+	err := addStsObserver(comp, svc)
+	if err != nil {
+		return fmt.Errorf("could not set up STS observer: %w", err)
+	}
+
+	stsObserved := appsv1.StatefulSet{}
+	err = svc.GetObservedKubeObject(&stsObserved, comp.GetName()+"-sts-observer")
+	if err != nil {
+		l.Info("could not get STS observer, skipping config job", "error", err.Error())
+		return nil
+	}
+
+	if stsObserved.Status.ReadyReplicas == 0 {
+		l.Info("Observed STS is reporting 0 ready replicas, will not yet create config job")
+		return nil
+	}
 
 	currentCombinedHash := fmt.Sprintf("%x", md5.Sum([]byte(currentConfigHash+currentEnvHash)))
 	shortHash := currentCombinedHash[:8]
@@ -251,7 +288,7 @@ func handleCustomConfig(ctx context.Context, comp *vshnv1.VSHNKeycloak, svc *run
 	}
 
 	observedJob := &batchv1.Job{}
-	err := svc.GetObservedKubeObject(observedJob, jobName)
+	err = svc.GetObservedKubeObject(observedJob, jobName)
 
 	if err != nil {
 		l.Info("Job for new configuration not found. Creating it now", "jobName", jobName)
@@ -317,6 +354,16 @@ func configOrEnvChanged(currentConfigHash, lastConfigHash, currentEnvHash, lastE
 	return true
 }
 
+func addStsObserver(comp *vshnv1.VSHNKeycloak, svc *runtime.ServiceRuntime) error {
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      comp.GetName() + "-keycloakx",
+			Namespace: comp.GetInstanceNamespace(),
+		},
+	}
+	return svc.SetDesiredKubeObject(sts, comp.GetName()+"-sts-observer", runtime.KubeOptionObserve)
+}
+
 func buildConfigApplyJob(comp *vshnv1.VSHNKeycloak, adminSecret, jobName string) *batchv1.Job {
 	volumes := []corev1.Volume{}
 	if comp.Spec.Parameters.Service.CustomConfigurationRef != nil {
@@ -342,6 +389,12 @@ func buildConfigApplyJob(comp *vshnv1.VSHNKeycloak, adminSecret, jobName string)
 			},
 		})
 	}
+
+	if comp.Spec.Parameters.Service.EnvFrom != nil {
+		envFrom = append(envFrom, *comp.Spec.Parameters.Service.EnvFrom...)
+	}
+
+	keycloakApiUrl := fmt.Sprintf("http://%s-%s.%s.svc.cluster.local", comp.GetName(), serviceSuffix, comp.GetInstanceNamespace())
 
 	return &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
@@ -384,7 +437,7 @@ func buildConfigApplyJob(comp *vshnv1.VSHNKeycloak, adminSecret, jobName string)
 								},
 								{
 									Name:  "KEYCLOAK_API_URL",
-									Value: fmt.Sprintf("http://%s-%s.%s.svc.cluster.local", comp.GetName(), serviceSuffix, comp.GetInstanceNamespace()),
+									Value: keycloakApiUrl,
 								},
 							},
 							Command: []string{"sh", "-c", "/opt/keycloak/bin/keycloak-setup.sh"},
@@ -625,6 +678,7 @@ func newValues(ctx context.Context, svc *runtime.ServiceRuntime, comp *vshnv1.VS
 	if err != nil {
 		return nil, err
 	}
+
 	values = map[string]any{
 		"replicas":          comp.Spec.Parameters.Instances,
 		"extraEnv":          extraEnv,
@@ -693,6 +747,31 @@ func newValues(ctx context.Context, svc *runtime.ServiceRuntime, comp *vshnv1.VS
 		"podSecurityContext": nil,
 	}
 
+	var envFromMap []v1.EnvFromSource
+	if comp.Spec.Parameters.Service.EnvFrom != nil {
+		envFromMap = *comp.Spec.Parameters.Service.EnvFrom
+	}
+
+	// Deprecated field, the logic below is kept for backwards compatibility
+	if comp.Spec.Parameters.Service.CustomEnvVariablesRef != nil {
+		envFromMap = append(envFromMap, v1.EnvFromSource{
+			SecretRef: &v1.SecretEnvSource{
+				LocalObjectReference: v1.LocalObjectReference{
+					Name: *comp.Spec.Parameters.Service.CustomEnvVariablesRef,
+				},
+			},
+		})
+	}
+
+	if envFromMap != nil {
+		envFrom, err := toYAML(envFromMap)
+		if err != nil {
+			return nil, err
+		}
+
+		values["extraEnvFrom"] = envFrom
+	}
+
 	if svc.Config.Data["imageRegistry"] != "" {
 		values["image"] = map[string]interface{}{
 			"repository": svc.Config.Data["imageRegistry"],
@@ -712,6 +791,25 @@ func newValues(ctx context.Context, svc *runtime.ServiceRuntime, comp *vshnv1.VS
 }
 
 func newRelease(ctx context.Context, svc *runtime.ServiceRuntime, comp *vshnv1.VSHNKeycloak, adminSecret, pgSecret string) (*xhelmv1.Release, error) {
+	if comp.Spec.Parameters.Service.EnvFrom != nil {
+		for _, r := range *comp.Spec.Parameters.Service.EnvFrom {
+			if r.SecretRef != nil {
+				obj := &corev1.Secret{}
+				_, err := svc.CopyKubeResource(ctx, obj, comp.GetName()+"-env-secret-"+r.SecretRef.Name, r.SecretRef.Name, comp.GetClaimNamespace(), comp.GetInstanceNamespace())
+				if err != nil {
+					return nil, fmt.Errorf("cannot copy Keycloak env variable Secret to instance namespace: %w", err)
+				}
+			}
+			if r.ConfigMapRef != nil {
+				obj := &corev1.ConfigMap{}
+				_, err := svc.CopyKubeResource(ctx, obj, comp.GetName()+"-env-cm-"+r.ConfigMapRef.Name, r.ConfigMapRef.Name, comp.GetClaimNamespace(), comp.GetInstanceNamespace())
+				if err != nil {
+					return nil, fmt.Errorf("cannot copy Keycloak env variable ConfigMap to instance namespace: %w", err)
+				}
+			}
+		}
+	}
+
 	values, err := newValues(ctx, svc, comp, adminSecret, pgSecret)
 	if err != nil {
 		return nil, err

--- a/pkg/comp-functions/functions/vshnkeycloak/deploy.go
+++ b/pkg/comp-functions/functions/vshnkeycloak/deploy.go
@@ -211,11 +211,16 @@ func handleCustomConfig(ctx context.Context, comp *vshnv1.VSHNKeycloak, svc *run
 		cm := &corev1.ConfigMap{}
 		obj, err := svc.CopyKubeResource(ctx, cm, configMapName, *customConfigurationRef, comp.GetClaimNamespace(), comp.GetInstanceNamespace())
 		if err != nil {
-			return fmt.Errorf("cannot copy ConfigMap: %w", err)
+			l.Error(err, "cannot copy ConfigMap")
+			svc.AddResult(runtime.NewWarningResult(fmt.Sprintf("cannot copy ConfigMap: %s", err)))
+			return nil
 		}
 		dataBytes, err := json.Marshal(obj.(*corev1.ConfigMap).Data)
 		if err != nil {
-			return fmt.Errorf("cannot marshal ConfigMap data for hashing: %w", err)
+			l.Error(err, "cannot marshal ConfigMap data for hashing")
+			svc.AddResult(runtime.NewWarningResult(fmt.Sprintf("cannot marshal ConfigMap data for hashing: %s", err)))
+
+			return nil
 		}
 		currentConfigHash = fmt.Sprintf("%x", md5.Sum(dataBytes))
 	}
@@ -224,11 +229,15 @@ func handleCustomConfig(ctx context.Context, comp *vshnv1.VSHNKeycloak, svc *run
 		sec := &corev1.Secret{}
 		obj, err := svc.CopyKubeResource(ctx, sec, envSecretName, *customEnvVariablesRef, comp.GetClaimNamespace(), comp.GetInstanceNamespace())
 		if err != nil {
-			return fmt.Errorf("cannot copy Secret: %w", err)
+			l.Error(err, "cannot copy Secret")
+			svc.AddResult(runtime.NewWarningResult(fmt.Sprintf("cannot copy Secret: %s", err)))
+			return nil
 		}
 		dataBytes, err := json.Marshal(obj.(*corev1.Secret).Data)
 		if err != nil {
-			return fmt.Errorf("cannot marshal Secret data for hashing: %w", err)
+			l.Error(err, "cannot marshal Secret data for hashing")
+			svc.AddResult(runtime.NewWarningResult(fmt.Sprintf("cannot marshal Secret data for hashing: %s", err)))
+			return nil
 		}
 		currentEnvHash = fmt.Sprintf("%x", md5.Sum(dataBytes))
 	}
@@ -245,7 +254,9 @@ func handleCustomConfig(ctx context.Context, comp *vshnv1.VSHNKeycloak, svc *run
 	// Only create job if/once STS is healthy.
 	err := addStsObserver(comp, svc)
 	if err != nil {
-		return fmt.Errorf("could not set up STS observer: %w", err)
+		l.Error(err, "could not set up STS observer")
+		svc.AddResult(runtime.NewWarningResult(fmt.Sprintf("could not set up STS observer: %s", err)))
+		return nil
 	}
 
 	stsObserved := appsv1.StatefulSet{}
@@ -257,6 +268,7 @@ func handleCustomConfig(ctx context.Context, comp *vshnv1.VSHNKeycloak, svc *run
 
 	if stsObserved.Status.ReadyReplicas == 0 {
 		l.Info("Observed STS is reporting 0 ready replicas, will not yet create config job")
+		svc.SetDesiredResourceReadiness(comp.GetName()+"-sts-observer", runtime.ResourceUnReady)
 		return nil
 	}
 
@@ -276,14 +288,18 @@ func handleCustomConfig(ctx context.Context, comp *vshnv1.VSHNKeycloak, svc *run
 		l.Info("Job for new configuration not found. Creating it now", "jobName", jobName)
 		applyJob := buildConfigApplyJob(comp, adminSecret, jobName)
 		if err := svc.SetDesiredKubeObject(applyJob, jobName, runtime.KubeOptionAllowDeletion); err != nil {
-			return fmt.Errorf("cannot create config apply Job: %w", err)
+			l.Error(err, "cannot create config apply Job")
+			svc.AddResult(runtime.NewWarningResult(fmt.Sprintf("cannot create config apply Job: %s", err)))
+			return nil
 		}
 		svc.SetDesiredResourceReadiness(jobName, runtime.ResourceUnReady)
 		return nil
 	}
 
 	if err := svc.SetDesiredKubeObject(observedJob, jobName, runtime.KubeOptionAllowDeletion); err != nil {
-		return fmt.Errorf("cannot set desired kube object for existing job: %w", err)
+		l.Error(err, "cannot set desired kube object for existing job")
+		svc.AddResult(runtime.NewWarningResult(fmt.Sprintf("cannot set desired kube object for existing job: %s", err)))
+		return nil
 	}
 
 	if observedJob.Status.Succeeded > 0 {
@@ -304,6 +320,8 @@ func handleCustomConfig(ctx context.Context, comp *vshnv1.VSHNKeycloak, svc *run
 }
 
 func handleCustomMounts(ctx context.Context, comp *vshnv1.VSHNKeycloak, svc *runtime.ServiceRuntime) error {
+	l := svc.Log
+
 	if len(comp.Spec.Parameters.Service.CustomMounts) > 0 {
 		for _, m := range comp.Spec.Parameters.Service.CustomMounts {
 			switch m.Type {
@@ -311,16 +329,23 @@ func handleCustomMounts(ctx context.Context, comp *vshnv1.VSHNKeycloak, svc *run
 				obj := &corev1.Secret{}
 				_, err := svc.CopyKubeResource(ctx, obj, comp.GetName()+"-"+m.Name, m.Name, comp.GetClaimNamespace(), comp.GetInstanceNamespace())
 				if err != nil {
-					return fmt.Errorf("cannot copy secret %q: %s", m.Name, err)
+					l.Error(err, "cannot copy Secret", "name", m.Name)
+					svc.AddResult(runtime.NewWarningResult(fmt.Sprintf("cannot copy Secret %q: %s", m.Name, err)))
+					return nil
 				}
 			case customMountTypeConfigMap:
 				obj := &corev1.ConfigMap{}
 				_, err := svc.CopyKubeResource(ctx, obj, comp.GetName()+"-"+m.Name, m.Name, comp.GetClaimNamespace(), comp.GetInstanceNamespace())
 				if err != nil {
-					return fmt.Errorf("cannot copy configMap %q: %s", m.Name, err)
+					l.Error(err, "cannot copy ConfigMap", "name", m.Name)
+					svc.AddResult(runtime.NewWarningResult(fmt.Sprintf("cannot copy ConfigMap %q: %s", m.Name, err)))
+					return nil
 				}
 			default:
-				return fmt.Errorf("invalid customMount type %q for %q", m.Type, m.Name)
+				err := fmt.Errorf("invalid customMount type %q for %q", m.Type, m.Name)
+				l.Error(err, "invalid customMount", "name", m.Name, "type", m.Type)
+				svc.AddResult(runtime.NewWarningResult(fmt.Sprintf("invalid customMount type %q for %q", m.Type, m.Name)))
+				return nil
 			}
 		}
 	}
@@ -343,7 +368,7 @@ func addStsObserver(comp *vshnv1.VSHNKeycloak, svc *runtime.ServiceRuntime) erro
 			Namespace: comp.GetInstanceNamespace(),
 		},
 	}
-	return svc.SetDesiredKubeObject(sts, comp.GetName()+"-sts-observer", runtime.KubeOptionObserve)
+	return svc.SetDesiredKubeObject(sts, comp.GetName()+"-sts-observer", runtime.KubeOptionObserve, runtime.KubeOptionAllowDeletion)
 }
 
 func buildConfigApplyJob(comp *vshnv1.VSHNKeycloak, adminSecret, jobName string) *batchv1.Job {

--- a/test/functions/vshnkeycloak/01_default.yaml
+++ b/test/functions/vshnkeycloak/01_default.yaml
@@ -20,3 +20,43 @@ observed:
     mycloak-pg:
       connection_details:
         foo: YmFyCg==
+    # necessary for keycloak custom env variables
+    mycloak-env-cm-my-configmap-claim-observer:
+      resource:
+        apiVersion: v1
+        kind: Object
+        metadata:
+          name: unit-test
+        status:
+          atProvider:
+            manifest:
+              apiVersion: v1
+              kind: ConfigMap
+              metadata:
+                name: unit-test
+    mycloak-env-secret-my-secret-1-claim-observer:
+      resource:
+        apiVersion: v1
+        kind: Object
+        metadata:
+          name: unit-test
+        status:
+          atProvider:
+            manifest:
+              apiVersion: v1
+              kind: Secret
+              metadata:
+                name: unit-test
+    mycloak-env-secret-my-secret-2-claim-observer:
+      resource:
+        apiVersion: v1
+        kind: Object
+        metadata:
+          name: unit-test
+        status:
+          atProvider:
+            manifest:
+              apiVersion: v1
+              kind: Secret
+              metadata:
+                name: unit-test


### PR DESCRIPTION
## Summary

* PR https://github.com/vshn/appcat/pull/394 introduced a change in behaviour when the Config Apply Job should run
* This change corrects the logic so that if a user defines  customConfigurationRef  and/or customEnvVariablesRef during the initial installation, the Config Apply Job will execute accordingly. 


Component PR: https://github.com/vshn/component-appcat/pull/834