### PR TITLE
Fix keycloak restore copy job

### DIFF
--- a/pkg/comp-functions/functions/common/password.go
+++ b/pkg/comp-functions/functions/common/password.go
@@ -95,6 +95,60 @@ func AddGenericSecret(comp InfoGetter, svc *runtime.ServiceRuntime, suffix strin
 
 }
 
+// AddCredentialsSecretFromValues creates the credentials-secret using pre-set values
+// instead of generating new passwords. Intended for restore scenarios where the
+// credentials from the source instance must be preserved.
+// Fields in fieldList that are missing from values will have new passwords generated.
+func AddCredentialsSecretFromValues(comp InfoGetter, svc *runtime.ServiceRuntime, values map[string][]byte, fieldList []string, allowDeletion bool, opts ...CredentialSecretOption) (string, error) {
+	secretObjectName := runtime.EscapeDNS1123(comp.GetName()+"-credentials-secret", false)
+
+	cd := []xkube.ConnectionDetail{}
+	stringData := map[string]string{}
+
+	var err error
+	for _, field := range fieldList {
+		if v, ok := values[field]; ok {
+			stringData[field] = string(v)
+		} else {
+			svc.Log.Info("Restore credentials missing field, generating new password", "secret", secretObjectName, "field", field)
+			stringData[field], err = genPassword()
+			if err != nil {
+				return secretObjectName, fmt.Errorf("cannot generate pw for %s: %w", field, err)
+			}
+		}
+	}
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretObjectName,
+			Namespace: comp.GetInstanceNamespace(),
+		},
+		StringData: stringData,
+	}
+
+	for _, field := range fieldList {
+		cd = append(cd, xkube.ConnectionDetail{
+			ObjectReference: corev1.ObjectReference{
+				APIVersion: "v1",
+				Kind:       "Secret",
+				Namespace:  comp.GetInstanceNamespace(),
+				Name:       secretObjectName,
+				FieldPath:  "data." + field,
+			},
+			ToConnectionSecretKey: field,
+		})
+	}
+
+	for _, o := range opts {
+		cd = o(secret, cd)
+	}
+
+	if allowDeletion {
+		return secretObjectName, svc.SetDesiredKubeObject(secret, secretObjectName, runtime.KubeOptionAddConnectionDetails(svc.GetCrossplaneNamespace(), cd...), runtime.KubeOptionAllowDeletion)
+	}
+	return secretObjectName, svc.SetDesiredKubeObject(secret, secretObjectName, runtime.KubeOptionAddConnectionDetails(svc.GetCrossplaneNamespace(), cd...))
+}
+
 func genPassword() (string, error) {
 	gen, err := password.NewGenerator(&password.GeneratorInput{})
 	if err != nil {

--- a/pkg/comp-functions/functions/common/password.go
+++ b/pkg/comp-functions/functions/common/password.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/sethvargo/go-password/password"
@@ -38,7 +39,7 @@ func AddGenericSecret(comp InfoGetter, svc *runtime.ServiceRuntime, suffix strin
 
 	err := svc.GetObservedKubeObject(secret, secretObjectName)
 	if err != nil {
-		if err == runtime.ErrNotFound {
+		if errors.Is(err, runtime.ErrNotFound) {
 			svc.Log.Info("Could not find secret, generating new passwords", "secret", secretObjectName)
 		} else {
 			return secretObjectName, err
@@ -116,17 +117,6 @@ func AddCredentialsSecretFromValues(comp InfoGetter, svc *runtime.ServiceRuntime
 				return secretObjectName, fmt.Errorf("cannot generate pw for %s: %w", field, err)
 			}
 		}
-	}
-
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      secretObjectName,
-			Namespace: comp.GetInstanceNamespace(),
-		},
-		StringData: stringData,
-	}
-
-	for _, field := range fieldList {
 		cd = append(cd, xkube.ConnectionDetail{
 			ObjectReference: corev1.ObjectReference{
 				APIVersion: "v1",
@@ -137,6 +127,14 @@ func AddCredentialsSecretFromValues(comp InfoGetter, svc *runtime.ServiceRuntime
 			},
 			ToConnectionSecretKey: field,
 		})
+	}
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretObjectName,
+			Namespace: comp.GetInstanceNamespace(),
+		},
+		StringData: stringData,
 	}
 
 	for _, o := range opts {

--- a/pkg/comp-functions/functions/common/password_test.go
+++ b/pkg/comp-functions/functions/common/password_test.go
@@ -11,6 +11,37 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+func TestAddCredentialsSecretFromValues(t *testing.T) {
+	comp := &vshnv1.VSHNRedis{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "mytest",
+		},
+	}
+
+	svc := commontest.LoadRuntimeFromFile(t, "empty.yaml")
+
+	values := map[string][]byte{
+		"adminPassword": []byte("oldpassword"),
+	}
+
+	res, err := AddCredentialsSecretFromValues(comp, svc, values, []string{"adminPassword", "missingField"}, DisallowDeletion)
+	assert.NoError(t, err)
+	assert.Equal(t, "mytest-credentials-secret", res)
+
+	secret := &corev1.Secret{}
+	assert.NoError(t, svc.GetDesiredKubeObject(secret, res))
+
+	// Provided value must be preserved exactly.
+	assert.Equal(t, "oldpassword", secret.StringData["adminPassword"])
+
+	// Missing field must be generated (non-empty).
+	assert.NotEmpty(t, secret.StringData["missingField"])
+
+	obj := &xkube.Object{}
+	assert.NoError(t, svc.GetDesiredComposedResourceByName(obj, res))
+	assert.Len(t, obj.Spec.ConnectionDetails, 2)
+}
+
 func TestAddCredentialsSecret(t *testing.T) {
 	comp := &vshnv1.VSHNRedis{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/comp-functions/functions/vshnkeycloak/deploy.go
+++ b/pkg/comp-functions/functions/vshnkeycloak/deploy.go
@@ -1191,7 +1191,7 @@ func copyKeycloakCredentials(comp *vshnv1.VSHNKeycloak, svc *runtime.ServiceRunt
 	observed := &corev1.Secret{}
 	err = svc.GetObservedKubeObject(observed, stagingSecretName)
 	if err != nil {
-		if err == runtime.ErrNotFound {
+		if errors.Is(err, runtime.ErrNotFound) {
 			return nil, nil
 		}
 		return nil, fmt.Errorf("cannot observe restore credentials: %w", err)

--- a/pkg/comp-functions/functions/vshnkeycloak/deploy.go
+++ b/pkg/comp-functions/functions/vshnkeycloak/deploy.go
@@ -48,6 +48,7 @@ const (
 	providerInitName              = "copy-original-providers"
 	realmInitName                 = "copy-original-realm-setup"
 	customImagePullsecretName     = "customimagepullsecret"
+	restoreCredentialsSuffix      = "restore-credentials"
 	cdCertsSuffix                 = "-keycloakx-http-server-cert"
 	customMountTypeSecret         = "secret"
 	customMountTypeConfigMap      = "configMap"
@@ -138,14 +139,22 @@ func DeployKeycloak(ctx context.Context, comp *vshnv1.VSHNKeycloak, svc *runtime
 
 	var adminSecret string
 	if comp.Spec.Parameters.Restore != nil {
-		err := copyKeycloakCredentials(comp, svc)
+		oldCreds, err := copyKeycloakCredentials(comp, svc)
 		if err != nil {
-			return runtime.NewWarningResult(fmt.Sprintf("cannot copy keycloak secret: %s", err))
+			return runtime.NewWarningResult(fmt.Sprintf("cannot copy keycloak credentials: %s", err))
 		}
-	}
-	adminSecret, err = common.AddCredentialsSecret(comp, svc, []string{internalAdminPWSecretField, adminPWSecretField}, common.DisallowDeletion)
-	if err != nil {
-		return runtime.NewWarningResult(fmt.Sprintf("cannot generate admin secret: %s", err))
+		if oldCreds == nil {
+			return runtime.NewWarningResult("waiting for restore credentials to be available")
+		}
+		adminSecret, err = common.AddCredentialsSecretFromValues(comp, svc, oldCreds, []string{internalAdminPWSecretField, adminPWSecretField}, common.DisallowDeletion)
+		if err != nil {
+			return runtime.NewWarningResult(fmt.Sprintf("cannot set restore admin secret: %s", err))
+		}
+	} else {
+		adminSecret, err = common.AddCredentialsSecret(comp, svc, []string{internalAdminPWSecretField, adminPWSecretField}, common.DisallowDeletion)
+		if err != nil {
+			return runtime.NewWarningResult(fmt.Sprintf("cannot generate admin secret: %s", err))
+		}
 	}
 
 	cd, err := svc.GetObservedComposedResourceConnectionDetails(adminSecret)
@@ -1114,7 +1123,10 @@ func addCustomFileCopyInitContainer(comp *vshnv1.VSHNKeycloak, extraInitContaine
 	return extraInitContainersMap, nil
 }
 
-func copyKeycloakCredentials(comp *vshnv1.VSHNKeycloak, svc *runtime.ServiceRuntime) error {
+// copyKeycloakCredentials schedules a Job to copy old credentials into a staging secret
+// and creates an observe-only KubeObject for it. Returns the credential data once the
+// copy job has run, or nil if the staging secret is not yet available.
+func copyKeycloakCredentials(comp *vshnv1.VSHNKeycloak, svc *runtime.ServiceRuntime) (map[string][]byte, error) {
 	copyJob := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      comp.GetName() + "-copyjob",
@@ -1158,11 +1170,38 @@ func copyKeycloakCredentials(comp *vshnv1.VSHNKeycloak, svc *runtime.ServiceRunt
 
 	err := svc.SetDesiredKubeObjectWithName(copyJob, comp.GetName()+"-copyjob", "copy-job")
 	if err != nil {
-		err = fmt.Errorf("cannot create copyJob: %w", err)
-		return err
+		return nil, fmt.Errorf("cannot create copyJob: %w", err)
 	}
 
-	return nil
+	// Observe-only KubeObject for the staging secret written by the copy job.
+	// KubeOptionObserve prevents provider-kubernetes from managing (and overwriting) it.
+	stagingSecretName := runtime.EscapeDNS1123(comp.GetName()+"-"+restoreCredentialsSuffix, false)
+	stagingSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      stagingSecretName,
+			Namespace: comp.GetInstanceNamespace(),
+		},
+	}
+	err = svc.SetDesiredKubeObject(stagingSecret, stagingSecretName, runtime.KubeOptionObserve)
+	if err != nil {
+		return nil, fmt.Errorf("cannot create restore credentials observer: %w", err)
+	}
+
+	// Returns nil until the copy job has run and the secret exists.
+	observed := &corev1.Secret{}
+	err = svc.GetObservedKubeObject(observed, stagingSecretName)
+	if err != nil {
+		if err == runtime.ErrNotFound {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("cannot observe restore credentials: %w", err)
+	}
+
+	if len(observed.Data) == 0 {
+		return nil, nil
+	}
+
+	return observed.Data, nil
 }
 
 func addServiceMonitor(comp *vshnv1.VSHNKeycloak, svc *runtime.ServiceRuntime) error {

--- a/pkg/comp-functions/functions/vshnkeycloak/deploy_test.go
+++ b/pkg/comp-functions/functions/vshnkeycloak/deploy_test.go
@@ -7,10 +7,12 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	xhelmv1 "github.com/vshn/appcat/v4/apis/helm/release/v1beta1"
+	xkube "github.com/vshn/appcat/v4/apis/kubernetes/v1alpha2"
 	vshnv1 "github.com/vshn/appcat/v4/apis/vshn/v1"
 	"github.com/vshn/appcat/v4/pkg/comp-functions/functions/common"
 	"github.com/vshn/appcat/v4/pkg/comp-functions/functions/commontest"
 	"gopkg.in/yaml.v2"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
@@ -399,4 +401,53 @@ func Test_configOrEnvChanged(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func newKeycloakCompWithRestore(name, sourceClaim string) *vshnv1.VSHNKeycloak {
+	return &vshnv1.VSHNKeycloak{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+		},
+		Spec: vshnv1.VSHNKeycloakSpec{
+			Parameters: vshnv1.VSHNKeycloakParameters{
+				Restore: &vshnv1.VSHNPostgreSQLRestore{
+					ClaimName: sourceClaim,
+				},
+			},
+		},
+	}
+}
+
+func Test_copyKeycloakCredentials_WaitingForCopyJob(t *testing.T) {
+	// Staging secret not yet in observed state — copy job has not run.
+	svc := commontest.LoadRuntimeFromFile(t, "vshnkeycloak/01_default.yaml")
+	comp := newKeycloakCompWithRestore("mycloak", "old-keycloak")
+
+	creds, err := copyKeycloakCredentials(comp, svc)
+	assert.NoError(t, err)
+	assert.Nil(t, creds, "expected nil credentials while waiting for copy job")
+
+	// Copy job must be scheduled.
+	copyJob := &batchv1.Job{}
+	assert.NoError(t, svc.GetDesiredKubeObject(copyJob, "copy-job"))
+
+	// Observer KubeObject must be scheduled with observe-only policy.
+	observer := &xkube.Object{}
+	stagingName := comp.GetName() + "-" + restoreCredentialsSuffix
+	assert.NoError(t, svc.GetDesiredComposedResourceByName(observer, stagingName))
+	assert.Len(t, observer.Spec.ManagementPolicies, 1)
+	assert.Equal(t, "Observe", string(observer.Spec.ManagementPolicies[0]))
+}
+
+func Test_copyKeycloakCredentials_CredentialsReady(t *testing.T) {
+	// Staging secret is present in observed state — copy job has already run.
+	svc := commontest.LoadRuntimeFromFile(t, "vshnkeycloak/restore_with_staging_secret.yaml")
+	comp := newKeycloakCompWithRestore("mycloak", "old-keycloak")
+
+	creds, err := copyKeycloakCredentials(comp, svc)
+	assert.NoError(t, err)
+	assert.NotNil(t, creds)
+	assert.Equal(t, "secret1", string(creds[adminPWSecretField]))
+	assert.Equal(t, "secret2", string(creds[internalAdminPWSecretField]))
 }

--- a/pkg/comp-functions/functions/vshnkeycloak/scripts/copy-kc-creds.sh
+++ b/pkg/comp-functions/functions/vshnkeycloak/scripts/copy-kc-creds.sh
@@ -10,4 +10,4 @@ source_namespace=$(kubectl get xvshnkeycloak "${sourcexrdname}" -ojson | jq -r '
 
 
 echo "copy secret"
-kubectl -n "${source_namespace}" get secret "${sourcexrdname}"-credentials-secret -ojson | jq --arg targetxrdname "${targetxrdname}" 'del(.metadata.namespace) | del(.metadata.labels) | del(.metadata.annotations) | del(.metadata.resourceVersion) | del(.metadata.uid) | .metadata.name = $targetxrdname + "-credentials-secret"' | kubectl -n "${TARGET_NAMESPACE}" apply -f -
+kubectl -n "${source_namespace}" get secret "${sourcexrdname}"-credentials-secret -ojson | jq --arg targetxrdname "${targetxrdname}" 'del(.metadata.namespace) | del(.metadata.labels) | del(.metadata.annotations) | del(.metadata.resourceVersion) | del(.metadata.uid) | .metadata.name = $targetxrdname + "-restore-credentials"' | kubectl -n "${TARGET_NAMESPACE}" apply -f -

--- a/test/functions/vshnkeycloak/restore_with_staging_secret.yaml
+++ b/test/functions/vshnkeycloak/restore_with_staging_secret.yaml
@@ -1,0 +1,34 @@
+desired: {}
+input:
+  apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    annotations: {}
+    labels:
+      name: xfn-config
+    name: xfn-config
+  data:
+    defaultPlan: standard-2
+    controlNamespace: appcat-control
+    kubectl_image: bitnami/kubectl:latest
+    plans: '{"standard-2": {"size": {"cpu": "500m", "disk": "16Gi", "enabled":
+            true, "memory": "2Gi"}}}'
+observed:
+  resources:
+    mycloak-restore-credentials:
+      resource:
+        apiVersion: v1
+        kind: Object
+        metadata:
+          name: mycloak-restore-credentials
+        status:
+          atProvider:
+            manifest:
+              apiVersion: v1
+              kind: Secret
+              metadata:
+                name: mycloak-restore-credentials
+                namespace: vshn-keycloak-mycloak-instancens
+              data:
+                adminPassword: c2VjcmV0MQ==
+                internalAdminPassword: c2VjcmV0Mg==


### PR DESCRIPTION
## Summary

This fixes the copy job used when restoring a vshnkeycloak instance. By using a staging secret we can ensure that provider kubernetes doesn't overwrite the secret again on a reconcile.

## Checklist

- [ ] Update tests.
- [ ] Link this PR to related issues.
- [ ] Merge with `/merge` comment.

Component PR: https://github.com/vshn/component-appcat/pull/1119