### PR TITLE
Block nextcloud downgrade

### DIFF
--- a/pkg/controller/webhooks/nextcloud.go
+++ b/pkg/controller/webhooks/nextcloud.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	valid "github.com/asaskevich/govalidator"
+	"github.com/blang/semver/v4"
 	vshnv1 "github.com/vshn/appcat/v4/apis/vshn/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -112,6 +113,12 @@ func (n *NextcloudWebhookHandler) ValidateUpdate(ctx context.Context, oldObj, ne
 		return nil, fmt.Errorf("provided old manifest is not a valid VSHNNextcloud object")
 	}
 
+	if nx.Spec.Parameters.Maintenance.PinImageTag == "" {
+		if err := validateNoVersionDowngrade(oldNx.Spec.Parameters.Service.Version, nx.Spec.Parameters.Service.Version); err != nil {
+			allErrs.Add(err)
+		}
+	}
+
 	if err := validateFQDNs(nx.Spec.Parameters.Service.FQDN); err != nil {
 		allErrs.Add(err)
 	}
@@ -140,6 +147,32 @@ func (n *NextcloudWebhookHandler) ValidateUpdate(ctx context.Context, oldObj, ne
 	}
 
 	return nil, allErrs.Get()
+}
+
+func validateNoVersionDowngrade(oldVersion, newVersion string) *field.Error {
+	if oldVersion == "" || newVersion == "" {
+		return nil
+	}
+	oldV, err := semver.ParseTolerant(oldVersion)
+	if err != nil {
+		return nil
+	}
+	newV, err := semver.ParseTolerant(newVersion)
+	if err != nil {
+		return field.Invalid(
+			field.NewPath("spec", "parameters", "service", "version"),
+			newVersion,
+			fmt.Sprintf("invalid version %q", newVersion),
+		)
+	}
+	if newV.LT(oldV) {
+		return field.Invalid(
+			field.NewPath("spec", "parameters", "service", "version"),
+			newVersion,
+			fmt.Sprintf("downgrading from %q to %q is not supported; set spec.parameters.maintenance.pinImageTag to override", oldVersion, newVersion),
+		)
+	}
+	return nil
 }
 
 func validateFQDNs(fqdns []string) *field.Error {

--- a/pkg/controller/webhooks/nextcloud_test.go
+++ b/pkg/controller/webhooks/nextcloud_test.go
@@ -405,6 +405,90 @@ func TestNextcloudWebhookHandler_ValidateUpdate_CollaboraFQDN(t *testing.T) {
 	assert.NoError(t, err, "Updating Collabora FQDN to another valid one should pass validation")
 }
 
+func TestNextcloudWebhookHandler_ValidateUpdate_VersionDowngrade(t *testing.T) {
+	ctx := context.TODO()
+	fclient := fake.NewClientBuilder().
+		WithScheme(pkg.SetupScheme()).
+		Build()
+
+	handler := NextcloudWebhookHandler{
+		DefaultWebhookHandler: DefaultWebhookHandler{
+			client:     fclient,
+			log:        logr.Discard(),
+			withQuota:  false,
+			obj:        &vshnv1.VSHNNextcloud{},
+			name:       "nextcloud",
+			nameLength: 30,
+		},
+	}
+
+	newNC := func(version, pinImageTag string) *vshnv1.VSHNNextcloud {
+		return &vshnv1.VSHNNextcloud{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "myinstance",
+				Namespace: "testns",
+			},
+			Spec: vshnv1.VSHNNextcloudSpec{
+				Parameters: vshnv1.VSHNNextcloudParameters{
+					Service: vshnv1.VSHNNextcloudServiceSpec{
+						FQDN:    []string{"mynextcloud.example.tld"},
+						Version: version,
+					},
+					Maintenance: vshnv1.VSHNDBaaSMaintenanceScheduleSpec{
+						PinImageTag: pinImageTag,
+					},
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name        string
+		oldVersion  string
+		newVersion  string
+		pinImageTag string
+		wantErr     bool
+		errContains string
+	}{
+		// --- happy path ---
+		{name: "major upgrade", oldVersion: "30", newVersion: "31", wantErr: false},
+		{name: "same major version", oldVersion: "31", newVersion: "31", wantErr: false},
+		{name: "major.minor upgrade", oldVersion: "30.0", newVersion: "31.0", wantErr: false},
+		{name: "minor upgrade within major", oldVersion: "30.0", newVersion: "30.1", wantErr: false},
+		{name: "same version different formats", oldVersion: "30", newVersion: "30.0", wantErr: false},
+		{name: "empty old version (first set)", oldVersion: "", newVersion: "31", wantErr: false},
+		{name: "both empty versions", oldVersion: "", newVersion: "", wantErr: false},
+		{name: "new version cleared", oldVersion: "31", newVersion: "", wantErr: false},
+		{name: "unparsable old version", oldVersion: "garbage", newVersion: "30", wantErr: false},
+
+		// --- downgrade blocked ---
+		{name: "major downgrade", oldVersion: "31", newVersion: "30", wantErr: true, errContains: "downgrading from"},
+		{name: "minor downgrade within major", oldVersion: "30.1", newVersion: "30.0", wantErr: true, errContains: "downgrading from"},
+		{name: "patch downgrade", oldVersion: "30.0.1", newVersion: "30.0.0", wantErr: true, errContains: "downgrading from"},
+
+		// --- invalid new version ---
+		{name: "unparsable new version", oldVersion: "30", newVersion: "garbage", wantErr: true, errContains: "invalid version"},
+
+		// --- pinImageTag bypasses check ---
+		{name: "downgrade allowed with pinImageTag", oldVersion: "31", newVersion: "30", pinImageTag: "nextcloud:30.0.5", wantErr: false},
+		{name: "invalid new version allowed with pinImageTag", oldVersion: "30", newVersion: "garbage", pinImageTag: "nextcloud:30.0.5", wantErr: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := handler.ValidateUpdate(ctx, newNC(tt.oldVersion, ""), newNC(tt.newVersion, tt.pinImageTag))
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.errContains != "" {
+					assert.ErrorContains(t, err, tt.errContains)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestNextcloudWebhookHandler_ValidatePostgreSQLEncryptionChanges(t *testing.T) {
 	ctx := context.TODO()
 	fclient := fake.NewClientBuilder().


### PR DESCRIPTION
## Summary

* Downgrading version was possible. We have to block downgrades. Customer can use `PinImageTag` to set any version they want on their own risk.

## Checklist

- [x] Update tests.
- [ ] Link this PR to related issues.
- [ ] Merge with `/merge` comment.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->


Component PR: https://github.com/vshn/component-appcat/pull/1096