### PR TITLE
Fix empty string serverName parameter for CNPG

### DIFF
--- a/pkg/comp-functions/functions/vshnpostgrescnpg/backup.go
+++ b/pkg/comp-functions/functions/vshnpostgrescnpg/backup.go
@@ -64,7 +64,6 @@ func insertBackupValues(svc *runtime.ServiceRuntime, comp *vshnv1.VSHNPostgreSQL
 		"isWALArchiver": true,
 		"parameters": map[string]any{
 			"barmanObjectName": "postgresql-object-store",
-			"serverName":       "",
 		},
 	}}
 

--- a/pkg/comp-functions/functions/vshnpostgrescnpg/backup_test.go
+++ b/pkg/comp-functions/functions/vshnpostgrescnpg/backup_test.go
@@ -88,7 +88,7 @@ func TestBackupBooststrapEnabled(t *testing.T) {
 	assert.True(t, plugins[0]["isWALArchiver"].(bool))
 	pluginParams := plugins[0]["parameters"].(map[string]any)
 	assert.Equal(t, "postgresql-object-store", pluginParams["barmanObjectName"])
-	assert.Equal(t, "", pluginParams["serverName"])
+	assert.Nil(t, pluginParams["serverName"])
 
 	// Check scheduled backups
 	scheduledBackups := backupValues["scheduledBackups"].([]map[string]any)


### PR DESCRIPTION


## Summary
Passing an empty string for serverName resulted in an `ObjectStore` which was partially invalid.

`kubectl cnpg status $clusterName` threw an error that there's no recovery window for the instance.

By not setting it at all, it will default to the cluster name.

The issue is only of cosmetic nature, but could cause concern if a user saw the error.
## Checklist

- [ ] Update tests.
- [ ] Link this PR to related issues.
- [ ] Merge with `/merge` comment.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->


Component PR: https://github.com/vshn/component-appcat/pull/1109