### PR TITLE
Fix race conditions due to desiredComposite

### DIFF
--- a/pkg/comp-functions/functions/vshnforgejo/maintenance.go
+++ b/pkg/comp-functions/functions/vshnforgejo/maintenance.go
@@ -14,7 +14,7 @@ import (
 
 // AddMaintenanceJob will add a job to do the maintenance for the instance
 func AddMaintenanceJob(ctx context.Context, comp *vshnv1.VSHNForgejo, svc *runtime.ServiceRuntime) *xfnproto.Result {
-	if err := svc.GetDesiredComposite(comp); err != nil {
+	if err := svc.GetObservedComposite(comp); err != nil {
 		return runtime.NewFatalResult(fmt.Errorf("can't get composite: %w", err))
 	}
 

--- a/pkg/comp-functions/functions/vshnkeycloak/maintenance.go
+++ b/pkg/comp-functions/functions/vshnkeycloak/maintenance.go
@@ -14,7 +14,7 @@ import (
 
 // AddMaintenanceJob will add a job to do the maintenance for the instance
 func AddMaintenanceJob(ctx context.Context, comp *vshnv1.VSHNKeycloak, svc *runtime.ServiceRuntime) *xfnproto.Result {
-	if err := svc.GetDesiredComposite(comp); err != nil {
+	if err := svc.GetObservedComposite(comp); err != nil {
 		return runtime.NewFatalResult(fmt.Errorf("can't get desired composite: %w", err))
 	}
 

--- a/pkg/comp-functions/functions/vshnmariadb/maintenance.go
+++ b/pkg/comp-functions/functions/vshnmariadb/maintenance.go
@@ -13,7 +13,7 @@ import (
 
 // AddMaintenanceJob will add a job to do the maintenance for the instance
 func AddMaintenanceJob(ctx context.Context, comp *vshnv1.VSHNMariaDB, svc *runtime.ServiceRuntime) *xfnproto.Result {
-	if err := svc.GetDesiredComposite(comp); err != nil {
+	if err := svc.GetObservedComposite(comp); err != nil {
 		return runtime.NewFatalResult(fmt.Errorf("can't get composite: %w", err))
 	}
 

--- a/pkg/comp-functions/functions/vshnmariadb/proxysql.go
+++ b/pkg/comp-functions/functions/vshnmariadb/proxysql.go
@@ -50,7 +50,7 @@ type proxySQLUsers struct {
 // This service is necessary to seamlessly scale up and down without changing the IP address.
 func AddProxySQL(_ context.Context, comp *vshnv1.VSHNMariaDB, svc *runtime.ServiceRuntime) *xfnproto.Result {
 
-	err := svc.GetDesiredComposite(comp)
+	err := svc.GetObservedComposite(comp)
 	if err != nil {
 		return runtime.NewFatalResult(fmt.Errorf("cannot get mariadb composite: %s", err))
 	}

--- a/pkg/comp-functions/functions/vshnmariadb/user_management.go
+++ b/pkg/comp-functions/functions/vshnmariadb/user_management.go
@@ -17,7 +17,7 @@ import (
 
 func UserManagement(ctx context.Context, comp *vshnv1.VSHNMariaDB, svc *runtime.ServiceRuntime) *xfnproto.Result {
 
-	err := svc.GetDesiredComposite(comp)
+	err := svc.GetObservedComposite(comp)
 	if err != nil {
 		return runtime.NewFatalResult(fmt.Errorf("Cannot get composite from function io: %w", err))
 	}

--- a/pkg/comp-functions/functions/vshnminio/maintenance.go
+++ b/pkg/comp-functions/functions/vshnminio/maintenance.go
@@ -13,7 +13,7 @@ import (
 
 // AddMaintenanceJob will add a job to do the maintenance for the instance
 func AddMaintenanceJob(ctx context.Context, comp *vshnv1.VSHNMinio, svc *runtime.ServiceRuntime) *xfnproto.Result {
-	if err := svc.GetDesiredComposite(comp); err != nil {
+	if err := svc.GetObservedComposite(comp); err != nil {
 		err = fmt.Errorf("cannot get observed composite: %w", err)
 		return runtime.NewFatalResult(err)
 	}

--- a/pkg/comp-functions/functions/vshnnextcloud/maintenance.go
+++ b/pkg/comp-functions/functions/vshnnextcloud/maintenance.go
@@ -13,7 +13,7 @@ import (
 
 // AddMaintenanceJob will add a job to do the maintenance for the instance
 func AddMaintenanceJob(ctx context.Context, comp *vshnv1.VSHNNextcloud, svc *runtime.ServiceRuntime) *xfnproto.Result {
-	if err := svc.GetDesiredComposite(comp); err != nil {
+	if err := svc.GetObservedComposite(comp); err != nil {
 		return runtime.NewFatalResult(fmt.Errorf("can't get composite: %w", err))
 	}
 

--- a/pkg/comp-functions/functions/vshnpostgres/user_management.go
+++ b/pkg/comp-functions/functions/vshnpostgres/user_management.go
@@ -17,7 +17,7 @@ import (
 )
 
 func UserManagement(ctx context.Context, comp *vshnv1.VSHNPostgreSQL, svc *runtime.ServiceRuntime) *xfnproto.Result {
-	err := svc.GetDesiredComposite(comp)
+	err := svc.GetObservedComposite(comp)
 	if err != nil {
 		return runtime.NewFatalResult(fmt.Errorf("Cannot get composite from function io: %w", err))
 	}

--- a/pkg/comp-functions/functions/vshnredis/maintenance.go
+++ b/pkg/comp-functions/functions/vshnredis/maintenance.go
@@ -13,7 +13,7 @@ import (
 
 // AddMaintenanceJob will add a job to do the maintenance for the instance
 func AddMaintenanceJob(ctx context.Context, comp *vshnv1.VSHNRedis, svc *runtime.ServiceRuntime) *xfnproto.Result {
-	if err := svc.GetDesiredComposite(comp); err != nil {
+	if err := svc.GetObservedComposite(comp); err != nil {
 		return runtime.NewFatalResult(fmt.Errorf("can't get composite: %w", err))
 	}
 

--- a/pkg/comp-functions/runtime/function_mgr.go
+++ b/pkg/comp-functions/runtime/function_mgr.go
@@ -701,12 +701,7 @@ func (s *ServiceRuntime) putIntoObject(o client.Object, kon, resourceName string
 
 // GetObservedComposite returns the observed composite and unmarshals it into the given object.
 func (s *ServiceRuntime) GetObservedComposite(obj client.Object) error {
-	comp, err := request.GetObservedCompositeResource(s.req)
-	if err != nil {
-		return err
-	}
-
-	jsonBytes, err := comp.Resource.MarshalJSON()
+	jsonBytes, err := s.observedComposite.MarshalJSON()
 	if err != nil {
 		return err
 	}
@@ -1456,7 +1451,7 @@ func (s *ServiceRuntime) deployConnectionDetailsToInstanceNS() error {
 
 		// We need to concatenate the name of the resource with the name of its immediate parent composite to avoid clashes
 		// in the desired map
-		err = s.SetDesiredKubeObject(secret, compName+"-"+s.desiredComposite.GetName())
+		err = s.SetDesiredKubeObject(secret, compName+"-"+s.observedComposite.GetName())
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Summary

The desiredComposite is not always initialized and can sometimes be empty. So any logic that relies on it to get the state of the observed composite might actually work on wrong values.

This commit fixes this issue.

## Checklist

- [x] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->


Component PR: https://github.com/vshn/component-appcat/pull/841