### PR TITLE
Make bucket name optional

### DIFF
--- a/config/controller/webhooks.yaml
+++ b/config/controller/webhooks.yaml
@@ -97,6 +97,7 @@ webhooks:
     - v1
     operations:
     - DELETE
+    - UPDATE
     resources:
     - objectbuckets
   sideEffects: None

--- a/crds/appcat.vshn.io_objectbuckets.yaml
+++ b/crds/appcat.vshn.io_objectbuckets.yaml
@@ -15,7 +15,7 @@ spec:
   scope: Namespaced
   versions:
     - additionalPrinterColumns:
-        - jsonPath: .spec.parameters.bucketName
+        - jsonPath: .status.bucketName
           name: Bucket Name
           type: string
         - jsonPath: .spec.parameters.region
@@ -68,6 +68,7 @@ spec:
                     bucketName:
                       description: |-
                         BucketName is the name of the bucket to create.
+                        If not set, the composite name will be used.
                         Cannot be changed after bucket is created.
                         Name must be acceptable by the S3 protocol, which follows RFC 1123.
                         Be aware that S3 providers may require a unique name across the platform or region.
@@ -105,8 +106,6 @@ spec:
                           type: boolean
                       type: object
                       default: {}
-                  required:
-                    - bucketName
                   type: object
                 writeConnectionSecretToRef:
                   description: WriteConnectionSecretToRef references a secret to which the connection details will be written.
@@ -200,6 +199,9 @@ spec:
                         type: string
                     type: object
                   type: array
+                bucketName:
+                  description: BucketName contains the effective bucket name being used.
+                  type: string
                 conditions:
                   description: Conditions of the resource.
                   items:

--- a/crds/appcat.vshn.io_xobjectbuckets.yaml
+++ b/crds/appcat.vshn.io_xobjectbuckets.yaml
@@ -94,6 +94,7 @@ spec:
                   bucketName:
                     description: |-
                       BucketName is the name of the bucket to create.
+                      If not set, the composite name will be used.
                       Cannot be changed after bucket is created.
                       Name must be acceptable by the S3 protocol, which follows RFC 1123.
                       Be aware that S3 providers may require a unique name across the platform or region.
@@ -136,8 +137,6 @@ spec:
                           instance if it is enabled (enabled by default)
                         type: boolean
                     type: object
-                required:
-                - bucketName
                 type: object
               providerConfigRef:
                 default:
@@ -364,6 +363,9 @@ spec:
                       type: string
                   type: object
                 type: array
+              bucketName:
+                description: BucketName contains the effective bucket name being used.
+                type: string
               conditions:
                 description: Conditions of the resource.
                 items:

--- a/pkg/comp-functions/functions/buckets/cloudscalebucket/cloudscalebucket.go
+++ b/pkg/comp-functions/functions/buckets/cloudscalebucket/cloudscalebucket.go
@@ -29,6 +29,13 @@ func ProvisionCloudscalebucket(_ context.Context, bucket *appcatv1.ObjectBucket,
 		return runtime.NewFatalResult(err)
 	}
 
+	// Set the effective bucket name in status
+	bucket.Status.BucketName = bucket.GetBucketName()
+	err = svc.SetDesiredCompositeStatus(bucket)
+	if err != nil {
+		return runtime.NewFatalResult(err)
+	}
+
 	config, ok := svc.Config.Data["providerConfig"]
 	if !ok {
 		return runtime.NewFatalResult(fmt.Errorf("no providerConfig specified"))
@@ -44,7 +51,7 @@ func ProvisionCloudscalebucket(_ context.Context, bucket *appcatv1.ObjectBucket,
 		return runtime.NewFatalResult(err)
 	}
 
-	svc.SetConnectionDetail("BUCKET_NAME", []byte(bucket.Spec.Parameters.BucketName))
+	svc.SetConnectionDetail("BUCKET_NAME", []byte(bucket.GetBucketName()))
 	svc.SetConnectionDetail("AWS_REGION", []byte(bucket.Spec.Parameters.Region))
 
 	err = populateEndpointConnectionDetails(svc)
@@ -63,7 +70,7 @@ func addBucket(svc *runtime.ServiceRuntime, bucket *appcatv1.ObjectBucket, confi
 			ForProvider: cloudscalev1.BucketParameters{
 				BucketDeletionPolicy: cloudscalev1.BucketDeletionPolicy(bucket.Spec.Parameters.BucketDeletionPolicy),
 				Region:               bucket.Spec.Parameters.Region,
-				BucketName:           bucket.Spec.Parameters.BucketName,
+				BucketName:           bucket.GetBucketName(),
 				CredentialsSecretRef: v1.SecretReference{
 					Namespace: svc.Config.Data["providerSecretNamespace"],
 				},

--- a/pkg/comp-functions/functions/buckets/miniobucket/miniobucket_test.go
+++ b/pkg/comp-functions/functions/buckets/miniobucket/miniobucket_test.go
@@ -34,3 +34,36 @@ func TestProvisionMiniobucket(t *testing.T) {
 	assert.Equal(t, bucketName, policy.GetName())
 
 }
+
+// TestBucketWithoutName tests that when bucketName is not specified, it uses the composite name
+func TestBucketWithoutName(t *testing.T) {
+	svc := commontest.LoadRuntimeFromFile(t, "miniobucket/bucket-no-name.yaml")
+
+	ctx := context.TODO()
+	compositeName := "testbucket-minio123"
+
+	// Get the composite bucket to verify bucketName gets populated
+	compositeBucket := &v1.ObjectBucket{}
+	err := svc.GetObservedComposite(compositeBucket)
+	assert.NoError(t, err)
+
+	res := ProvisionMiniobucket(ctx, compositeBucket, svc)
+	assert.Nil(t, res)
+
+	// Verify that bucketName was populated in the composite status
+	assert.Equal(t, compositeName, compositeBucket.Status.BucketName)
+
+	bucket := &miniov1.Bucket{}
+	assert.NoError(t, svc.GetDesiredComposedResourceByName(bucket, "minio-bucket"))
+	assert.Equal(t, compositeName, bucket.GetName())
+
+	user := &miniov1.User{}
+	assert.NoError(t, svc.GetDesiredComposedResourceByName(user, "minio-user"))
+	assert.Equal(t, compositeName, user.GetName())
+	assert.Contains(t, user.Spec.ForProvider.Policies, compositeName)
+
+	policy := &miniov1.Policy{}
+	assert.NoError(t, svc.GetDesiredComposedResourceByName(policy, "minio-policy"))
+	assert.Equal(t, compositeName, policy.GetName())
+	assert.Equal(t, compositeName, policy.Spec.ForProvider.AllowBucket)
+}

--- a/pkg/comp-functions/functions/buckets/util/naming.go
+++ b/pkg/comp-functions/functions/buckets/util/naming.go
@@ -18,7 +18,7 @@ func GetBucketObjectName(svc *runtime.ServiceRuntime, bucket *appcatv1.ObjectBuc
 
 	err := svc.GetObservedComposedResource(obj, resName)
 	if err != nil {
-		return bucket.Spec.Parameters.BucketName
+		return bucket.GetBucketName()
 	}
 
 	return obj.GetName()

--- a/pkg/controller/webhooks/objectbuckets_test.go
+++ b/pkg/controller/webhooks/objectbuckets_test.go
@@ -36,3 +36,50 @@ func TestObjectbucketDeletionProtectionHandler_ValidateDelete(t *testing.T) {
 	assert.NoError(t, err)
 
 }
+
+func TestObjectbucketDeletionProtectionHandler_ValidateUpdate_BucketNameChange(t *testing.T) {
+	oldBucket := &appcatv1.ObjectBucket{
+		Spec: appcatv1.ObjectBucketSpec{
+			Parameters: appcatv1.ObjectBucketParameters{
+				BucketName: "original-name",
+			},
+		},
+	}
+
+	newBucket := &appcatv1.ObjectBucket{
+		Spec: appcatv1.ObjectBucketSpec{
+			Parameters: appcatv1.ObjectBucketParameters{
+				BucketName: "changed-name",
+			},
+		},
+	}
+
+	p := &ObjectbucketDeletionProtectionHandler{
+		log: logr.Discard(),
+	}
+
+	// Test that changing bucketName is rejected
+	_, err := p.ValidateUpdate(context.TODO(), oldBucket, newBucket)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "bucketName cannot be changed")
+
+	// Test that keeping bucketName the same is allowed
+	newBucket.Spec.Parameters.BucketName = "original-name"
+	_, err = p.ValidateUpdate(context.TODO(), oldBucket, newBucket)
+	assert.NoError(t, err)
+
+	// Test that changing from empty to non-empty is also rejected
+	// because empty bucketName gets auto-generated, so it shouldn't change
+	oldBucket.Spec.Parameters.BucketName = ""
+	newBucket.Spec.Parameters.BucketName = "new-name"
+	_, err = p.ValidateUpdate(context.TODO(), oldBucket, newBucket)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "bucketName cannot be changed")
+
+	// Test that changing from non-empty to empty is also rejected
+	oldBucket.Spec.Parameters.BucketName = "original-name"
+	newBucket.Spec.Parameters.BucketName = ""
+	_, err = p.ValidateUpdate(context.TODO(), oldBucket, newBucket)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "bucketName cannot be changed")
+}

--- a/test/functions/cloudscalebucket/bucket-no-name.yaml
+++ b/test/functions/cloudscalebucket/bucket-no-name.yaml
@@ -1,0 +1,22 @@
+desired: {}
+input:
+  apiVersion: v1
+  data:
+    providerConfig: minio
+  kind: ConfigMap
+  metadata:
+    annotations: {}
+    labels:
+      name: xfn-config
+    name: xfn-config
+observed:
+  composite:
+    resource:
+      apiVersion: appcat.vshn.io/v1
+      kind: ObjectBucket
+      metadata:
+        name: testbucket-abc789
+        namespace: default
+      spec:
+        parameters:
+          region: lpg

--- a/test/functions/exoscalebucket/bucket-no-name.yaml
+++ b/test/functions/exoscalebucket/bucket-no-name.yaml
@@ -1,0 +1,22 @@
+desired: {}
+input:
+  apiVersion: v1
+  data:
+    providerConfig: minio
+  kind: ConfigMap
+  metadata:
+    annotations: {}
+    labels:
+      name: xfn-config
+    name: xfn-config
+observed:
+  composite:
+    resource:
+      apiVersion: appcat.vshn.io/v1
+      kind: ObjectBucket
+      metadata:
+        name: testbucket-xyz123
+        namespace: default
+      spec:
+        parameters:
+          region: ch-gva-2

--- a/test/functions/miniobucket/bucket-no-name.yaml
+++ b/test/functions/miniobucket/bucket-no-name.yaml
@@ -1,0 +1,22 @@
+desired: {}
+input:
+  apiVersion: v1
+  data:
+    providerConfig: minio
+  kind: ConfigMap
+  metadata:
+    annotations: {}
+    labels:
+      name: xfn-config
+    name: xfn-config
+observed:
+  composite:
+    resource:
+      apiVersion: appcat.vshn.io/v1
+      kind: ObjectBucket
+      metadata:
+        name: testbucket-minio123
+        namespace: default
+      spec:
+        parameters:
+          region: us-east-1


### PR DESCRIPTION
## Summary

- The bucket name is now optional
- If the bucket name is not set, the name of the composite is used
- A webhook is in place to prevent changing the bucket name after creation

## Checklist

- [x] Update tests.
- [ ] Link this PR to related issues.
- [ ] Merge with `/merge` comment.


Component PR: https://github.com/vshn/component-appcat/pull/917