### PR TITLE
Fix some more bugs with user provisioning

### DIFF
--- a/pkg/comp-functions/functions/common/password.go
+++ b/pkg/comp-functions/functions/common/password.go
@@ -32,10 +32,22 @@ func AddCredentialsSecret(comp InfoGetter, svc *runtime.ServiceRuntime, fieldLis
 // This is helpful if multiple different random generated passwords are necessary.
 func AddGenericSecret(comp InfoGetter, svc *runtime.ServiceRuntime, suffix string, fieldList []string, allowDeletion bool, opts ...CredentialSecretOption) (string, error) {
 	secretObjectName := runtime.EscapeDNS1123(comp.GetName()+"-"+suffix, false)
+
 	secret := &corev1.Secret{}
 	cd := []xkube.ConnectionDetail{}
+
+	errObj := svc.GetObservedComposedResource(&xkube.Object{}, secretObjectName)
+
 	err := svc.GetObservedKubeObject(secret, secretObjectName)
-	if err == runtime.ErrNotFound {
+
+	// runtime.ErrNotFound for the secret alone isn't enough here to prevent re-creating passwords
+	// during provisioning it can happen that provider-kubernetes already applied a secret, but
+	// hasn't yet set the status. If the status of the object is empty, the runtime will
+	// also throw an ErrNotFound.
+	// So we also check for the existence of the `Object` itself from the observed state, by
+	// trying to get the object directly.
+	if err == runtime.ErrNotFound && errObj == runtime.ErrNotFound {
+
 		stringData := map[string]string{}
 
 		for _, field := range fieldList {
@@ -51,7 +63,7 @@ func AddGenericSecret(comp InfoGetter, svc *runtime.ServiceRuntime, suffix strin
 			},
 			StringData: stringData,
 		}
-	} else if err != nil {
+	} else if err != nil && err != runtime.ErrNotFound {
 		return secretObjectName, err
 	}
 

--- a/pkg/comp-functions/functions/vshnpostgres/user_management.go
+++ b/pkg/comp-functions/functions/vshnpostgres/user_management.go
@@ -110,6 +110,13 @@ func addUser(comp common.Composite, svc *runtime.ServiceRuntime, username string
 					Name: comp.GetName(),
 				},
 				ManagementPolicies: managementPoliciesWithoutDelete,
+				// we need to also write the connection details or the provider can't track
+				// password changes
+				// https://github.com/crossplane-contrib/provider-sql/issues/131
+				WriteConnectionSecretToReference: &xpv1.SecretReference{
+					Name:      secretName,
+					Namespace: svc.GetCrossplaneNamespace(),
+				},
 			},
 		},
 	}


### PR DESCRIPTION
## Summary

- MariaDB did not actually set a password at all
- Made the detection for the password secret more robust. It will now only regenerate if the `Object` itself doesn't exist.
- Provider-SQL requires a `writeConnectionSecretToRef` or password changes won't actually get applied.

Number 2 and 3 contributed to the problems where the password didn't actually match what got applied by provider-sql. I observed edge-cases where mutliple passwords got re-created during privsioning in such a way that provider-sql saw one password but the end user secret got another.

Due to the missing `writeConnectionSecretToRef` the provider never fixed drifted passwords by itself.

However, with the more robust detection there should not be any password re-creation in the first place.





## Checklist

- [ ] Update tests.
- [ ] Link this PR to related issues.
- [ ] Merge with `/merge` comment.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->


Component PR: https://github.com/vshn/component-appcat/pull/889