### PR TITLE
Expand maintenance window

### DIFF
--- a/pkg/comp-functions/functions/common/schedule.go
+++ b/pkg/comp-functions/functions/common/schedule.go
@@ -26,12 +26,26 @@ type MaintenanceScheduler interface {
 	GetMaintenanceTimeOfDay() *v1.TimeOfDay
 }
 
-// SetRandomSchedules initializes the backup and maintenance schedules  if the user did not explicitly provide a schedule.
-// The maintenance will be set to a random time on Tuesday night between 21:00 and 5:00, and the backup schedule will be set to once a day between 20:00 and 4:00.
+// SetRandomSchedules initializes the backup and maintenance schedules if the user did not explicitly provide a schedule.
+// The maintenance will be set to a random time on a random day (Sunday-Friday) between 21:00 and 5:00,
+// with the exception that Sunday maintenance only runs after 21:00 (not in the early morning hours).
+// The backup schedule will be set to once a day between 20:00 and 4:00.
 // If neither maintenance nor backup is set, the function will make sure that there will be backup scheduled one hour before the maintenance.
 func SetRandomSchedules(backup BackupScheduler, maintenance MaintenanceScheduler) {
 	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	availableDays := []string{"sunday", "monday", "tuesday", "wednesday", "thursday", "friday"}
+	selectedDay := availableDays[rng.Intn(len(availableDays))]
 	maintTime := time.Unix(maitenanceWindowStart.Unix()+rng.Int63n(maitenanceWindowRange), 0).In(time.UTC)
+
+	// Special handling for Sunday: only allow times after 21:00 (not early morning)
+	if selectedDay == "sunday" && maintTime.Hour() < 21 {
+		// If time is in early morning (0-5), shift to evening (21-23)
+		eveningStart := time.Date(1970, 1, 1, 21, 0, 0, 0, time.UTC)
+		eveningEnd := time.Date(1970, 1, 1, 23, 59, 59, 0, time.UTC)
+		eveningRange := eveningEnd.Unix() - eveningStart.Unix()
+		maintTime = time.Unix(eveningStart.Unix()+rng.Int63n(eveningRange), 0).In(time.UTC)
+	}
+
 	backupTime := maintTime.Add(-1 * time.Hour).In(time.UTC)
 
 	if backup.GetBackupSchedule() == "" {
@@ -45,10 +59,6 @@ func SetRandomSchedules(backup BackupScheduler, maintenance MaintenanceScheduler
 	}
 
 	if maintenance.GetMaintenanceDayOfWeek() == "" {
-		day := "tuesday"
-		if maintTime.Day() > 1 {
-			day = "wednesday"
-		}
-		maintenance.SetMaintenanceDayOfWeek(day)
+		maintenance.SetMaintenanceDayOfWeek(selectedDay)
 	}
 }

--- a/pkg/comp-functions/functions/common/schedule.go
+++ b/pkg/comp-functions/functions/common/schedule.go
@@ -9,9 +9,9 @@ import (
 )
 
 var (
-	maitenanceWindowStart = time.Date(1970, 1, 1, 21, 0, 0, 0, time.UTC)
-	maitenanceWindowEnd   = time.Date(1970, 1, 2, 5, 0, 0, 0, time.UTC)
-	maitenanceWindowRange = maitenanceWindowEnd.Unix() - maitenanceWindowStart.Unix()
+	maintenanceWindowStart = time.Date(1970, 1, 1, 21, 0, 0, 0, time.UTC)
+	maintenanceWindowEnd   = time.Date(1970, 1, 2, 5, 0, 0, 0, time.UTC)
+	maintenanceWindowRange = maintenanceWindowEnd.Unix() - maintenanceWindowStart.Unix()
 )
 
 // BackupScheduler can schedule backups
@@ -35,7 +35,7 @@ func SetRandomSchedules(backup BackupScheduler, maintenance MaintenanceScheduler
 	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
 	availableDays := []string{"sunday", "monday", "tuesday", "wednesday", "thursday", "friday"}
 	selectedDay := availableDays[rng.Intn(len(availableDays))]
-	maintTime := time.Unix(maitenanceWindowStart.Unix()+rng.Int63n(maitenanceWindowRange), 0).In(time.UTC)
+	maintTime := time.Unix(maintenanceWindowStart.Unix()+rng.Int63n(maintenanceWindowRange), 0).In(time.UTC)
 
 	// Special handling for Sunday: only allow times after 21:00 (not early morning)
 	if selectedDay == "sunday" && maintTime.Hour() < 21 {

--- a/pkg/comp-functions/functions/common/schedule_test.go
+++ b/pkg/comp-functions/functions/common/schedule_test.go
@@ -1,0 +1,317 @@
+package common
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	v1 "github.com/vshn/appcat/v4/apis/vshn/v1"
+)
+
+// Test implementations that use real types
+type testBackupScheduler struct {
+	schedule string
+}
+
+func (t *testBackupScheduler) GetBackupSchedule() string {
+	return t.schedule
+}
+
+func (t *testBackupScheduler) SetBackupSchedule(schedule string) {
+	t.schedule = schedule
+}
+
+type testMaintenanceScheduler struct {
+	dayOfWeek string
+	timeOfDay v1.TimeOfDay
+}
+
+func (t *testMaintenanceScheduler) GetMaintenanceDayOfWeek() string {
+	return t.dayOfWeek
+}
+
+func (t *testMaintenanceScheduler) SetMaintenanceDayOfWeek(day string) {
+	t.dayOfWeek = day
+}
+
+func (t *testMaintenanceScheduler) GetMaintenanceTimeOfDay() *v1.TimeOfDay {
+	return &t.timeOfDay
+}
+
+func TestSetRandomSchedules_EmptySchedules(t *testing.T) {
+	backup := &testBackupScheduler{}
+	maintenance := &testMaintenanceScheduler{}
+
+	SetRandomSchedules(backup, maintenance)
+
+	// Test that backup schedule is set
+	if backup.GetBackupSchedule() == "" {
+		t.Error("Expected backup schedule to be set, but it was empty")
+	}
+
+	// Test that maintenance day is set to one of the valid days
+	validDays := map[string]bool{
+		"sunday": true, "monday": true, "tuesday": true,
+		"wednesday": true, "thursday": true, "friday": true,
+	}
+	day := maintenance.GetMaintenanceDayOfWeek()
+	if !validDays[day] {
+		t.Errorf("Expected maintenance day to be one of [sunday, monday, tuesday, wednesday, thursday, friday], got: %s", day)
+	}
+
+	// Test that maintenance time is set
+	timeOfDay := maintenance.GetMaintenanceTimeOfDay()
+	if timeOfDay.IsNotSet() {
+		t.Error("Expected maintenance time to be set, but it was not")
+	}
+}
+
+func TestSetRandomSchedules_PresetBackupSchedule(t *testing.T) {
+	existingSchedule := "30 2 * * *"
+	backup := &testBackupScheduler{schedule: existingSchedule}
+	maintenance := &testMaintenanceScheduler{}
+
+	SetRandomSchedules(backup, maintenance)
+
+	// Test that existing backup schedule is preserved
+	if backup.GetBackupSchedule() != existingSchedule {
+		t.Errorf("Expected backup schedule to remain unchanged as '%s', got: '%s'", existingSchedule, backup.GetBackupSchedule())
+	}
+
+	// Test that maintenance is still set
+	if maintenance.GetMaintenanceDayOfWeek() == "" {
+		t.Error("Expected maintenance day to be set")
+	}
+}
+
+func TestSetRandomSchedules_PresetMaintenanceDay(t *testing.T) {
+	existingDay := "monday"
+	backup := &testBackupScheduler{}
+	maintenance := &testMaintenanceScheduler{dayOfWeek: existingDay}
+
+	SetRandomSchedules(backup, maintenance)
+
+	// Test that existing maintenance day is preserved
+	if maintenance.GetMaintenanceDayOfWeek() != existingDay {
+		t.Errorf("Expected maintenance day to remain unchanged as '%s', got: '%s'", existingDay, maintenance.GetMaintenanceDayOfWeek())
+	}
+
+	// Test that backup schedule is still set
+	if backup.GetBackupSchedule() == "" {
+		t.Error("Expected backup schedule to be set")
+	}
+}
+
+func TestSetRandomSchedules_PresetMaintenanceTime(t *testing.T) {
+	backup := &testBackupScheduler{}
+	maintenance := &testMaintenanceScheduler{}
+
+	// Pre-set the maintenance time
+	presetTime := time.Date(2023, 1, 1, 22, 30, 0, 0, time.UTC)
+	maintenance.timeOfDay.SetTime(presetTime)
+
+	SetRandomSchedules(backup, maintenance)
+
+	// Test that existing maintenance time is preserved
+	timeOfDay := maintenance.GetMaintenanceTimeOfDay()
+	if timeOfDay.IsNotSet() {
+		t.Error("Expected maintenance time to remain set")
+	}
+
+	// Test that backup schedule and maintenance day are still set
+	if backup.GetBackupSchedule() == "" {
+		t.Error("Expected backup schedule to be set")
+	}
+	if maintenance.GetMaintenanceDayOfWeek() == "" {
+		t.Error("Expected maintenance day to be set")
+	}
+}
+
+func TestSetRandomSchedules_MaintenanceTimeWindow(t *testing.T) {
+	// Run the test multiple times to check randomness
+	for i := 0; i < 100; i++ {
+		backup := &testBackupScheduler{}
+		maintenance := &testMaintenanceScheduler{}
+
+		SetRandomSchedules(backup, maintenance)
+
+		// Extract hour from the maintenance time
+		// We need to check the actual time that was set
+		timeOfDay := maintenance.GetMaintenanceTimeOfDay()
+		if timeOfDay.IsNotSet() {
+			t.Error("Maintenance time should be set")
+			continue
+		}
+
+		day := maintenance.GetMaintenanceDayOfWeek()
+
+		// Parse the backup schedule to get the maintenance time
+		// Since backup is 1 hour before maintenance, we can calculate maintenance time
+		backupSchedule := backup.GetBackupSchedule()
+		parts := strings.Fields(backupSchedule)
+		if len(parts) < 2 {
+			t.Errorf("Invalid backup schedule format: %s", backupSchedule)
+			continue
+		}
+
+		backupHour, err := strconv.Atoi(parts[1])
+		if err != nil {
+			t.Errorf("Invalid backup hour: %s", parts[1])
+			continue
+		}
+
+		// Calculate maintenance hour (1 hour after backup)
+		maintHour := (backupHour + 1) % 24
+
+		// Check if maintenance time is within the valid window
+		// For Sunday: only 21:00-23:59 (no early morning)
+		// For other days: 21:00-23:59 or 00:00-04:59
+		var validTime bool
+		if day == "sunday" {
+			validTime = maintHour >= 21 && maintHour <= 23
+		} else {
+			validTime = (maintHour >= 21 && maintHour <= 23) || (maintHour >= 0 && maintHour <= 4)
+		}
+
+		if !validTime {
+			if day == "sunday" {
+				t.Errorf("Sunday maintenance time %d:xx is outside the valid window (21:00-23:59)", maintHour)
+			} else {
+				t.Errorf("Maintenance time %d:xx on %s is outside the valid window (21:00-05:00)", maintHour, day)
+			}
+		}
+	}
+}
+
+func TestSetRandomSchedules_BackupOneHourBeforeMaintenance(t *testing.T) {
+	backup := &testBackupScheduler{}
+	maintenance := &testMaintenanceScheduler{}
+
+	SetRandomSchedules(backup, maintenance)
+
+	// Parse the backup schedule (format: "minute hour * * *")
+	backupSchedule := backup.GetBackupSchedule()
+	parts := strings.Fields(backupSchedule)
+	if len(parts) < 2 {
+		t.Fatalf("Invalid backup schedule format: %s", backupSchedule)
+	}
+
+	backupMinute, err := strconv.Atoi(parts[0])
+	if err != nil {
+		t.Fatalf("Invalid backup minute: %s", parts[0])
+	}
+
+	backupHour, err := strconv.Atoi(parts[1])
+	if err != nil {
+		t.Fatalf("Invalid backup hour: %s", parts[1])
+	}
+
+	// The maintenance should be exactly 1 hour after backup
+	expectedMaintHour := (backupHour + 1) % 24
+	expectedMaintMinute := backupMinute
+
+	// Verify the relationship exists (we can't directly get maintenance time from v1.TimeOfDay easily,
+	// but we can verify the schedule format is correct)
+	if backupSchedule == "" {
+		t.Error("Backup schedule should not be empty")
+	}
+
+	// Test that the format is correct (minute hour * * *)
+	if len(parts) != 5 || parts[2] != "*" || parts[3] != "*" || parts[4] != "*" {
+		t.Errorf("Expected backup schedule format 'minute hour * * *', got: %s", backupSchedule)
+	}
+
+	t.Logf("Backup scheduled at %d:%02d, maintenance should be at %d:%02d",
+		backupHour, backupMinute, expectedMaintHour, expectedMaintMinute)
+}
+
+func TestSetRandomSchedules_SundayTimeRestriction(t *testing.T) {
+	sundayCount := 0
+	iterations := 1000
+
+	// Run many iterations to specifically test Sunday scheduling
+	for i := 0; i < iterations; i++ {
+		backup := &testBackupScheduler{}
+		maintenance := &testMaintenanceScheduler{}
+
+		SetRandomSchedules(backup, maintenance)
+
+		if maintenance.GetMaintenanceDayOfWeek() == "sunday" {
+			sundayCount++
+
+			// Parse backup schedule to determine maintenance time
+			backupSchedule := backup.GetBackupSchedule()
+			parts := strings.Fields(backupSchedule)
+			if len(parts) >= 2 {
+				backupHour, err := strconv.Atoi(parts[1])
+				if err == nil {
+					maintHour := (backupHour + 1) % 24
+
+					// Sunday maintenance should only be between 21:00-23:59
+					if maintHour < 21 {
+						t.Errorf("Sunday maintenance scheduled at %d:xx, but should only be after 21:00", maintHour)
+					}
+				}
+			}
+		}
+	}
+
+	// Ensure we actually tested some Sunday cases
+	if sundayCount == 0 {
+		t.Errorf("No Sunday maintenance was scheduled in %d iterations", iterations)
+	}
+
+	t.Logf("Tested %d Sunday maintenance schedules out of %d total iterations", sundayCount, iterations)
+}
+
+func TestSetRandomSchedules_DayDistribution(t *testing.T) {
+	dayCount := make(map[string]int)
+	iterations := 1000
+
+	// Run many iterations to test day distribution
+	for i := 0; i < iterations; i++ {
+		backup := &testBackupScheduler{}
+		maintenance := &testMaintenanceScheduler{}
+
+		SetRandomSchedules(backup, maintenance)
+		day := maintenance.GetMaintenanceDayOfWeek()
+		dayCount[day]++
+	}
+
+	// Check that all expected days are present
+	expectedDays := []string{"sunday", "monday", "tuesday", "wednesday", "thursday", "friday"}
+	for _, day := range expectedDays {
+		if dayCount[day] == 0 {
+			t.Errorf("Day '%s' was never selected in %d iterations", day, iterations)
+		}
+	}
+
+	// Check that no unexpected days are present
+	for day := range dayCount {
+		found := false
+		for _, expectedDay := range expectedDays {
+			if day == expectedDay {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("Unexpected day '%s' was selected", day)
+		}
+	}
+
+	// Check that distribution is reasonably uniform (each day should appear at least 10% of the time)
+	minExpected := iterations / 10
+	for day, count := range dayCount {
+		if count < minExpected {
+			t.Errorf("Day '%s' appeared only %d times out of %d iterations (expected at least %d)", day, count, iterations, minExpected)
+		}
+	}
+
+	// Log the distribution for visibility
+	t.Log("Day distribution:")
+	for _, day := range expectedDays {
+		t.Logf("  %s: %d times (%.1f%%)", day, dayCount[day], float64(dayCount[day])/float64(iterations)*100)
+	}
+}

--- a/pkg/comp-functions/functions/vshnpostgres/schedule_test.go
+++ b/pkg/comp-functions/functions/vshnpostgres/schedule_test.go
@@ -151,18 +151,37 @@ func parseAndValidateMaintenance(t *testing.T, comp *vshnv1.VSHNPostgreSQL) time
 		maintTime, err = time.ParseInLocation(time.TimeOnly, string(comp.GetFullMaintenanceSchedule().TimeOfDay), time.UTC)
 		assert.NoError(t, err)
 		assert.NotEmpty(t, comp.GetFullMaintenanceSchedule().DayOfWeek)
-		switch comp.GetFullMaintenanceSchedule().DayOfWeek {
-		case "tuesday":
-		case "wednesday":
-			maintTime = maintTime.Add(24 * time.Hour)
-		default:
-			assert.Failf(t, "unexpected Maintenance day", "Day: %q", comp.GetFullMaintenanceSchedule().DayOfWeek)
+
+		// Updated to support Sunday through Friday
+		dayOfWeek := comp.GetFullMaintenanceSchedule().DayOfWeek
+		validDays := map[string]bool{
+			"sunday": true, "monday": true, "tuesday": true,
+			"wednesday": true, "thursday": true, "friday": true,
 		}
 
-		maintWindowStart := time.Date(0, 1, 1, 21, 0, 0, 0, time.UTC)
-		maintWindowEnd := time.Date(0, 1, 2, 5, 0, 0, 0, time.UTC)
-		assert.LessOrEqual(t, maintWindowStart, maintTime)
-		assert.LessOrEqual(t, maintTime, maintWindowEnd)
+		if !validDays[dayOfWeek] {
+			assert.Failf(t, "unexpected Maintenance day", "Day: %q", dayOfWeek)
+			return
+		}
+
+		if maintTime.Hour() < 6 {
+			maintTime = maintTime.Add(24 * time.Hour)
+		}
+
+		// Updated time window validation based on day
+		if dayOfWeek == "sunday" {
+			// Sunday: only 21:00-23:59 (no early morning)
+			sundayWindowStart := time.Date(0, 1, 1, 21, 0, 0, 0, time.UTC)
+			sundayWindowEnd := time.Date(0, 1, 1, 23, 59, 59, 0, time.UTC)
+			assert.LessOrEqual(t, sundayWindowStart, maintTime)
+			assert.LessOrEqual(t, maintTime, sundayWindowEnd)
+		} else {
+			// Monday-Friday: 21:00-05:00 (can cross midnight)
+			maintWindowStart := time.Date(0, 1, 1, 21, 0, 0, 0, time.UTC)
+			maintWindowEnd := time.Date(0, 1, 2, 5, 0, 0, 0, time.UTC)
+			assert.LessOrEqual(t, maintWindowStart, maintTime)
+			assert.LessOrEqual(t, maintTime, maintWindowEnd)
+		}
 	})
 	return maintTime
 }


### PR DESCRIPTION
## Summary

* We should not configure maintenance and backup only on Tuesday to Wednesday. For security reasons we should expand further the window
** from Sunday (starting 21:00) to Friday
** Window 21:00 - 05:00


## Checklist

- [ ] Update tests.
- [ ] Link this PR to related issues.
- [ ] Merge with `/merge` comment.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->


Component PR: https://github.com/vshn/component-appcat/pull/877