### PR TITLE
Helm Chart updates August 2025

### DIFF
--- a/apis/vshn/v1/dbaas_vshn_forgejo.go
+++ b/apis/vshn/v1/dbaas_vshn_forgejo.go
@@ -99,8 +99,8 @@ type VSHNForgejoServiceSpec struct {
 	ServiceLevel VSHNDBaaSServiceLevel `json:"serviceLevel,omitempty"`
 
 	// Version contains supported version of Forgejo.
-	// Multiple versions are supported. Defaults to 11.0.0 if not set.
-	// +kubebuilder:default="11.0.0"
+	// Multiple versions are supported. Defaults to 12.0.0 if not set.
+	// +kubebuilder:default="12.0.0"
 	MajorVersion string `json:"majorVersion,omitempty"`
 }
 

--- a/apis/vshn/v1/dbaas_vshn_mariadb.go
+++ b/apis/vshn/v1/dbaas_vshn_mariadb.go
@@ -97,11 +97,11 @@ type VSHNMariaDBParameters struct {
 
 // VSHNMariaDBServiceSpec contains MariaDB DBaaS specific properties
 type VSHNMariaDBServiceSpec struct {
-	// +kubebuilder:validation:Enum="10.4";"10.5";"10.6";"10.9";"10.10";"10.11";"11.0";"11.1";"11.2";"11.3";"11.4";"11.5";
-	// +kubebuilder:default="11.5"
+	// +kubebuilder:validation:Enum="10.4";"10.5";"10.6";"10.9";"10.10";"10.11";"11.0";"11.1";"11.2";"11.3";"11.4";"11.5";"11.8"
+	// +kubebuilder:default="11.8"
 
 	// Version contains supported version of MariaDB.
-	// Multiple versions are supported. The latest version "11.5" is the default version.
+	// Multiple versions are supported. The latest version "11.8" is the default version.
 	Version string `json:"version,omitempty"`
 
 	// MariadbSettings contains additional MariaDB settings.

--- a/apis/vshn/v1/dbaas_vshn_redis.go
+++ b/apis/vshn/v1/dbaas_vshn_redis.go
@@ -91,7 +91,7 @@ type VSHNRedisServiceSpec struct {
 	// +kubebuilder:default="7.2"
 
 	// Version contains supported version of Redis.
-	// Multiple versions are supported. The latest version "7.0" is the default version.
+	// Multiple versions are supported. The latest version "7.2" is the default version.
 	Version string `json:"version,omitempty"`
 
 	// RedisSettings contains additional Redis settings.

--- a/apis/vshn/v1/vshn_nextcloud.go
+++ b/apis/vshn/v1/vshn_nextcloud.go
@@ -117,10 +117,10 @@ type VSHNNextcloudServiceSpec struct {
 	// +kubebuilder:default="/"
 	RelativePath string `json:"relativePath,omitempty"`
 
-	// +kubebuilder:default="30"
+	// +kubebuilder:default="31"
 
 	// Version contains supported version of nextcloud.
-	// Multiple versions are supported. The latest version 30 is the default version.
+	// Multiple versions are supported. The latest version 31 is the default version.
 	Version string `json:"version,omitempty"`
 
 	// +kubebuilder:validation:Enum="besteffort";"guaranteed"

--- a/pkg/comp-functions/functions/vshnforgejo/deploy.go
+++ b/pkg/comp-functions/functions/vshnforgejo/deploy.go
@@ -173,10 +173,10 @@ func addForgejo(ctx context.Context, svc *runtime.ServiceRuntime, comp *vshnv1.V
 		"postgresql-ha": map[string]any{
 			"enabled": false,
 		},
-		"redis": map[string]any{
+		"valkey": map[string]any{
 			"enabled": false,
 		},
-		"redis-cluster": map[string]any{
+		"valkey-cluster": map[string]any{
 			"enabled": false,
 		},
 		"strategy": map[string]any{


### PR DESCRIPTION
## Summary

* Updated charts: Redis, MariaDB, Nextcloud, Forgejo
* New default versions for Nextcloud, Forgejo and MariaDB

## Checklist

- [ ] Update tests.
- [ ] Link this PR to related issues.
- [ ] Merge with `/merge` comment.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
