### PR TITLE
Fix codey webhook

### DIFF
--- a/apis/codey/dbaas_vshn_codey.go
+++ b/apis/codey/dbaas_vshn_codey.go
@@ -137,8 +137,13 @@ func (v *CodeyInstance) GetAllowedNamespaces() []string {
 func (v *CodeyInstance) GetBackupRetention() vshnv1.K8upRetentionPolicy {
 	return vshnv1.K8upRetentionPolicy{}
 }
+
 func (v *CodeyInstance) GetBackupSchedule() string {
 	return ""
+}
+
+func (v *CodeyInstance) IsBackupEnabled() bool {
+	return false
 }
 
 func (v *CodeyInstance) GetServiceName() string {

--- a/config/controller/cluster-role.yaml
+++ b/config/controller/cluster-role.yaml
@@ -59,6 +59,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - syn.tools
   resources:

--- a/pkg/controller/webhooks/codey.go
+++ b/pkg/controller/webhooks/codey.go
@@ -65,13 +65,13 @@ func (n *CodeyInstanceWebhookHandler) ValidateCreate(ctx context.Context, obj ru
 		return warning, err
 	}
 
-	codey, ok := obj.(*codey.CodeyInstance)
+	codeyInstance, ok := obj.(*codey.CodeyInstance)
 	if !ok {
 		return nil, fmt.Errorf("provided manifest is not a valid CodeyInstance object")
 	}
 
-	codeyFqdn := codey.ObjectMeta.Name + codeyUrlSuffix
-	if err := isCodeyFqdnUnique(codeyFqdn, codey.Spec.ResourceRef.Name, n.client); err != nil {
+	codeyFqdn := codeyInstance.ObjectMeta.Name + codeyUrlSuffix
+	if err := isCodeyFqdnUnique(codeyFqdn, codeyInstance.Spec.ResourceRef.Name, n.client); err != nil {
 		return nil, fmt.Errorf("failed FQDN validation: %v", err)
 	}
 
@@ -107,19 +107,23 @@ func isCodeyFqdnUnique(fqdn, compositeName string, cl client.Client) error {
 		return err
 	}
 
-	//... but not the one belonging to ourself.
-	reqComposite, err := labels.NewRequirement("crossplane.io/composite", selection.NotEquals, []string{compositeName})
-	if err != nil {
-		return err
-	}
-
-	err = cl.List(context.TODO(), ingressList,
+	listOpts := []client.ListOption{
 		client.MatchingLabelsSelector{
 			Selector: labels.NewSelector().Add(*reqOwnerkind),
 		},
-		client.MatchingLabelsSelector{
+	}
+
+	if compositeName != "" {
+		reqComposite, err := labels.NewRequirement("crossplane.io/composite", selection.NotEquals, []string{compositeName})
+		if err != nil {
+			return err
+		}
+		listOpts = append(listOpts, client.MatchingLabelsSelector{
 			Selector: labels.NewSelector().Add(*reqComposite),
 		})
+	}
+
+	err = cl.List(context.TODO(), ingressList, listOpts...)
 	if err != nil {
 		return fmt.Errorf("failed listing ingresses: %v", err)
 	}

--- a/pkg/controller/webhooks/codey.go
+++ b/pkg/controller/webhooks/codey.go
@@ -71,7 +71,9 @@ func (n *CodeyInstanceWebhookHandler) ValidateCreate(ctx context.Context, obj ru
 	}
 
 	codeyFqdn := codeyInstance.ObjectMeta.Name + codeyUrlSuffix
-	if err := isCodeyFqdnUnique(codeyFqdn, codeyInstance.Spec.ResourceRef.Name, n.client); err != nil {
+
+	// compositeName is empty on creation
+	if err := isCodeyFqdnUnique(codeyFqdn, "", n.client); err != nil {
 		return nil, fmt.Errorf("failed FQDN validation: %v", err)
 	}
 


### PR DESCRIPTION
## Summary

* The CodeyInstance webhook was failing because CodeyInstance didn't implement the `IsBackupEnabled()` method required by the `common.Composite` interface causing type assertion failures.
* Additionally, the FQDN uniqueness check was updated to handle empty `spec.ResourceRef.Name`  on instance creation by conditionally applying the composite name filter only when it's populated.

## Checklist

- [ ] Update tests.
- [x] Link this PR to related issues.
- [ ] Merge with `/merge` comment.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->


Component PR: https://github.com/vshn/component-appcat/pull/941