### PR TITLE
Trigger release in pre-release workflow

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -85,6 +85,13 @@ jobs:
           git push origin $NEW_TAG
           echo "new_tag=$NEW_TAG" >> $GITHUB_OUTPUT
 
+      - name: Trigger Release Workflow
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ env.APPCAT_REPO }}
+          event-type: trigger-release
+          client-payload: '{"tag": "${{ steps.bump.outputs.new_tag }}"}'
 
   create-component-release-pr:
     needs: create-and-merge-appcat-pr
@@ -132,4 +139,3 @@ jobs:
             --body "This PR updates the version in defaults.yaml and regenerates golden files."
         env:
           GH_TOKEN: ${{ secrets.COMPONENT_ACCESS_TOKEN }}
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,12 +4,8 @@ on:
   push:
     tags:
       - "*"
-  workflow_dispatch:
-    inputs:
-      tag:
-        description: 'Tag to release'
-        required: true
-        type: string
+  repository_dispatch:
+    types: [trigger-release]
 
 env:
   APP_NAME: appcat
@@ -26,6 +22,16 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          # Checkout the specific tag when triggered by repository_dispatch
+          ref: ${{ github.event_name == 'repository_dispatch' && github.event.client_payload.tag || github.ref }}
+
+      - name: Set tag variable
+        run: |
+          if [ "${{ github.event_name }}" == "repository_dispatch" ]; then
+            echo "TAG=${{ github.event.client_payload.tag }}" >> $GITHUB_ENV
+          else
+            echo "TAG=${GITHUB_REF##*/}" >> $GITHUB_ENV
+          fi
 
       - name: Determine Go version from go.mod
         run: echo "GO_VERSION=$(grep "go 1." go.mod | cut -d " " -f 2)" >> $GITHUB_ENV
@@ -56,11 +62,11 @@ jobs:
 
       - name: Push docker image
         if: env.PUSH_IMAGE == 'true'
-        run: make docker-push -e IMG_TAG=${GITHUB_REF##*/} -e APP_NAME=${{ env.APP_NAME }}
+        run: make docker-push -e IMG_TAG=${{ env.TAG }} -e APP_NAME=${{ env.APP_NAME }}
 
       - name: Build and push function package
         if: env.PUSH_PACKAGE == 'true'
-        run: make package-push -e IMG_TAG=${GITHUB_REF##*/} -e APP_NAME=${{ env.APP_NAME }}
+        run: make package-push -e IMG_TAG=${{ env.TAG }} -e APP_NAME=${{ env.APP_NAME }}
 
       - name: Login to Upbound
         if: env.PUSH_UPBOUND == 'true'
@@ -72,7 +78,7 @@ jobs:
 
       - name: Build branch and push package to upbound
         if: env.PUSH_UPBOUND == 'true' && env.PUSH_PACKAGE == 'true'
-        run: make package-push -e IMG_TAG=${GITHUB_REF##*/} -e APP_NAME=${{ env.APP_NAME }} -e IMG_REPO=xpkg.upbound.io
+        run: make package-push -e IMG_TAG=${{ env.TAG }} -e APP_NAME=${{ env.APP_NAME }} -e IMG_REPO=xpkg.upbound.io
 
       - name: Build changelog from PRs with labels
         id: build_changelog
@@ -82,8 +88,9 @@ jobs:
           # PreReleases still get a changelog, but the next full release gets a diff since the last full release,
           # combining possible changelogs of all previous PreReleases in between. PreReleases show a partial changelog
           # since last PreRelease.
-          ignorePreReleases: "${{ !contains(github.ref, '-rc') }}"
+          ignorePreReleases: "${{ !contains(env.TAG, '-rc') }}"
           outputFile: .github/release-notes.md
+          toTag: ${{ env.TAG }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -95,4 +102,3 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CONTAINER_REGISTRY: ghcr.io
           IMAGE_NAME: ${{ github.repository }}${{ env.SUFFIX }}
-


### PR DESCRIPTION
## Summary

* GITHUB_ACTION token cannot trigger the Release workflow due to security reasons. We need another step to explicetly trigger a release otherwise during scheduled release only a tag will be created. This PR addressed this issue.

## Checklist

- [ ] Update tests.
- [ ] Link this PR to related issues.
- [ ] Merge with `/merge` comment.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->


Component PR: https://github.com/vshn/component-appcat/pull/874