### PR TITLE
Add missing sidecar and init container to config

### DIFF
--- a/pkg/comp-functions/functions/vshnnextcloud/deploy.go
+++ b/pkg/comp-functions/functions/vshnnextcloud/deploy.go
@@ -422,10 +422,16 @@ func newValues(ctx context.Context, svc *runtime.ServiceRuntime, comp *vshnv1.VS
 			"password": string(cd[vshnpostgres.PostgresqlPassword]),
 		}
 
+		dbcheckerImage := svc.Config.Data["busybox_image"]
+
+		if tag := svc.Config.Data["busybox_image_tag"]; tag != "" {
+			dbcheckerImage = fmt.Sprintf("%s:%s", dbcheckerImage, tag)
+		}
+
 		extraInitContainers = []map[string]any{
 			{
 				"name":  "dbchecker",
-				"image": svc.Config.Data["busybox_image"],
+				"image": dbcheckerImage,
 				"command": []string{
 					"sh",
 					"-c",

--- a/pkg/comp-functions/functions/vshnredis/redis_deploy.go
+++ b/pkg/comp-functions/functions/vshnredis/redis_deploy.go
@@ -304,9 +304,14 @@ func newValues(ctx context.Context, svc *runtime.ServiceRuntime, comp *vshnv1.VS
 			return nil, err
 		}
 
+		exporterTag := svc.Config.Data["exporter_tag"]
+		if exporterTag == "" {
+			exporterTag = "1.76.0-debian-12-r0"
+		}
+
 		if err := common.SetNestedObjectValue(values, []string{"metrics", "image"}, map[string]any{
 			"repository": fmt.Sprintf("%s/redis-exporter", imageRepositoryPrefix),
-			"tag":        "1.76.0-debian-12-r0",
+			"tag":        exporterTag,
 		}); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Summary

- dbchecker for Nextcloud, now uses the same image as for Keycloak
- redis-export for redis is now configurable, but we will need to build it from source ourselves, as the upstream image is not compatible with whatever bitnami does

## Checklist

- [ ] Update tests.
- [ ] Link this PR to related issues.
- [ ] Merge with `/merge` comment.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->


Component PR: https://github.com/vshn/component-appcat/pull/1126