### PR TITLE
Keycloak: keep apply config for 12 hours after completion

### DIFF
--- a/pkg/comp-functions/functions/vshnkeycloak/deploy.go
+++ b/pkg/comp-functions/functions/vshnkeycloak/deploy.go
@@ -464,7 +464,7 @@ func buildConfigApplyJob(comp *vshnv1.VSHNKeycloak, adminSecret, jobName string)
 		},
 		Spec: batchv1.JobSpec{
 			BackoffLimit:            ptr.To(int32(10)),
-			TTLSecondsAfterFinished: ptr.To(int32(3600)),
+			TTLSecondsAfterFinished: ptr.To(int32(43200)),
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
 					RestartPolicy:    corev1.RestartPolicyOnFailure,


### PR DESCRIPTION
## Summary

The apply config job for VSHNKeycloak was only kept for an hour. This increases it to 12 hours to allow for more debugging time

## Checklist

- [ ] Update tests.
- [ ] Link this PR to related issues.
- [ ] Merge with `/merge` comment.


Component PR: https://github.com/vshn/component-appcat/pull/1125