### PR TITLE
Fixed naming of the luks secret for stackgres VSHNPostgreSQL implementation

### DIFF
--- a/pkg/comp-functions/functions/vshnpostgres/encrypted_pvc.go
+++ b/pkg/comp-functions/functions/vshnpostgres/encrypted_pvc.go
@@ -95,7 +95,7 @@ func writeLuksSecret(svc *runtime.ServiceRuntime, log logr.Logger, comp *vshnv1.
 
 	secret = &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-data-%s-%d-luks-key", comp.ObjectMeta.Labels["crossplane.io/composite"], comp.ObjectMeta.Labels["crossplane.io/composite"], i),
+			Name:      fmt.Sprintf("%s-data-%s-%d-luks-key", comp.GetName(), comp.GetName(), i),
 			Namespace: getInstanceNamespace(comp),
 		},
 		Data: map[string][]byte{


### PR DESCRIPTION
## Summary

- LUKS secret names used parent composite name instead of actual PostgreSQL composite name
- Keycloak creates PostgreSQL with -pg suffix, but secrets were named without it. This caused the mounting of the secret to fail

## Checklist

- [ ] Update tests.
- [ ] Link this PR to related issues.
- [ ] Merge with `/merge` comment.

Component PR: https://github.com/vshn/component-appcat/pull/936