### PR TITLE
Fixed long startup times on nextcloud via security contexts

### DIFF
--- a/pkg/comp-functions/functions/vshnnextcloud/deploy.go
+++ b/pkg/comp-functions/functions/vshnnextcloud/deploy.go
@@ -445,6 +445,7 @@ func newValues(ctx context.Context, svc *runtime.ServiceRuntime, comp *vshnv1.VS
 		return nil, fmt.Errorf("cannot determine if this is an OpenShift cluster or not: %w", err)
 	}
 	securityContext := map[string]any{}
+	podSecurityContext := map[string]any{}
 	if isOpenShift {
 		securityContext = map[string]any{
 			"runAsUser":                nil,
@@ -453,6 +454,12 @@ func newValues(ctx context.Context, svc *runtime.ServiceRuntime, comp *vshnv1.VS
 				"drop": []string{
 					"ALL",
 				},
+			},
+		}
+		podSecurityContext = map[string]any{
+			"fsGroupChangePolicy": "OnRootMismatch",
+			"seLinuxOptions": map[string]any{
+				"type": "spc_t",
 			},
 		}
 	}
@@ -500,7 +507,7 @@ func newValues(ctx context.Context, svc *runtime.ServiceRuntime, comp *vshnv1.VS
 			},
 			"extraInitContainers": extraInitContainers,
 			"containerPort":       8080,
-			"podSecurityContext":  securityContext,
+			"podSecurityContext":  podSecurityContext,
 			"extraVolumes": []map[string]any{
 				{
 					"name": "apache-config",


### PR DESCRIPTION
## Summary

- Fixed a bug where Nextcloud startup times would be slow with a bunch of files in the PVC. See https://docs.appuio.cloud/user/how-to/long-pod-startup.html for more information on the bug.

## Checklist

- [ ] Update tests.
- [ ] Link this PR to related issues.
- [ ] Merge with `/merge` comment.

Component PR: https://github.com/vshn/component-appcat/pull/888