### PR TITLE
Remove runAsUser value when deploying to OpenShift

### DIFF
--- a/pkg/comp-functions/functions/vshnnextcloud/deploy.go
+++ b/pkg/comp-functions/functions/vshnnextcloud/deploy.go
@@ -451,6 +451,11 @@ func newValues(ctx context.Context, svc *runtime.ServiceRuntime, comp *vshnv1.VS
 	}
 	securityContext := map[string]any{}
 	podSecurityContext := map[string]any{}
+
+	metrics := map[string]any{
+		"enabled": true,
+	}
+
 	if isOpenShift {
 		securityContext = map[string]any{
 			"runAsUser":                nil,
@@ -466,6 +471,10 @@ func newValues(ctx context.Context, svc *runtime.ServiceRuntime, comp *vshnv1.VS
 			"seLinuxOptions": map[string]any{
 				"type": "spc_t",
 			},
+		}
+
+		metrics["securityContext"] = map[string]any{
+			"runAsUser": nil,
 		}
 	}
 
@@ -585,9 +594,7 @@ func newValues(ctx context.Context, svc *runtime.ServiceRuntime, comp *vshnv1.VS
 			"enabled":             true,
 		},
 		"externalDatabase": externalDb,
-		"metrics": map[string]any{
-			"enabled": true,
-		},
+		"metrics":          metrics,
 		"resources": map[string]any{
 			"requests": map[string]any{
 				"memory": res.ReqMem,


### PR DESCRIPTION
## Summary

* By default the nextcloud helm chart sets `runAsUser: 1000` which doesn't work on OpenShift: https://artifacthub.io/packages/helm/nextcloud/nextcloud?modal=values&path=metrics.securityContext.runAsUser
* In order for it to work we have to clear that value when deploying to OpenShift

## Checklist

- [ ] Update tests.
- [ ] Link this PR to related issues.
- [ ] Merge with `/merge` comment.
