### PR TITLE
Fix merge reference in workflow

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -189,7 +189,7 @@ jobs:
           if git diff --cached --quiet; then
             echo "✅ No changes to commit"
           else
-            git commit -m "Auto update from appcat PR #${{ needs.check-conditions.outputs.pr-number }}, dependency $APPCAT_FR_COMMIT_SHA"
+            git commit -m "Auto update from appcat PR https://github.com/${{ env.APPCAT_REPO }}/pull/${{ needs.check-conditions.outputs.pr-number }}, dependency $APPCAT_FR_COMMIT_SHA"
             git push origin "$COMPONENT_BRANCH"
           fi
 
@@ -301,7 +301,7 @@ jobs:
           if git diff --cached --quiet; then
             echo "✅ No changes to commit"
           else
-            git commit -m "Auto update from appcat PR #${{ needs.check-conditions.outputs.pr-number }}, dependency $APPCAT_NEW_TAG"
+            git commit -m "Auto update from appcat PR https://github.com/${{ env.APPCAT_REPO }}/pull/${{ needs.check-conditions.outputs.pr-number }}, dependency $APPCAT_NEW_TAG"
             git push origin "$COMPONENT_BRANCH"
           fi
 


### PR DESCRIPTION
## Summary

* The PR references in component-appcat that are coming form the appcat workflow are wrong due t GitHub refereincing numbers from the repos they are in. THis will confuse the engineer instead of pointing to appcat it points to a PR in the component-appcat

## Checklist

- [ ] Update tests.
- [ ] Link this PR to related issues.
- [ ] Merge with `/merge` comment.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->


Component PR: https://github.com/vshn/component-appcat/pull/937