### PR TITLE
Add RBAC for providerconfig checks

### DIFF
--- a/config/controller/cluster-role.yaml
+++ b/config/controller/cluster-role.yaml
@@ -9,6 +9,7 @@ rules:
   resources:
   - configmaps
   - namespaces
+  - secrets
   verbs:
   - delete
   - get
@@ -27,6 +28,18 @@ rules:
   - list
   - patch
   - update
+  - watch
+- apiGroups:
+  - cloudscale.crossplane.io
+  - helm.crossplane.io
+  - kubernetes.crossplane.io
+  - minio.crossplane.io
+  - postgresql.sql.crossplane.io
+  resources:
+  - providerconfigs
+  verbs:
+  - get
+  - list
   - watch
 - apiGroups:
   - codey.io

--- a/pkg/controller/webhooks/default_handler.go
+++ b/pkg/controller/webhooks/default_handler.go
@@ -20,6 +20,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
+//+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;patch;update;delete
+//+kubebuilder:rbac:groups=cloudscale.crossplane.io;kubernetes.crossplane.io;helm.crossplane.io;minio.crossplane.io;postgresql.sql.crossplane.io,resources=providerconfigs,verbs=get;list;watch
+
 type DefaultWebhookHandler struct {
 	client    client.Client
 	log       logr.Logger


### PR DESCRIPTION


## Summary

This commit adds RBAC so that the controller service account actually has permissions to check the providerconfigs.

## Checklist

- [x] Update tests.
- [x] Link this PR to related issues.
- [ ] Merge with `/merge` comment.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->


Component PR: https://github.com/vshn/component-appcat/pull/934