### PR TITLE
Removed omitempty from default=true boolean fields

### DIFF
--- a/apis/vshn/v1/common_types.go
+++ b/apis/vshn/v1/common_types.go
@@ -196,7 +196,8 @@ type Security struct {
 
 	// DeletionProtection blocks the deletion of the instance if it is enabled (enabled by default)
 	// +kubebuilder:default=true
-	DeletionProtection bool `json:"deletionProtection,omitempty"`
+	// +kubebuilder:validation:Optional
+	DeletionProtection bool `json:"deletionProtection"`
 
 	// AllowedGroups defines a list of Groups that have limited access to the instance namespace
 	AllowedGroups []string `json:"allowedGroups,omitempty"`

--- a/apis/vshn/v1/dbaas_vshn_postgresql.go
+++ b/apis/vshn/v1/dbaas_vshn_postgresql.go
@@ -186,7 +186,8 @@ type VSHNPostgreSQLBackup struct {
 	// DeletionProtection will protect the instance from being deleted for the given retention time.
 	// This is enabled by default.
 	// +kubebuilder:default=true
-	DeletionProtection *bool `json:"deletionProtection,omitempty"`
+	// +kubebuilder:validation:Optional
+	DeletionProtection *bool `json:"deletionProtection"`
 
 	// DeletionRetention specifies in days how long the instance should be kept after deletion.
 	// The default is keeping it one week.


### PR DESCRIPTION
## Summary

Fixes an issue where boolean fields with omitempty and default=true could not be set to false via YAML. The YAML serializer would omit false values due to the omitempty tag, causing them to be interpreted as the default true value instead.

## Checklist

- [ ] Merge with `/merge` comment.



Component PR: https://github.com/vshn/component-appcat/pull/879