### PR TITLE
Fixed permission denied error for nextcloud backups

### DIFF
--- a/pkg/comp-functions/functions/vshnnextcloud/files/backup.sh
+++ b/pkg/comp-functions/functions/vshnnextcloud/files/backup.sh
@@ -2,19 +2,28 @@
 
 set -e
 
-# We need to run the occ command as the www-data user, but there's no sudo by default
-apt update 1>&2 && apt install sudo -y 1>&2
+# Determine if we need to switch users to run occ
+OCC_OWNER=$(stat -c '%U' /var/www/html/occ 2>/dev/null || echo "www-data")
+CURRENT_USER=$(whoami)
+
+run_occ() {
+  if [ "$CURRENT_USER" = "$OCC_OWNER" ]; then
+    /var/www/html/occ "$@"
+  else
+    runuser -u "$OCC_OWNER" -- /var/www/html/occ "$@"
+  fi
+}
 
 function disableMaintenance {
   >&2 echo "Disabling maintenance"
-  sudo -u www-data /var/www/html/occ maintenance:mode --off 1>&2
+  run_occ maintenance:mode --off 1>&2
 }
 
 if [ "$SKIP_MAINTENANCE" = false ]; then
 
   trap disableMaintenance EXIT
 
-  sudo -u www-data /var/www/html/occ maintenance:mode --on 1>&2
+  run_occ maintenance:mode --on 1>&2
 fi
 
 tar -cf - /var/www


### PR DESCRIPTION
## Summary

Removed `sudo` commands in the backup script of Nextcloud to fix permission errors on OpenShift and added a condition for non OpenShift environments. This is not needed on OpenShift since the user running the job is also the user who owns `occ`. `runuser` would fail there. 

```sh
ls -lah | grep occ
-rwxr-xr-x.  1 1001810000 1001810000  596 Aug 27 13:30 occ

whoami
1001810000
```

## Checklist

- [ ] Update tests.
- [ ] Link this PR to related issues.
- [ ] Merge with `/merge` comment.


Component PR: https://github.com/vshn/component-appcat/pull/894