### PR TITLE
Fix bug in UserManagement if username != dbname

### DIFF
--- a/pkg/comp-functions/functions/vshnpostgres/user_management_test.go
+++ b/pkg/comp-functions/functions/vshnpostgres/user_management_test.go
@@ -80,12 +80,29 @@ func Test_addDatabase(t *testing.T) {
 	comp := &vshnv1.VSHNPostgreSQL{}
 	assert.NoError(t, svc.GetObservedComposite(comp))
 
-	addDatabase(comp, svc, "unit")
+	addDatabase(comp, svc, "unit", "unit")
 
 	// then
 	db := &pgv1alpha1.Database{}
 	assert.NoError(t, svc.GetDesiredComposedResourceByName(db, fmt.Sprintf("%s-%s-database", comp.GetName(), "unit")))
+	assert.Equal(t, *db.Spec.ForProvider.Owner, "unit")
+}
 
+func Test_addDatabaseAndUser(t *testing.T) {
+	// given
+	svc := commontest.LoadRuntimeFromFile(t, "vshn-postgres/usermanagement/01-emptyaccess.yaml")
+
+	// when
+	comp := &vshnv1.VSHNPostgreSQL{}
+	assert.NoError(t, svc.GetObservedComposite(comp))
+
+	addUser(comp, svc, "myUser")
+	addDatabase(comp, svc, "myUser", "myDB")
+
+	// then
+	db := &pgv1alpha1.Database{}
+	assert.NoError(t, svc.GetDesiredComposedResourceByName(db, fmt.Sprintf("%s-%s-database", comp.GetName(), "myDB")))
+	assert.Equal(t, *db.Spec.ForProvider.Owner, "myUser")
 }
 
 func Test_addGrants(t *testing.T) {


### PR DESCRIPTION
## Summary

This commit fixes a bug in the usermanagement feature when the username is different from the dbname.
The bug resulted in a wrong owner of the database.

## Checklist

- [x] Update tests.
- [ ] Link this PR to related issues.
- [x] Merge with `/merge` comment.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->


Component PR: https://github.com/vshn/component-appcat/pull/868