### PR TITLE
Fix Redis restore and pvc resize

### DIFF
--- a/pkg/comp-functions/functions/vshnredis/backup.go
+++ b/pkg/comp-functions/functions/vshnredis/backup.go
@@ -71,17 +71,17 @@ func updateRelease(ctx context.Context, svc *runtime.ServiceRuntime) error {
 	}
 
 	l.Info("Adding the PVC k8up annotations")
-	if err := backup.AddPVCAnnotationToValues(values, "master", "persistence", "annotations"); err != nil {
+	if err := backup.AddPVCAnnotationToValues(values, "replica", "persistence", "annotations"); err != nil {
 		return err
 	}
 
 	l.Info("Adding the Pod k8up annotations")
-	if err := backup.AddPodAnnotationToValues(values, "/scripts/backup.sh", ".tar", "master", "podAnnotations"); err != nil {
+	if err := backup.AddPodAnnotationToValues(values, "/scripts/backup.sh", ".tar", "replica", "podAnnotations"); err != nil {
 		return err
 	}
 
 	l.Info("Mounting CM into pod")
-	if err := backup.AddBackupCMToValues(values, []string{"master", "extraVolumes"}, []string{"master", "extraVolumeMounts"}); err != nil {
+	if err := backup.AddBackupCMToValues(values, []string{"replica", "extraVolumes"}, []string{"replica", "extraVolumeMounts"}); err != nil {
 		return err
 	}
 

--- a/pkg/comp-functions/functions/vshnredis/pvcresize_test.go
+++ b/pkg/comp-functions/functions/vshnredis/pvcresize_test.go
@@ -63,7 +63,7 @@ func Test_needReleasePatch(t *testing.T) {
 					},
 				},
 				values: map[string]interface{}{
-					"master": map[string]interface{}{
+					"replica": map[string]interface{}{
 						"persistence": map[string]interface{}{
 							"size": "15Gi",
 						},
@@ -85,7 +85,7 @@ func Test_needReleasePatch(t *testing.T) {
 					},
 				},
 				values: map[string]interface{}{
-					"master": map[string]interface{}{
+					"replica": map[string]interface{}{
 						"persistence": map[string]interface{}{
 							"size": "15Gi",
 						},
@@ -107,7 +107,7 @@ func Test_needReleasePatch(t *testing.T) {
 					},
 				},
 				values: map[string]interface{}{
-					"master": map[string]interface{}{
+					"replica": map[string]interface{}{
 						"persistence": map[string]interface{}{
 							"size": "15Gi",
 						},
@@ -130,7 +130,7 @@ func Test_needReleasePatch(t *testing.T) {
 					},
 				},
 				values: map[string]interface{}{
-					"master": map[string]interface{}{
+					"replica": map[string]interface{}{
 						"persistence": map[string]interface{}{
 							"size": "15Gi",
 						},
@@ -153,7 +153,7 @@ func Test_needReleasePatch(t *testing.T) {
 					},
 				},
 				values: map[string]interface{}{
-					"master": map[string]interface{}{
+					"replica": map[string]interface{}{
 						"persistence": map[string]interface{}{
 							"size": "foo",
 						},
@@ -176,7 +176,7 @@ func Test_needReleasePatch(t *testing.T) {
 					},
 				},
 				values: map[string]interface{}{
-					"master": map[string]interface{}{
+					"replica": map[string]interface{}{
 						"persistence": map[string]interface{}{},
 					},
 				},

--- a/pkg/comp-functions/functions/vshnredis/restore.go
+++ b/pkg/comp-functions/functions/vshnredis/restore.go
@@ -140,7 +140,7 @@ func addRestoreJob(ctx context.Context, comp *vshnv1.VSHNRedis, svc *runtime.Ser
 							Name: "data",
 							VolumeSource: corev1.VolumeSource{
 								PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-									ClaimName: "redis-data-redis-master-0",
+									ClaimName: "redis-data-redis-node-0",
 								},
 							},
 						},
@@ -234,6 +234,13 @@ func addRestoreJob(ctx context.Context, comp *vshnv1.VSHNRedis, svc *runtime.Ser
 				},
 			},
 		},
+	}
+
+	if !svc.GetBoolFromCompositionConfig("isOpenshift") {
+		fsGroup := int64(1001)
+		job.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{
+			FSGroup: &fsGroup,
+		}
 	}
 
 	return svc.SetDesiredKubeObject(job, restoreJobName)

--- a/pkg/comp-functions/functions/vshnredis/script/cleanupRestore.sh
+++ b/pkg/comp-functions/functions/vshnredis/script/cleanupRestore.sh
@@ -56,7 +56,7 @@ EOF
 fi
 echo "scaling up redis"
 
-kubectl -n "${TARGET_NAMESPACE}" scale statefulset redis-master --replicas "${NUM_REPLICAS}"
+kubectl -n "${TARGET_NAMESPACE}" scale statefulset redis-node --replicas "${NUM_REPLICAS}"
 
 echo "cleanup secret"
 

--- a/pkg/comp-functions/functions/vshnredis/script/prepRestore.sh
+++ b/pkg/comp-functions/functions/vshnredis/script/prepRestore.sh
@@ -14,14 +14,14 @@ restic_password=$(kubectl -n "${source_namespace}" get secret k8up-repository-pa
 restic_repository=$(kubectl -n "${source_namespace}" get snapshots.k8up.io "${BACKUP_NAME}" -o jsonpath='{.spec.repository}')
 backup_path=$(kubectl -n "${source_namespace}" get snapshots.k8up.io "${BACKUP_NAME}" -o jsonpath='{.spec.paths[0]}')
 backup_name=$(kubectl -n "${source_namespace}" get snapshots.k8up.io "${BACKUP_NAME}" -o jsonpath='{.spec.id}')
-num_replicas=$(kubectl -n "${TARGET_NAMESPACE}" get statefulset redis-master -o jsonpath='{.spec.replicas}')
+num_replicas=$(kubectl -n "${TARGET_NAMESPACE}" get statefulset redis-node -o jsonpath='{.spec.replicas}')
 kubectl -n "${TARGET_NAMESPACE}" create secret generic "restore-credentials-${BACKUP_NAME}" --from-literal AWS_ACCESS_KEY_ID="${access_key}" --from-literal AWS_SECRET_ACCESS_KEY="${secret_key}" --from-literal RESTIC_PASSWORD="${restic_password}" --from-literal RESTIC_REPOSITORY="${restic_repository}" --from-literal BACKUP_PATH="${backup_path}" --from-literal BACKUP_NAME="${backup_name}"
 kubectl create secret generic "statefulset-replicas-${SOURCE_CLAIM_NAME}-${BACKUP_NAME}" --from-literal NUM_REPLICAS="${num_replicas}"
 echo "scaling down redis"
 
-until kubectl -n "${TARGET_NAMESPACE}" get statefulset redis-master > /dev/null 2>&1
+until kubectl -n "${TARGET_NAMESPACE}" get statefulset redis-node > /dev/null 2>&1
 do
   sleep 1
 done
 
-kubectl -n "${TARGET_NAMESPACE}" scale statefulset redis-master --replicas 0
+kubectl -n "${TARGET_NAMESPACE}" scale statefulset redis-node --replicas 0

--- a/pkg/comp-functions/functions/vshnredis/script/recreate.sh
+++ b/pkg/comp-functions/functions/vshnredis/script/recreate.sh
@@ -19,15 +19,15 @@ if [[ $foundsize != "$size" ]]; then
   # deletion with orphan doesn't go through and the sts is stuck with an orphan finalizer.
   # So if the delete hasn't returned after 5s we forcefully patch away the finalizer.
   kubectl -n "$namespace" delete sts "$name" --cascade=orphan --ignore-not-found --wait=true --timeout 5s || true
-  kubectl -n "$namespace" patch sts redis-master -p '{"metadata":{"finalizers":null}}' || true
+  kubectl -n "$namespace" patch sts "$name" -p '{"metadata":{"finalizers":null}}' || true
   # Poke the release so it tries again to create the sts
   # We first set it to garbage to ensure that the release is in an invalid state, we use an invalid state so it doesn't
   # actually deploy anything.
   # Then we patch the right size to enforce an upgrade
   # This is necessary as provider-helm doesn't actually retry failed helm deployments unless the values change.
   echo "Triggering sts re-creation"
-  kubectl patch release "$release" --type merge -p "{\"spec\":{\"forProvider\":{\"values\":{\"master\":{\"persistence\":{\"size\":\"foo\"}}}}}}"
-  kubectl patch release "$release" --type merge -p "{\"spec\":{\"forProvider\":{\"values\":{\"master\":{\"persistence\":{\"size\":\"$size\"}}}}}}"
+  kubectl patch release "$release" --type merge -p "{\"spec\":{\"forProvider\":{\"values\":{\"replica\":{\"persistence\":{\"size\":\"foo\"}}}}}}"
+  kubectl patch release "$release" --type merge -p "{\"spec\":{\"forProvider\":{\"values\":{\"replica\":{\"persistence\":{\"size\":\"$size\"}}}}}}"
   count=0
   while ! kubectl -n "$namespace" get sts "$name" && [[ count -lt 300 ]]; do
     echo "waiting for sts to re-appear"

--- a/pkg/comp-functions/functions/vshnredis/script/restore.sh
+++ b/pkg/comp-functions/functions/vshnredis/script/restore.sh
@@ -2,10 +2,20 @@
 
 set -euo pipefail
 
-rm -rf /data/*
-restic dump "${BACKUP_NAME}" "${BACKUP_PATH}" > /data/restore.tar
-cd /data
-tar xvf restore.tar
-mv data/* .
-rmdir data
-rm restore.tar
+DEST="/data"
+
+echo "Starting restore process"
+
+echo "Removing existing files in ${DEST}"
+rm -rf "${DEST:?}/"*
+
+echo "Dumping restic backup '${BACKUP_NAME}' path '${BACKUP_PATH}' to ${DEST}/restore.tar"
+restic dump "${BACKUP_NAME}" "${BACKUP_PATH}" > "${DEST}/restore.tar"
+
+echo "Extracting files from restore.tar into ${DEST}"
+tar xvf "${DEST}/restore.tar" --strip-components=1 -C "${DEST}"
+
+echo "Removing temporary archive ${DEST}/restore.tar"
+rm "${DEST}/restore.tar"
+
+echo "Restore completed successfully"

--- a/test/functions/vshnredis/pvcresize/01_default.yaml
+++ b/test/functions/vshnredis/pvcresize/01_default.yaml
@@ -42,7 +42,7 @@ desired:
               image:
                 repository: bitnami/redis
                 tag: 7.0.11
-              master:
+              replica:
                 containerSecurityContext:
                   enabled: true
                 persistence:
@@ -115,7 +115,7 @@ observed:
               image:
                 repository: bitnami/redis
                 tag: "7.0"
-              master:
+              replica:
                 containerSecurityContext:
                   enabled: true
                 extraVolumes: []

--- a/test/functions/vshnredis/pvcresize/01_job.yaml
+++ b/test/functions/vshnredis/pvcresize/01_job.yaml
@@ -42,7 +42,7 @@ desired:
               image:
                 repository: bitnami/redis
                 tag: 7.0.11
-              master:
+              replica:
                 containerSecurityContext:
                   enabled: true
                 persistence:
@@ -169,7 +169,7 @@ observed:
               image:
                 repository: bitnami/redis
                 tag: "7.0"
-              master:
+              replica:
                 containerSecurityContext:
                   enabled: true
                 extraVolumes: []

--- a/test/functions/vshnredis/restore/01-GivenNoRestoreConfig.yaml
+++ b/test/functions/vshnredis/restore/01-GivenNoRestoreConfig.yaml
@@ -39,7 +39,7 @@ desired:
               image:
                 repository: bitnami/redis
                 tag: dummy
-              master:
+              replica:
                 containerSecurityContext:
                   enabled: true
                 persistence:

--- a/test/functions/vshnredis/restore/01-GivenRestoreConfig.yaml
+++ b/test/functions/vshnredis/restore/01-GivenRestoreConfig.yaml
@@ -53,7 +53,7 @@ desired:
               image:
                 repository: bitnami/redis
                 tag: dummy
-              master:
+              replica:
                 containerSecurityContext:
                   enabled: true
                 persistence:

--- a/test/functions/vshnredis/restore/01-GivenRestoreConfigNoBN.yaml
+++ b/test/functions/vshnredis/restore/01-GivenRestoreConfigNoBN.yaml
@@ -39,7 +39,7 @@ desired:
               image:
                 repository: bitnami/redis
                 tag: dummy
-              master:
+              replica:
                 containerSecurityContext:
                   enabled: true
                 persistence:

--- a/test/functions/vshnredis/restore/01-GivenRestoreConfigNoCN.yaml
+++ b/test/functions/vshnredis/restore/01-GivenRestoreConfigNoCN.yaml
@@ -39,7 +39,7 @@ desired:
               image:
                 repository: bitnami/redis
                 tag: dummy
-              master:
+              replica:
                 containerSecurityContext:
                   enabled: true
                 persistence:


### PR DESCRIPTION
## Summary

* This fixes the restore and resize procedures by updating script references to the new naming convention. Previously, scripts pointed to the old names and failed.

## Checklist

- [x] Update tests.
- [x] Link this PR to related issues.
- [ ] Merge with `/merge` comment.


Component PR: https://github.com/vshn/component-appcat/pull/858