### PR TITLE
Make proxysql report the actual mariadb server version

### DIFF
--- a/apis/vshn/v1/dbaas_vshn_mariadb.go
+++ b/apis/vshn/v1/dbaas_vshn_mariadb.go
@@ -145,6 +145,10 @@ type VSHNMariaDBStatus struct {
 	// CurrentInstances tracks the current amount of instances.
 	// Mainly used to detect if there was a change in instances
 	CurrentInstances int `json:"currentInstances,omitempty"`
+	// MariaDBVersion contains the current MariaDB server version
+	MariaDBVersion string `json:"mariadbVersion,omitempty"`
+	// InitialMaintenanceRan tracks if the initial maintenance job has been triggered
+	InitialMaintenanceRan bool `json:"initialMaintenanceRan,omitempty"`
 	// ResourceStatus represents the observed state of a managed resource.
 	xpv1.ResourceStatus `json:",inline"`
 }

--- a/crds/vshn.appcat.vshn.io_vshnmariadbs.yaml
+++ b/crds/vshn.appcat.vshn.io_vshnmariadbs.yaml
@@ -4895,6 +4895,9 @@ spec:
                     CurrentInstances tracks the current amount of instances.
                     Mainly used to detect if there was a change in instances
                   type: integer
+                initialMaintenanceRan:
+                  description: InitialMaintenanceRan tracks if the initial maintenance job has been triggered
+                  type: boolean
                 instanceNamespace:
                   description: InstanceNamespace contains the name of the namespace where the instance resides
                   type: string
@@ -4935,6 +4938,9 @@ spec:
                         type: string
                     type: object
                   type: array
+                mariadbVersion:
+                  description: MariaDBVersion contains the current MariaDB server version
+                  type: string
                 namespaceConditions:
                   items:
                     properties:

--- a/crds/vshn.appcat.vshn.io_xvshnmariadbs.yaml
+++ b/crds/vshn.appcat.vshn.io_xvshnmariadbs.yaml
@@ -5804,6 +5804,10 @@ spec:
                   CurrentInstances tracks the current amount of instances.
                   Mainly used to detect if there was a change in instances
                 type: integer
+              initialMaintenanceRan:
+                description: InitialMaintenanceRan tracks if the initial maintenance
+                  job has been triggered
+                type: boolean
               instanceNamespace:
                 description: InstanceNamespace contains the name of the namespace
                   where the instance resides
@@ -5848,6 +5852,9 @@ spec:
                       type: string
                   type: object
                 type: array
+              mariadbVersion:
+                description: MariaDBVersion contains the current MariaDB server version
+                type: string
               namespaceConditions:
                 items:
                   properties:

--- a/pkg/comp-functions/functions/vshnmariadb/files/proxysql.conf.tmpl
+++ b/pkg/comp-functions/functions/vshnmariadb/files/proxysql.conf.tmpl
@@ -9,11 +9,12 @@ admin_variables=
     cluster_password="{{ .RootPassword }}"
 }
 
-{{ if eq .TLS 1 }}
 mysql_variables = {
+    {{ if eq .TLS 1 }}
     ssl_p2s_ca = "/var/lib/proxysql/proxysql-ca.pem"
+    {{ end }}
+    server_version = "{{ .MariaDBVersion }}"
 }
-{{ end }}
 
 mysql_servers =
 (

--- a/pkg/comp-functions/functions/vshnmariadb/proxysql.go
+++ b/pkg/comp-functions/functions/vshnmariadb/proxysql.go
@@ -33,11 +33,12 @@ var (
 )
 
 type proxySQLConfigParams struct {
-	CompName     string
-	RootPassword string
-	Namespace    string
-	TLS          int
-	Users        []proxySQLUsers
+	CompName       string
+	RootPassword   string
+	Namespace      string
+	TLS            int
+	Users          []proxySQLUsers
+	MariaDBVersion string
 }
 
 type proxySQLUsers struct {
@@ -119,11 +120,12 @@ func createProxySQLConfig(comp *vshnv1.VSHNMariaDB, svc *runtime.ServiceRuntime,
 	}
 
 	confParams := proxySQLConfigParams{
-		CompName:     comp.GetName(),
-		RootPassword: string(cd["MARIADB_PASSWORD"]),
-		Namespace:    comp.GetInstanceNamespace(),
-		Users:        userList,
-		TLS:          tls,
+		CompName:       comp.GetName(),
+		RootPassword:   string(cd["MARIADB_PASSWORD"]),
+		Namespace:      comp.GetInstanceNamespace(),
+		Users:          userList,
+		TLS:            tls,
+		MariaDBVersion: comp.Status.MariaDBVersion,
 	}
 
 	var buf bytes.Buffer

--- a/pkg/comp-functions/functions/vshnmariadb/proxysql_test.go
+++ b/pkg/comp-functions/functions/vshnmariadb/proxysql_test.go
@@ -53,7 +53,7 @@ func Test_createProxySQLConfig(t *testing.T) {
 	svc := commontest.LoadRuntimeFromFile(t, "empty.yaml")
 	comp := getComp()
 
-	expectedHash := "56e11403faab20eb54184eccef557c85"
+	expectedHash := "1bf00f243388da2aa7ba6b8d14bf7ad3"
 
 	hash, err := createProxySQLConfig(comp, svc, false)
 	assert.NoError(t, err)


### PR DESCRIPTION
## Summary

* Proxysql now returns the actual mariadb version
* Maintenance is run directly after instance creation to populate the image tag correctly

## Checklist

- [x] Update tests.
- [ ] Link this PR to related issues.
- [ ] Merge with `/merge` comment.


Component PR: https://github.com/vshn/component-appcat/pull/938