### PR TITLE
Validate VSHNPG encryption state

### DIFF
--- a/pkg/controller/webhooks/keycloak_test.go
+++ b/pkg/controller/webhooks/keycloak_test.go
@@ -1,11 +1,16 @@
 package webhooks
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
+	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	vshnv1 "github.com/vshn/appcat/v4/apis/vshn/v1"
+	"github.com/vshn/appcat/v4/pkg"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func Test_validateCustomFilePaths(t *testing.T) {
@@ -69,4 +74,90 @@ func Test_validateCustomFilePaths(t *testing.T) {
 			},
 		},
 	))
+}
+
+func TestKeycloakWebhookHandler_ValidatePostgreSQLEncryptionChanges(t *testing.T) {
+	ctx := context.TODO()
+	fclient := fake.NewClientBuilder().
+		WithScheme(pkg.SetupScheme()).
+		Build()
+
+	handler := KeycloakWebhookHandler{
+		DefaultWebhookHandler: DefaultWebhookHandler{
+			client:    fclient,
+			log:       logr.Discard(),
+			withQuota: false,
+			obj:       &vshnv1.VSHNKeycloak{},
+			name:      "keycloak",
+		},
+	}
+
+	// Test 1: Same encryption state should be valid
+	keycloakOrig := &vshnv1.VSHNKeycloak{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "myinstance",
+			Namespace: "testns",
+		},
+		Spec: vshnv1.VSHNKeycloakSpec{
+			Parameters: vshnv1.VSHNKeycloakParameters{
+				Service: vshnv1.VSHNKeycloakServiceSpec{
+					PostgreSQLParameters: &vshnv1.VSHNPostgreSQLParameters{
+						Encryption: vshnv1.VSHNPostgreSQLEncryption{
+							Enabled: false,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	keycloakUpdated := keycloakOrig.DeepCopy()
+	// No changes to encryption state
+
+	_, err := handler.ValidateUpdate(ctx, keycloakOrig, keycloakUpdated)
+	assert.NoError(t, err)
+
+	// Test 2: Enabling encryption after creation should fail
+	keycloakEncryptionEnabled := keycloakOrig.DeepCopy()
+	keycloakEncryptionEnabled.Spec.Parameters.Service.PostgreSQLParameters.Encryption.Enabled = true
+
+	_, err = handler.ValidateUpdate(ctx, keycloakOrig, keycloakEncryptionEnabled)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "encryption setting cannot be changed after instance creation")
+
+	// Test 3: Disabling encryption after creation should fail
+	keycloakOrigEncrypted := keycloakOrig.DeepCopy()
+	keycloakOrigEncrypted.Spec.Parameters.Service.PostgreSQLParameters.Encryption.Enabled = true
+
+	keycloakEncryptionDisabled := keycloakOrigEncrypted.DeepCopy()
+	keycloakEncryptionDisabled.Spec.Parameters.Service.PostgreSQLParameters.Encryption.Enabled = false
+
+	_, err = handler.ValidateUpdate(ctx, keycloakOrigEncrypted, keycloakEncryptionDisabled)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "encryption setting cannot be changed after instance creation")
+
+	// Test 4: Same encryption state (enabled) should be valid
+	keycloakSameEncryption := keycloakOrigEncrypted.DeepCopy()
+	// No changes to encryption state
+
+	_, err = handler.ValidateUpdate(ctx, keycloakOrigEncrypted, keycloakSameEncryption)
+	assert.NoError(t, err)
+
+	// Test 5: No PostgreSQL parameters should be valid
+	keycloakNoPostgreSQL := &vshnv1.VSHNKeycloak{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "myinstance",
+			Namespace: "testns",
+		},
+		Spec: vshnv1.VSHNKeycloakSpec{
+			Parameters: vshnv1.VSHNKeycloakParameters{
+				Service: vshnv1.VSHNKeycloakServiceSpec{
+					// No PostgreSQLParameters
+				},
+			},
+		},
+	}
+
+	_, err = handler.ValidateUpdate(ctx, keycloakNoPostgreSQL, keycloakNoPostgreSQL)
+	assert.NoError(t, err)
 }


### PR DESCRIPTION
## Summary

- Implemented controller functionality to ensure the pg encryption can't be changed after an instance has been created

## Checklist

- [x] Update tests.
- [ ] Link this PR to related issues.
- [ ] Merge with `/merge` comment.

Component PR: https://github.com/vshn/component-appcat/pull/876