### PR TITLE
Do not run PR workflow on automated release

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   check-allow-merge:
-    if: github.event.pull_request.base.ref != 'develop' || github.event.pull_request.head.ref != 'master'
+    if: github.event.pull_request.base.ref != 'develop' || github.event.pull_request.head.ref != 'master' && !contains(github.event.pull_request.labels.*.name, 'automated-release')
     runs-on: ubuntu-latest
     steps:
       # Labels in the context don't get updated so they are stuck at what's set during creation
@@ -33,7 +33,8 @@ jobs:
 
   check-labels:
     # Act doesn't set a pull request number by default, so we skip if it's 0
-    if: github.event.pull_request.number != 0 && (github.event.pull_request.base.ref != 'develop' || github.event.pull_request.head.ref != 'master')
+    # Skip if PR has automated-release label
+    if: github.event.pull_request.number != 0 && (github.event.pull_request.base.ref != 'develop' || github.event.pull_request.head.ref != 'master') && !contains(github.event.pull_request.labels.*.name, 'automated-release')
     name: Check labels
     runs-on: ubuntu-latest
     steps:
@@ -48,7 +49,8 @@ jobs:
           one_of: major,minor,patch,documentation,dependency
           repo_token: ${{ secrets.GITHUB_TOKEN }}
   publish-branch-images:
-    if: github.event.action != 'closed' && (github.event.pull_request.base.ref != 'develop' || github.event.pull_request.head.ref != 'master')
+    # Skip if PR has automated-release label
+    if: github.event.action != 'closed' && (github.event.pull_request.base.ref != 'develop' || github.event.pull_request.head.ref != 'master') && !contains(github.event.pull_request.labels.*.name, 'automated-release')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -106,8 +108,9 @@ jobs:
         run: make package-push-branchtag -e IMG_TAG="${{ steps.extract_branch.outputs.branch }}" -e IMG_REPO=xpkg.upbound.io
 
   open-pr-component:
+    # Skip if PR has automated-release label
+    if: github.event.pull_request.number != 0 && github.event.action == 'opened' && (github.event.pull_request.base.ref != 'develop' || github.event.pull_request.head.ref != 'master') && !contains(github.event.pull_request.labels.*.name, 'automated-release')
     runs-on: ubuntu-latest
-    if: github.event.pull_request.number != 0 && github.event.action == 'opened' && (github.event.pull_request.base.ref != 'develop' || github.event.pull_request.head.ref != 'master')
     steps:
       - name: Get current labels
         uses: snnaplab/get-labels-action@v1
@@ -170,7 +173,7 @@ jobs:
           labels: ignoreChangelog
 
   create-release:
-    if: github.event.pull_request.merged && github.base_ref == 'master'
+    if: github.event.pull_request.merged && github.base_ref == 'master' && !contains(github.event.pull_request.labels.*.name, 'automated-release')
     runs-on: ubuntu-latest
     steps:
       - name: Check for patch label

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -35,6 +35,7 @@ jobs:
             --head develop \
             --title "🔀 Merge develop into master (Release)" \
             --body "Auto-generated PR to release from develop to master." \
+            --label "automated-release" \
             || echo "PR already exists or failed"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -130,12 +131,14 @@ jobs:
           git push origin develop
 
       - name: Create PR in component repo
+        id: create_component_pr
         run: |
           gh pr create \
             --repo "$COMPONENT_REPO" \
             --base master \
             --head develop \
             --title "⬆️ Update appcat version to ${{ needs.create-and-merge-appcat-pr.outputs.new_tag }}" \
-            --body "This PR updates the version in defaults.yaml and regenerates golden files."
+            --body "This PR updates the version in defaults.yaml and regenerates golden files." \
+            --label "automated-release"
         env:
           GH_TOKEN: ${{ secrets.COMPONENT_ACCESS_TOKEN }}


### PR DESCRIPTION
## Summary

* Our pre release workflow is a bit broken. This fixes issue with the automated release PR workflow being triggered.

## Checklist

- [ ] Update tests.
- [ ] Link this PR to related issues.
- [ ] Merge with `/merge` comment.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->


Component PR: https://github.com/vshn/component-appcat/pull/913