### PR TITLE
Disable billing controller via flag by default

### DIFF
--- a/cmd/controller.go
+++ b/cmd/controller.go
@@ -54,7 +54,7 @@ func init() {
 	ControllerCMD.Flags().StringVar(&c.certDir, "certdir", "/etc/webhook/certs", "Set the webhook certificate directory")
 	ControllerCMD.Flags().BoolVar(&c.enableQuotas, "quotas", false, "Enable the quota webhooks, is only active if webhooks is also true")
 	ControllerCMD.Flags().BoolVar(&c.enableEventForwarding, "event-forwarding", true, "Disable event-forwarding")
-	ControllerCMD.Flags().BoolVar(&c.enableBilling, "billing", true, "Disable billing")
+	ControllerCMD.Flags().BoolVar(&c.enableBilling, "billing", false, "Disable billing")
 	viper.AutomaticEnv()
 	if !viper.IsSet("PLANS_NAMESPACE") {
 		viper.Set("PLANS_NAMESPACE", "syn-appcat")


### PR DESCRIPTION
## Summary

* Instead of relying on disabling the new billing controller via component-appcat, we should disable it in the actual flag for now

## Checklist

- [ ] Update tests.
- [ ] Link this PR to related issues.
- [ ] Merge with `/merge` comment.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
