### PR TITLE
Fix keycloak connnection to stackgres

### DIFF
--- a/pkg/comp-functions/functions/vshnkeycloak/deploy.go
+++ b/pkg/comp-functions/functions/vshnkeycloak/deploy.go
@@ -594,8 +594,9 @@ func newValues(ctx context.Context, svc *runtime.ServiceRuntime, comp *vshnv1.VS
 			},
 		},
 		{
-			"name":  "KC_DB_URL_PROPERTIES",
-			"value": "?sslmode=verify-full&sslrootcert=/certs/pg/ca.crt",
+			"name": "KC_DB_URL_PROPERTIES",
+			// targetServerType=any is necessary only for stackgres based instances, remove once stackgres is gone
+			"value": "?sslmode=verify-full&sslrootcert=/certs/pg/ca.crt&targetServerType=any",
 		},
 		{
 			"name": "JAVA_OPTS_APPEND",


### PR DESCRIPTION
## Summary

* Our Keycloak version 26.5.6 does not work with Stackgres, we need to use `targetServerType=any` to help pgbouncer to properly connect to postgres. This changes has to be reverted once stackgres is gone.

## Checklist

- [] Update tests.
- [ ] Link this PR to related issues.
- [ ] Merge with `/merge` comment.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->


Component PR: https://github.com/vshn/component-appcat/pull/1122