### PR TITLE
Fix race condition in initial-maintenance job creation

### DIFF
--- a/pkg/comp-functions/functions/common/maintenance/maintenance.go
+++ b/pkg/comp-functions/functions/common/maintenance/maintenance.go
@@ -160,6 +160,11 @@ func (m *Maintenance) Run(ctx context.Context) *xfnproto.Result {
 	// Handle initial maintenance job
 	// Keep the job in desired state until 30 minutes after completion
 	if !m.resource.GetInitialMaintenanceRan() {
+		if m.resource.GetName() == "" {
+			log.Info("Composite resource not yet fully populated, deferring initial maintenance job")
+			return runtime.NewNormalResult("Composite resource not yet fully populated, deferring initial maintenance job")
+		}
+
 		// Job hasn't been created yet, create it
 		if err := m.createInitialMaintenanceJob(ctx); err != nil {
 			log.Error(err, "Failed to create initial maintenance job")


### PR DESCRIPTION
## Summary

On the first reconcile, the composite resource metadata may not be fully populated yet, causing a job named just `initial-maintenance` instead of `{composite}-initial-maintenance` with empty env vars that fails immediately. The orphaned error pods trigger `KubePodNotReady` alerts indefinitely.

Defer job creation until `GetName()` is non-empty. The next reconcile will have the full metadata.


## Checklist

- [ ] Update tests.
- [ ] Link this PR to related issues.
- [ ] Merge with `/merge` comment.

Component PR: https://github.com/vshn/component-appcat/pull/1104