### PR TITLE
Add nextcloud cron scc capability

### DIFF
--- a/pkg/comp-functions/functions/vshnnextcloud/deploy.go
+++ b/pkg/comp-functions/functions/vshnnextcloud/deploy.go
@@ -679,6 +679,13 @@ func configureCronSidecar(values map[string]interface{}, version string, svc *ru
 			"command": []any{
 				"/cron.sh",
 			},
+			"securityContext": map[string]interface{}{
+				"capabilities": map[string]interface{}{
+					"add": []string{
+						"SETGID",
+					},
+				},
+			},
 			"image": image,
 			"volumeMounts": []any{
 				map[string]any{


### PR DESCRIPTION
## Summary

* Cron container inside the nextcloud pod is not able to run the script due to missing scc capability.

## Checklist

- [ ] Update tests.
- [ ] Link this PR to related issues.
- [ ] Merge with `/merge` comment.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->


Component PR: https://github.com/vshn/component-appcat/pull/915