### PR TITLE
Expose oauth2 client configuration for forgejo

### DIFF
--- a/apis/vshn/v1/dbaas_vshn_forgejo.go
+++ b/apis/vshn/v1/dbaas_vshn_forgejo.go
@@ -127,6 +127,12 @@ type VSHNForgejoConfig struct {
 	// https://forgejo.org/docs/latest/admin/config-cheat-sheet/#openid-openid
 	OpenID map[string]string `json:"openid,omitempty"`
 
+	// https://forgejo.org/docs/latest/admin/config-cheat-sheet/#oauth2-oauth2
+	OAuth2 map[string]string `json:"oauth2,omitempty"`
+
+	// https://forgejo.org/docs/latest/admin/config-cheat-sheet/#oauth2-client-oauth2_client
+	OAuth2Client map[string]string `json:"oauth2_client,omitempty"`
+
 	// https://forgejo.org/docs/latest/admin/config-cheat-sheet/#service-service
 	Service map[string]string `json:"service,omitempty"`
 

--- a/apis/vshn/v1/zz_generated.deepcopy.go
+++ b/apis/vshn/v1/zz_generated.deepcopy.go
@@ -502,6 +502,20 @@ func (in *VSHNForgejoConfig) DeepCopyInto(out *VSHNForgejoConfig) {
 			(*out)[key] = val
 		}
 	}
+	if in.OAuth2 != nil {
+		in, out := &in.OAuth2, &out.OAuth2
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
+	if in.OAuth2Client != nil {
+		in, out := &in.OAuth2Client, &out.OAuth2Client
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.Service != nil {
 		in, out := &in.Service, &out.Service
 		*out = make(map[string]string, len(*in))

--- a/crds/vshn.appcat.vshn.io_vshnforgejoes.yaml
+++ b/crds/vshn.appcat.vshn.io_vshnforgejoes.yaml
@@ -4642,6 +4642,16 @@ spec:
                                     type: string
                                   description: https://forgejo.org/docs/latest/admin/config-cheat-sheet/#mailer-mailer
                                   type: object
+                                oauth2:
+                                  additionalProperties:
+                                    type: string
+                                  description: https://forgejo.org/docs/latest/admin/config-cheat-sheet/#oauth2-oauth2
+                                  type: object
+                                oauth2_client:
+                                  additionalProperties:
+                                    type: string
+                                  description: https://forgejo.org/docs/latest/admin/config-cheat-sheet/#oauth2-client-oauth2_client
+                                  type: object
                                 openid:
                                   additionalProperties:
                                     type: string

--- a/crds/vshn.appcat.vshn.io_xvshnforgejoes.yaml
+++ b/crds/vshn.appcat.vshn.io_xvshnforgejoes.yaml
@@ -5368,6 +5368,16 @@ spec:
                                   type: string
                                 description: https://forgejo.org/docs/latest/admin/config-cheat-sheet/#mailer-mailer
                                 type: object
+                              oauth2:
+                                additionalProperties:
+                                  type: string
+                                description: https://forgejo.org/docs/latest/admin/config-cheat-sheet/#oauth2-oauth2
+                                type: object
+                              oauth2_client:
+                                additionalProperties:
+                                  type: string
+                                description: https://forgejo.org/docs/latest/admin/config-cheat-sheet/#oauth2-client-oauth2_client
+                                type: object
                               openid:
                                 additionalProperties:
                                   type: string

--- a/pkg/comp-functions/functions/vshnforgejo/deploy_test.go
+++ b/pkg/comp-functions/functions/vshnforgejo/deploy_test.go
@@ -49,6 +49,19 @@ func TestDeployment(t *testing.T) {
 		assert.Equal(t, appName, values["gitea"].(map[string]any)["config"].(map[string]any)["APP_NAME"])
 	})
 
+	t.Run("GivenOAuth2ClientSettings_ExpectInHelmValues", func(t *testing.T) {
+		svc, comp, secretName := bootstrapTest(t)
+		assert.NoError(t, addForgejo(context.TODO(), svc, comp, secretName))
+
+		release := &xhelmv1.Release{}
+		assert.NoError(t, svc.GetDesiredComposedResourceByName(release, comp.GetName()))
+
+		values := getReleaseValues(t, *release)
+		config := values["gitea"].(map[string]any)["config"].(map[string]any)
+		assert.Equal(t, map[string]any{"ENABLE_AUTO_REGISTRATION": "true"}, config["oauth2_client"])
+		assert.Equal(t, map[string]any{"ENABLE_AUTO_REGISTRATION": "true"}, config["oauth2"])
+	})
+
 	t.Run("GivenPlan_ExpectPlanResources", func(t *testing.T) {
 		const (
 			plan = "small"

--- a/pkg/comp-functions/functions/vshnforgejo/deploy_test.go
+++ b/pkg/comp-functions/functions/vshnforgejo/deploy_test.go
@@ -59,7 +59,7 @@ func TestDeployment(t *testing.T) {
 		values := getReleaseValues(t, *release)
 		config := values["gitea"].(map[string]any)["config"].(map[string]any)
 		assert.Equal(t, map[string]any{"ENABLE_AUTO_REGISTRATION": "true"}, config["oauth2_client"])
-		assert.Equal(t, map[string]any{"ENABLE_AUTO_REGISTRATION": "true"}, config["oauth2"])
+		assert.Equal(t, map[string]any{"ENABLE": "true"}, config["oauth2"])
 	})
 
 	t.Run("GivenPlan_ExpectPlanResources", func(t *testing.T) {

--- a/test/functions/vshnforgejo/01_default.yaml
+++ b/test/functions/vshnforgejo/01_default.yaml
@@ -40,7 +40,7 @@ observed:
                 openid:
                   ENABLE_OPENID_SIGNIN: "false"
                 oauth2:
-                  ENABLE_AUTO_REGISTRATION: "true"
+                  ENABLE: "true"
                 oauth2_client:
                   ENABLE_AUTO_REGISTRATION: "true"
                 service:

--- a/test/functions/vshnforgejo/01_default.yaml
+++ b/test/functions/vshnforgejo/01_default.yaml
@@ -39,6 +39,10 @@ observed:
                   ENABLED: "true"
                 openid:
                   ENABLE_OPENID_SIGNIN: "false"
+                oauth2:
+                  ENABLE_AUTO_REGISTRATION: "true"
+                oauth2_client:
+                  ENABLE_AUTO_REGISTRATION: "true"
                 service:
                   REGISTER_EMAIL_CONFIRM: "true"
                 mailer:


### PR DESCRIPTION
## Summary

This exposes the necessary parameters to configure oauth2 client configurations for vshnforgejo

## Checklist

- [x] Update tests.
- [x] Link this PR to related issues.
- [ ] Merge with `/merge` comment.

Component PR: https://github.com/vshn/component-appcat/pull/1103