### PR TITLE
Add new memory alert for DB services and add alert to all DB services

### DIFF
--- a/pkg/comp-functions/functions/common/nonsla/alerting.go
+++ b/pkg/comp-functions/functions/common/nonsla/alerting.go
@@ -95,6 +95,26 @@ var (
 				},
 			}
 		},
+		memCriticalDB: func(name, namespace string) promV1.Rule {
+			return promV1.Rule{
+				Alert: "MemoryCritical",
+				Annotations: map[string]string{
+					"description": "The memory claimed by the instance {{ $labels.name }} in namespace {{ $labels.label_appcat_vshn_io_claim_namespace }} has been over 85% for 2 hours.\n  Please reduce the load of this instance, or increase the memory.",
+					"runbook_url": "https://hub.syn.tools/appcat/runbooks/vshn-generic.html#MemoryCritical",
+					"summary":     "Memory usage critical.",
+				},
+				Expr: intstr.IntOrString{
+					Type:   intstr.String,
+					StrVal: "label_replace( topk(1, (max(container_memory_rss{container=\"" + name + "\"})without (name, id)  / on(container,pod,namespace)  kube_pod_container_resource_limits{resource=\"memory\"}* 100) > 85) * on(namespace) group_left(label_appcat_vshn_io_claim_namespace)kube_namespace_labels, \"name\", \"$1\", \"namespace\",\"(" + namespace + ")\")",
+				},
+				For: TwoHourInterval,
+				Labels: map[string]string{
+					"severity": SeverityCritical,
+					"syn_team": SynTeam,
+					"syn":      "true",
+				},
+			}
+		},
 	}
 )
 
@@ -102,6 +122,7 @@ var (
 	pvFillUp         alert = "PersistentVolumeFillingUp"
 	pvExpectedFillUp alert = "PersistentVolumeExpectedToFillUp"
 	memCritical      alert = "MemoryCritical"
+	memCriticalDB    alert = "MemoryCriticalDB"
 )
 
 type AlertBuilder struct {
@@ -132,6 +153,11 @@ func (a *AlertBuilder) AddMemory() *AlertBuilder {
 	return a
 }
 
+func (a *AlertBuilder) AddMemoryDB() *AlertBuilder {
+	a.as.alerts = append(a.as.alerts, memCriticalDB)
+	return a
+}
+
 func (a *AlertBuilder) AddCustom(r []promV1.Rule) *AlertBuilder {
 	a.as.customRules = r
 	return a
@@ -145,8 +171,20 @@ func (a *AlertBuilder) AddCustomServiceRule(name string, rule ServiceRule) *Aler
 
 func (a *AlertBuilder) AddAll() *AlertBuilder {
 	a.as.alerts = make([]alert, 0)
-	for alert, _ := range a.as.alertDefinitions {
-		a.as.alerts = append(a.as.alerts, alert)
+	for alert := range a.as.alertDefinitions {
+		if alert != memCriticalDB {
+			a.as.alerts = append(a.as.alerts, alert)
+		}
+	}
+	return a
+}
+
+func (a *AlertBuilder) AddAllDB() *AlertBuilder {
+	a.as.alerts = make([]alert, 0)
+	for alert := range a.as.alertDefinitions {
+		if alert != memCritical {
+			a.as.alerts = append(a.as.alerts, alert)
+		}
 	}
 	return a
 }

--- a/pkg/comp-functions/functions/common/nonsla/alerting_test.go
+++ b/pkg/comp-functions/functions/common/nonsla/alerting_test.go
@@ -11,7 +11,7 @@ var (
 	// PostgreSQL alerts - most specific as currently those are the only ones where we have different container name and namespace
 	patroniPersistentVolumeExpectedToFillUp = `label_replace( bottomk(1, (kubelet_volume_stats_available_bytes{job="kubelet",metrics_path="/metrics"} / kubelet_volume_stats_capacity_bytes{job="kubelet",metrics_path="/metrics"}) < 0.15 and kubelet_volume_stats_used_bytes{job="kubelet",metrics_path="/metrics"} > 0 and predict_linear(kubelet_volume_stats_available_bytes{job="kubelet",metrics_path="/metrics"}[6h], 4 * 24 * 3600) < 0  unless on(namespace, persistentvolumeclaim) kube_persistentvolumeclaim_access_mode{access_mode="ReadOnlyMany"} == 1 unless on(namespace,persistentvolumeclaim) kube_persistentvolumeclaim_labels{label_excluded_from_alerts="true"}== 1) * on(namespace) group_left(label_appcat_vshn_io_claim_namespace)kube_namespace_labels, "name", "$1", "namespace","(vshn-postgresql-test)")`
 
-	patroniMemoryCritical = `label_replace( topk(1, (max(container_memory_working_set_bytes{container="patroni"})without (name, id)  / on(container,pod,namespace)  kube_pod_container_resource_limits{resource="memory"}* 100) > 85) * on(namespace) group_left(label_appcat_vshn_io_claim_namespace)kube_namespace_labels, "name", "$1", "namespace","(vshn-postgresql-test)")`
+	patroniMemoryCritical = `label_replace( topk(1, (max(container_memory_rss{container="patroni"})without (name, id)  / on(container,pod,namespace)  kube_pod_container_resource_limits{resource="memory"}* 100) > 85) * on(namespace) group_left(label_appcat_vshn_io_claim_namespace)kube_namespace_labels, "name", "$1", "namespace","(vshn-postgresql-test)")`
 
 	patroniPersistentVolumeFillingUp = `label_replace( bottomk(1, (kubelet_volume_stats_available_bytes{job="kubelet", metrics_path="/metrics"} / kubelet_volume_stats_capacity_bytes{job="kubelet",metrics_path="/metrics"}) < 0.03 and kubelet_volume_stats_used_bytes{job="kubelet",metrics_path="/metrics"} > 0 unless on(namespace,persistentvolumeclaim) kube_persistentvolumeclaim_access_mode{access_mode="ReadOnlyMany"} == 1 unless on(namespace,persistentvolumeclaim) kube_persistentvolumeclaim_labels{label_excluded_from_alerts="true"}== 1) * on(namespace) group_left(label_appcat_vshn_io_claim_namespace)kube_namespace_labels, "name", "$1", "namespace","(vshn-postgresql-test)")`
 
@@ -30,7 +30,7 @@ func TestNewAlertSetBuilder(t *testing.T) {
 	assert.Empty(t, builder.as.customRules)
 	assert.Empty(t, builder.as.alerts)
 
-	builder.AddAll()
+	builder.AddAllDB()
 	// if this test fail, please simply update order and count of alerts in this slice
 	expectedAlerts := []alert{pvFillUp, pvExpectedFillUp, memCritical}
 

--- a/pkg/comp-functions/functions/vshnmariadb/register.go
+++ b/pkg/comp-functions/functions/vshnmariadb/register.go
@@ -33,7 +33,7 @@ func init() {
 			},
 			{
 				Name:    "non-sla-prometheus-rules",
-				Execute: nonsla.GenerateNonSLAPromRules[*vshnv1.VSHNMariaDB](nonsla.NewAlertSetBuilder("mariadb-galera").AddAll().GetAlerts()),
+				Execute: nonsla.GenerateNonSLAPromRules[*vshnv1.VSHNMariaDB](nonsla.NewAlertSetBuilder("mariadb-galera").AddAllDB().GetAlerts()),
 			},
 			{
 				Name:    "billing",

--- a/pkg/comp-functions/functions/vshnpostgres/register.go
+++ b/pkg/comp-functions/functions/vshnpostgres/register.go
@@ -7,7 +7,7 @@ import (
 	"github.com/vshn/appcat/v4/pkg/comp-functions/runtime"
 )
 
-var pgAlerts = nonsla.NewAlertSetBuilder("patroni").AddAll().AddCustomServiceRule("maxconnections", maxConnectionsAlert).GetAlerts()
+var pgAlerts = nonsla.NewAlertSetBuilder("patroni").AddAllDB().AddCustomServiceRule("maxconnections", maxConnectionsAlert).GetAlerts()
 
 func init() {
 	runtime.RegisterService[*vshnv1.VSHNPostgreSQL]("postgresql", runtime.Service[*vshnv1.VSHNPostgreSQL]{

--- a/pkg/comp-functions/functions/vshnpostgrescnpg/register.go
+++ b/pkg/comp-functions/functions/vshnpostgrescnpg/register.go
@@ -8,7 +8,7 @@ import (
 )
 
 var pgAlerts = nonsla.NewAlertSetBuilder("patroni").
-	AddAll().
+	AddAllDB().
 	AddCustomServiceRule("maxconnections", maxConnectionsAlert).
 	AddCustomServiceRule("longrunningtx", longRunningTransactionAlert).
 	AddCustomServiceRule("backendwaiting", backendsWaitingAlert).

--- a/pkg/comp-functions/functions/vshnredis/register.go
+++ b/pkg/comp-functions/functions/vshnredis/register.go
@@ -40,7 +40,7 @@ func init() {
 			},
 			{
 				Name:    "non-sla-prometheus-rules",
-				Execute: nonsla.GenerateNonSLAPromRules[*vshnv1.VSHNRedis](nonsla.NewAlertSetBuilder("redis").AddAll().GetAlerts()),
+				Execute: nonsla.GenerateNonSLAPromRules[*vshnv1.VSHNRedis](nonsla.NewAlertSetBuilder("redis").AddAllDB().GetAlerts()),
 			},
 			{
 				Name:    "billing",


### PR DESCRIPTION
## Summary

* This PR adds a new alert for critical memory on DB systems. It uses the `container_memory_rss` metric which doesn't include the cache.

## Checklist

- [x] Update tests.
- [ ] Link this PR to related issues.
- [ ] Merge with `/merge` comment.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->


Component PR: https://github.com/vshn/component-appcat/pull/1108