### PR TITLE
Fixing some race conditions and e2e

### DIFF
--- a/pkg/comp-functions/functions/common/instance_namespace.go
+++ b/pkg/comp-functions/functions/common/instance_namespace.go
@@ -264,9 +264,6 @@ func isBillingDisabled(controlNS, instanceNamespace, compName string, svc *runti
 
 	err = svc.GetObservedKubeObject(cm, compName+objSuffix)
 	if err != nil {
-		if err == runtime.ErrNotFound {
-			return false, nil
-		}
 		return false, err
 	}
 

--- a/pkg/comp-functions/functions/vshnnextcloud/collabora.go
+++ b/pkg/comp-functions/functions/vshnnextcloud/collabora.go
@@ -511,11 +511,11 @@ func createInstallCollaboraJob(comp *vshnv1.VSHNNextcloud, svc *runtime.ServiceR
 					Containers: []corev1.Container{
 						{
 							Name:  comp.GetName() + "-install-collabora",
-							Image: svc.Config.Data["oc_image"],
+							Image: svc.Config.Data["kubectl_image"],
 							Command: []string{
 								"bash",
 								"-cefx",
-								fmt.Sprintf("oc exec -i deployments/%s -- /install-collabora.sh \"%s\" \"%s\" \"%s\"", comp.GetWorkloadName(), svc.Config.Data["isOpenshift"], comp.GetName(), comp.Spec.Parameters.Service.Collabora.FQDN),
+								fmt.Sprintf("kubectl exec -i deployments/%s -- /install-collabora.sh \"%s\" \"%s\" \"%s\"", comp.GetWorkloadName(), svc.Config.Data["isOpenshift"], comp.GetName(), comp.Spec.Parameters.Service.Collabora.FQDN),
 							},
 						},
 					},

--- a/test/functions/common/billing.yaml
+++ b/test/functions/common/billing.yaml
@@ -97,6 +97,21 @@ observed:
                 name: unit-test
                 labels:
                   appuio.io/organization: vshn
+    nextcloud-gc9x4-ns-conf-observer:
+      resource:
+        apiVersion: v1
+        kind: Object
+        metadata:
+          name: tbd
+        status:
+          atProvider:
+            manifest:
+              apiVersion: v1
+              kind: ConfigMap
+              metadata:
+                labels:
+                name: dummy
+              data: {}
     nextcloud-gc9x4-credentials-secret:
       connection_details:
         admin: czNjcjN0UGFzcwo=
@@ -183,5 +198,3 @@ observed:
             reason: ReconcileSuccess
             status: "True"
             type: Synced
-
-


### PR DESCRIPTION
## Summary

* Provider-kubernetes uses a filter that only reacts to changes in `.spec` and `.metadata`. As seen [here](https://github.com/crossplane-contrib/provider-kubernetes/blob/main/internal/controller/object/object.go#L196) and [here](https://github.com/crossplane/crossplane-runtime/blob/main/pkg/resource/predicates.go#L51). Unfortunately this disables the polling from Crossplane itself. Which means that the state of observed `Objects` can potentially lag behind by 10 minutes. This lead to many issues with observing `Objects`. For instance that it can take up to 20 minutes for a Keycloak instance to get ready depending on it's configurations in the claim.
* To combat this behavior, we now update a special annotation on each function reconcile, which in turn forces provider-kubernetes to reconcile as well and update the status of the objects.
  * This will only slightly increase the API load, as during a function reconcile Crossplane will trigger a noop reconcile on the `Objects` anyway.
* `WaitForObservedDependenciesWithConnectionDetails()` will now set the readiness of the dependencies to `unready` if it's not yet ready. This will speed up provisioning even more. And is necessary with the new change above, as a `ready` dependency can actually cause the whole composite to become ready, before the actual service gets deployed (Nextcloud or Keycloak). Thus slowing down the reconcilation causing the provisioning to take 1h.
* `isBillingDisabled` not returns the `ErrNotFound` as well, as that also caused issues with the now fixed deletionprotection. As it defaulted to billing enabled in that case and deployed the rule, but then on further reconciles it removed it again and getting stuck.
* Use `kubectl` instead of `oc` for collabora installs. The `oc` image is not available on arm.

## Checklist

- [x] Update tests.
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->


Component PR: https://github.com/vshn/component-appcat/pull/845