### PR TITLE
Switch Bitnami images to legacy registry

### DIFF
--- a/pkg/comp-functions/functions/common/maintenance/maintenance.go
+++ b/pkg/comp-functions/functions/common/maintenance/maintenance.go
@@ -253,6 +253,10 @@ func (m *Maintenance) createMaintenanceJob(_ context.Context, cronSchedule strin
 			Name:  "RELEASE_MANAGEMENT_ENABLED",
 			Value: m.svc.Config.Data["releaseManagementEnabled"],
 		},
+		{
+			Name:  "MAINTENANCE_URL",
+			Value: m.svc.Config.Data["maintenanceURL"],
+		},
 	}
 
 	job := &batchv1.CronJob{

--- a/pkg/comp-functions/functions/vshnkeycloak/deploy.go
+++ b/pkg/comp-functions/functions/vshnkeycloak/deploy.go
@@ -1090,7 +1090,7 @@ func copyKeycloakCredentials(comp *vshnv1.VSHNKeycloak, svc *runtime.ServiceRunt
 					Containers: []v1.Container{
 						{
 							Name:    "copyjob",
-							Image:   "bitnami/kubectl:latest",
+							Image:   svc.Config.Data["kubectl_image"],
 							Command: []string{"sh", "-c"},
 							Args:    []string{keycloakCredentialsCopyJobScript},
 							Env: []v1.EnvVar{

--- a/pkg/comp-functions/functions/vshnmariadb/mariadb_deploy.go
+++ b/pkg/comp-functions/functions/vshnmariadb/mariadb_deploy.go
@@ -244,6 +244,20 @@ func newValues(ctx context.Context, svc *runtime.ServiceRuntime, comp *vshnv1.VS
 		}
 	}
 
+	if imageRepositoryPrefix := svc.Config.Data["imageRepositoryPrefix"]; imageRepositoryPrefix != "" {
+		if err := common.SetNestedObjectValue(values, []string{"image"}, map[string]any{
+			"repository": fmt.Sprintf("%s/mariadb-galera", imageRepositoryPrefix),
+		}); err != nil {
+			return nil, err
+		}
+
+		if err := common.SetNestedObjectValue(values, []string{"metrics", "image"}, map[string]any{
+			"repository": fmt.Sprintf("%s/mysqld-exporter", imageRepositoryPrefix),
+		}); err != nil {
+			return nil, err
+		}
+	}
+
 	return values, nil
 }
 

--- a/pkg/comp-functions/functions/vshnpostgres/postgresql_deploy.go
+++ b/pkg/comp-functions/functions/vshnpostgres/postgresql_deploy.go
@@ -664,7 +664,7 @@ func createCopyJob(comp *vshnv1.VSHNPostgreSQL, svc *runtime.ServiceRuntime) err
 					Containers: []v1.Container{
 						{
 							Name:    "copyjob",
-							Image:   "bitnami/kubectl:latest",
+							Image:   svc.Config.Data["kubectl_image"],
 							Command: []string{"sh", "-c"},
 							Args:    []string{postgresqlCopyJobScript},
 							Env: []v1.EnvVar{

--- a/pkg/comp-functions/functions/vshnredis/pvcresize.go
+++ b/pkg/comp-functions/functions/vshnredis/pvcresize.go
@@ -178,7 +178,7 @@ func addDeletionJob(svc *runtime.ServiceRuntime, comp *vshnv1.VSHNRedis) error {
 					Containers: []corev1.Container{
 						{
 							Name:            "sts-deleter",
-							Image:           "bitnami/kubectl",
+							Image:           svc.Config.Data["kubectl_image"],
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							Env: []corev1.EnvVar{
 								{

--- a/pkg/comp-functions/functions/vshnredis/restore.go
+++ b/pkg/comp-functions/functions/vshnredis/restore.go
@@ -89,7 +89,7 @@ func addPrepareRestoreJob(ctx context.Context, comp *vshnv1.VSHNRedis, svc *runt
 					Containers: []corev1.Container{
 						{
 							Name:  "copyjob",
-							Image: "bitnami/kubectl:latest",
+							Image: svc.Config.Data["kubectl_image"],
 							Command: []string{
 								"bash",
 								"-c",
@@ -259,7 +259,7 @@ func addCleanUpJob(ctx context.Context, comp *vshnv1.VSHNRedis, svc *runtime.Ser
 					Containers: []corev1.Container{
 						{
 							Name:  "copyjob",
-							Image: "bitnami/kubectl:latest",
+							Image: svc.Config.Data["kubectl_image"],
 							Command: []string{
 								"bash",
 								"-c",

--- a/pkg/maintenance/forgejo.go
+++ b/pkg/maintenance/forgejo.go
@@ -2,16 +2,13 @@ package maintenance
 
 import (
 	"context"
-	"github.com/vshn/appcat/v4/pkg/maintenance/release"
 	"net/http"
+
+	"github.com/vshn/appcat/v4/pkg/maintenance/release"
 
 	"github.com/go-logr/logr"
 	"github.com/vshn/appcat/v4/pkg/maintenance/helm"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-)
-
-const (
-	forgejoURL = "https://codeberg.org/v2/forgejo/forgejo/tags/list"
 )
 
 // Forgejo contains all necessary dependencies to successfully run a Forgejo maintenance
@@ -34,7 +31,12 @@ func NewForgejo(c client.Client, hc *http.Client, vh release.VersionHandler, log
 
 // DoMaintenance will run forgejo's maintenance script.
 func (f *Forgejo) DoMaintenance(ctx context.Context) error {
+	maintenanceURL, err := getMaintenanceURL()
+	if err != nil {
+		return err
+	}
+
 	patcher := helm.NewImagePatcher(f.k8sClient, f.httpClient, f.log)
 	valuesPath := helm.NewValuePath("image", "tag")
-	return patcher.DoMaintenance(ctx, forgejoURL, valuesPath, helm.SemVerPatchesOnly(true))
+	return patcher.DoMaintenance(ctx, maintenanceURL, valuesPath, helm.SemVerPatchesOnly(true))
 }

--- a/pkg/maintenance/keycloak.go
+++ b/pkg/maintenance/keycloak.go
@@ -11,10 +11,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const (
-	keycloakURL = "https://docker-registry.inventage.com:10121/v2/keycloak-competence-center/keycloak-managed/tags/list"
-)
-
 // Keycloak contains all necessary dependencies to successfully run a Keycloak maintenance
 type Keycloak struct {
 	k8sClient  client.Client
@@ -35,7 +31,12 @@ func NewKeycloak(c client.Client, hc *http.Client, vh release.VersionHandler, lo
 
 // DoMaintenance will run minios's maintenance script.
 func (k *Keycloak) DoMaintenance(ctx context.Context) error {
+	maintenanceURL, err := getMaintenanceURL()
+	if err != nil {
+		return err
+	}
+
 	patcher := helm.NewImagePatcher(k.k8sClient, k.httpClient, k.log)
 	valuesPath := helm.NewValuePath("image", "tag")
-	return patcher.DoMaintenance(ctx, keycloakURL, valuesPath, helm.SemVerMinorAndPatches(true))
+	return patcher.DoMaintenance(ctx, maintenanceURL, valuesPath, helm.SemVerMinorAndPatches(true))
 }

--- a/pkg/maintenance/mariadb.go
+++ b/pkg/maintenance/mariadb.go
@@ -2,16 +2,12 @@ package maintenance
 
 import (
 	"context"
-	"github.com/vshn/appcat/v4/pkg/maintenance/release"
 	"net/http"
 
 	"github.com/go-logr/logr"
 	"github.com/vshn/appcat/v4/pkg/maintenance/helm"
+	"github.com/vshn/appcat/v4/pkg/maintenance/release"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-)
-
-const (
-	mariaDBURL = "https://hub.docker.com/v2/repositories/bitnami/mariadb-galera/tags/?page_size=100"
 )
 
 // MariaDB holds all the necessary objects to do a MariaDB maintenance
@@ -22,7 +18,7 @@ type MariaDB struct {
 	release.VersionHandler
 }
 
-// NewMariaDB returns a new Redis maintenance job runner
+// NewMariaDB returns a new MariaDB maintenance job runner
 func NewMariaDB(c client.Client, hc *http.Client, vh release.VersionHandler, logger logr.Logger) *MariaDB {
 	return &MariaDB{
 		k8sClient:      c,
@@ -32,8 +28,13 @@ func NewMariaDB(c client.Client, hc *http.Client, vh release.VersionHandler, log
 	}
 }
 
-// DoMaintenance will run redis' maintenance script.
+// DoMaintenance will run MariaDB's maintenance script.
 func (m *MariaDB) DoMaintenance(ctx context.Context) error {
+	maintenanceURL, err := getMaintenanceURL()
+	if err != nil {
+		return err
+	}
+
 	patcher := helm.NewImagePatcher(m.k8sClient, m.httpClient, m.log)
-	return patcher.DoMaintenance(ctx, mariaDBURL, helm.NewValuePath("image", "tag"), helm.SemVerPatchesOnly(false))
+	return patcher.DoMaintenance(ctx, maintenanceURL, helm.NewValuePath("image", "tag"), helm.SemVerPatchesOnly(false))
 }

--- a/pkg/maintenance/nextcloud.go
+++ b/pkg/maintenance/nextcloud.go
@@ -2,16 +2,13 @@ package maintenance
 
 import (
 	"context"
-	"github.com/vshn/appcat/v4/pkg/maintenance/release"
 	"net/http"
+
+	"github.com/vshn/appcat/v4/pkg/maintenance/release"
 
 	"github.com/go-logr/logr"
 	"github.com/vshn/appcat/v4/pkg/maintenance/helm"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-)
-
-const (
-	nextcloudURL = "https://hub.docker.com/v2/namespaces/library/repositories/nextcloud/tags?page_size=100"
 )
 
 // Nextcloud contains all necessary dependencies to successfully run a Nextcloud maintenance
@@ -34,7 +31,12 @@ func NewNextcloud(c client.Client, hc *http.Client, vh release.VersionHandler, l
 
 // DoMaintenance will run minios's maintenance script.
 func (n *Nextcloud) DoMaintenance(ctx context.Context) error {
+	maintenanceURL, err := getMaintenanceURL()
+	if err != nil {
+		return err
+	}
+
 	patcher := helm.NewImagePatcher(n.k8sClient, n.httpClient, n.log)
 	valuesPath := helm.NewValuePath("image", "tag")
-	return patcher.DoMaintenance(ctx, nextcloudURL, valuesPath, helm.SemVerPatchesOnly(true))
+	return patcher.DoMaintenance(ctx, maintenanceURL, valuesPath, helm.SemVerPatchesOnly(true))
 }

--- a/pkg/maintenance/redis.go
+++ b/pkg/maintenance/redis.go
@@ -2,15 +2,12 @@ package maintenance
 
 import (
 	"context"
+	"net/http"
+
 	"github.com/go-logr/logr"
 	"github.com/vshn/appcat/v4/pkg/maintenance/helm"
 	"github.com/vshn/appcat/v4/pkg/maintenance/release"
-	"net/http"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-)
-
-const (
-	redisURL = "https://hub.docker.com/v2/repositories/bitnami/redis/tags/?page_size=100"
 )
 
 // Redis holds all the necessary objects to do a Redis maintenance
@@ -33,6 +30,11 @@ func NewRedis(c client.Client, hc *http.Client, vh release.VersionHandler, logge
 
 // DoMaintenance will run redis' maintenance script.
 func (r *Redis) DoMaintenance(ctx context.Context) error {
+	maintenanceURL, err := getMaintenanceURL()
+	if err != nil {
+		return err
+	}
+
 	patcher := helm.NewImagePatcher(r.k8sClient, r.httpClient, r.log)
-	return patcher.DoMaintenance(ctx, redisURL, helm.NewValuePath("image", "tag"), helm.SemVerPatchesOnly(false))
+	return patcher.DoMaintenance(ctx, maintenanceURL, helm.NewValuePath("image", "tag"), helm.SemVerPatchesOnly(false))
 }

--- a/pkg/maintenance/redis_test.go
+++ b/pkg/maintenance/redis_test.go
@@ -3,10 +3,11 @@ package maintenance
 import (
 	"context"
 	"encoding/json"
-	"github.com/go-logr/logr"
-	"github.com/vshn/appcat/v4/pkg/maintenance/release"
 	"net/http"
 	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/vshn/appcat/v4/pkg/maintenance/release"
 
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
@@ -68,6 +69,7 @@ func TestRedis_DoMaintenance(t *testing.T) {
 
 			// GIVEN
 			t.Setenv("INSTANCE_NAMESPACE", "test-namespace")
+			t.Setenv("MAINTENANCE_URL", "https://hub.docker.com/v2/repositories/bitnamilegacy/redis/tags/?page_size=100")
 			viper.AutomaticEnv()
 			fClient := fake.NewClientBuilder().
 				WithScheme(pkg.SetupScheme()).

--- a/pkg/maintenance/url.go
+++ b/pkg/maintenance/url.go
@@ -1,0 +1,15 @@
+package maintenance
+
+import (
+	"fmt"
+	"os"
+)
+
+// getMaintenanceURL reads the MAINTENANCE_URL environment variable.
+func getMaintenanceURL() (string, error) {
+	const envKey = "MAINTENANCE_URL"
+	if url := os.Getenv(envKey); url != "" {
+		return url, nil
+	}
+	return "", fmt.Errorf("%s environment variable not set", envKey)
+}


### PR DESCRIPTION
## Summary

* In response to the following announcement https://github.com/bitnami/containers/issues/83267 we have to switch to the legacy registry before August 28th, to prevent image pull errors.

## Checklist

- [x] Link this PR to related issues.
- [ ] Merge with `/merge` comment.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->


Component PR: https://github.com/vshn/component-appcat/pull/851