### PR TITLE
Fix namespace quotas for appuio cloud

### DIFF
--- a/pkg/common/quotas/quotas.go
+++ b/pkg/common/quotas/quotas.go
@@ -187,7 +187,22 @@ func AddInitalNamespaceQuotas(ctx context.Context, ns *corev1.Namespace, s *util
 	}
 
 	if _, ok := annotations[utils.CpuRequestTerminationQuota]; !ok {
-		annotations[utils.CpuRequestTerminationQuota] = "1000m"
+		annotations[utils.CpuRequestTerminationQuota] = r.CPURequests.String()
+		added = true
+	}
+
+	if _, ok := annotations[utils.CpuLimitTerminationQuota]; !ok {
+		annotations[utils.CpuLimitTerminationQuota] = r.CPULimits.String()
+		added = true
+	}
+
+	if _, ok := annotations[utils.MemoryRequestTerminationQuota]; !ok {
+		annotations[utils.MemoryRequestTerminationQuota] = r.MemoryRequests.String()
+		added = true
+	}
+
+	if _, ok := annotations[utils.MemoryLimitTerminationQuota]; !ok {
+		annotations[utils.MemoryLimitTerminationQuota] = r.MemoryLimits.String()
 		added = true
 	}
 

--- a/pkg/common/quotas/quotas_test.go
+++ b/pkg/common/quotas/quotas_test.go
@@ -56,7 +56,7 @@ func TestQuotaChecker_CheckQuotas(t *testing.T) {
 		{
 			name: "GivenNotInstancenamespace_WhenCheckingAgainstDefault_ThenError",
 			requested: utils.Resources{
-				CPURequests:    *resource.NewMilliQuantity(5000, resource.DecimalSI),
+				CPURequests:    *resource.NewMilliQuantity(5500, resource.DecimalSI),
 				CPULimits:      *resource.NewMilliQuantity(400, resource.DecimalSI),
 				Disk:           *resource.NewQuantity(21474836480, resource.BinarySI),
 				MemoryRequests: *resource.NewQuantity(1811939328, resource.BinarySI),
@@ -87,7 +87,7 @@ func TestQuotaChecker_CheckQuotas(t *testing.T) {
 		{
 			name: "GivenInstancenamespace_WhenCheckingAgainst_ThenError",
 			requested: utils.Resources{
-				CPURequests:    *resource.NewMilliQuantity(5000, resource.DecimalSI),
+				CPURequests:    *resource.NewMilliQuantity(5500, resource.DecimalSI),
 				CPULimits:      *resource.NewMilliQuantity(400, resource.DecimalSI),
 				Disk:           *resource.NewQuantity(21474836480, resource.BinarySI),
 				MemoryRequests: *resource.NewQuantity(1811939328, resource.BinarySI),

--- a/pkg/common/utils/resources.go
+++ b/pkg/common/utils/resources.go
@@ -67,12 +67,12 @@ const (
 
 var (
 	// Now all the permutations for the annotations
-	CpuRequestAnnotation       = fmt.Sprintf("%s%s.%s", quotaAnnotationPrefix, resourceQuotaNameCompute, quotaResourceCPURequests)
-	CpuLimitAnnotation         = fmt.Sprintf("%s%s.%s", quotaAnnotationPrefix, resourceQuotaNameCompute, quotaResourceCPULimits)
-	MemoryRequestAnnotation    = fmt.Sprintf("%s%s.%s", quotaAnnotationPrefix, resourceQuotaNameCompute, quotaResourceMemoryRequests)
-	MemoryLimitAnnotation      = fmt.Sprintf("%s%s.%s", quotaAnnotationPrefix, resourceQuotaNameCompute, quotaResourceMemoryLimits)
-	DiskAnnotation             = fmt.Sprintf("%s%s.%s", quotaAnnotationPrefix, resourceQuotaNameObjects, quotaResourceDisk)
-	StorageClassesAnnotation   = fmt.Sprintf("%s%s.storageclasses", quotaAnnotationPrefix, resourceQuotaNameObjects)
+	CpuRequestAnnotation          = fmt.Sprintf("%s%s.%s", quotaAnnotationPrefix, resourceQuotaNameCompute, quotaResourceCPURequests)
+	CpuLimitAnnotation            = fmt.Sprintf("%s%s.%s", quotaAnnotationPrefix, resourceQuotaNameCompute, quotaResourceCPULimits)
+	MemoryRequestAnnotation       = fmt.Sprintf("%s%s.%s", quotaAnnotationPrefix, resourceQuotaNameCompute, quotaResourceMemoryRequests)
+	MemoryLimitAnnotation         = fmt.Sprintf("%s%s.%s", quotaAnnotationPrefix, resourceQuotaNameCompute, quotaResourceMemoryLimits)
+	DiskAnnotation                = fmt.Sprintf("%s%s.%s", quotaAnnotationPrefix, resourceQuotaNameObjects, quotaResourceDisk)
+	StorageClassesAnnotation      = fmt.Sprintf("%s%s.storageclasses", quotaAnnotationPrefix, resourceQuotaNameObjects)
 	CpuRequestTerminationQuota    = fmt.Sprintf("%s%s.%s", quotaAnnotationPrefix, resourceQuotaNameCompute+"-terminating", quotaResourceCPURequests)
 	CpuLimitTerminationQuota      = fmt.Sprintf("%s%s.%s", quotaAnnotationPrefix, resourceQuotaNameCompute+"-terminating", quotaResourceCPULimits)
 	MemoryRequestTerminationQuota = fmt.Sprintf("%s%s.%s", quotaAnnotationPrefix, resourceQuotaNameCompute+"-terminating", quotaResourceMemoryRequests)

--- a/pkg/common/utils/resources.go
+++ b/pkg/common/utils/resources.go
@@ -73,19 +73,23 @@ var (
 	MemoryLimitAnnotation      = fmt.Sprintf("%s%s.%s", quotaAnnotationPrefix, resourceQuotaNameCompute, quotaResourceMemoryLimits)
 	DiskAnnotation             = fmt.Sprintf("%s%s.%s", quotaAnnotationPrefix, resourceQuotaNameObjects, quotaResourceDisk)
 	StorageClassesAnnotation   = fmt.Sprintf("%s%s.storageclasses", quotaAnnotationPrefix, resourceQuotaNameObjects)
-	CpuRequestTerminationQuota = fmt.Sprintf("%s%s.%s", quotaAnnotationPrefix, resourceQuotaNameCompute+"-terminating", quotaResourceCPURequests)
+	CpuRequestTerminationQuota    = fmt.Sprintf("%s%s.%s", quotaAnnotationPrefix, resourceQuotaNameCompute+"-terminating", quotaResourceCPURequests)
+	CpuLimitTerminationQuota      = fmt.Sprintf("%s%s.%s", quotaAnnotationPrefix, resourceQuotaNameCompute+"-terminating", quotaResourceCPULimits)
+	MemoryRequestTerminationQuota = fmt.Sprintf("%s%s.%s", quotaAnnotationPrefix, resourceQuotaNameCompute+"-terminating", quotaResourceMemoryRequests)
+	MemoryLimitTerminationQuota   = fmt.Sprintf("%s%s.%s", quotaAnnotationPrefix, resourceQuotaNameCompute+"-terminating", quotaResourceMemoryLimits)
 
 	ErrNSLimitReached = fmt.Errorf("creating a new instance will violate the namespace quota." +
 		"Please contact VSHN support to increase the amounts of namespaces you can create.")
 
-	// These defaults allow up to a PostgreSQL or Redis standard-8 with one replica.
+	// These defaults allow up to a PostgreSQL or Redis standard-8 with one replica
+	// plus headroom for jobs and maintenance. Agreed with aldebaran: 22Gi memory, 5 CPU.
 
-	// defaultCPURequests 2* standard-8 will request 4 CPUs. This default has 500m as spare for jobs
-	DefaultCPURequests = resource.NewMilliQuantity(4500, resource.DecimalSI)
+	// defaultCPURequests 5 CPU total budget for the namespace
+	DefaultCPURequests = resource.NewMilliQuantity(5000, resource.DecimalSI)
 	// defaultCPULimit by default same as DefaultCPURequests
 	DefaultCPULimits = DefaultCPURequests
-	// defaultMemoryRequests 2* standard-8 will request 16Gb. This default has 500mb as spare for jobs
-	DefaultMemoryRequests = resource.NewQuantity(17301504000, resource.BinarySI)
+	// defaultMemoryRequests 22Gi total memory budget for the namespace
+	DefaultMemoryRequests = resource.NewQuantity(23622320128, resource.BinarySI)
 	// defaultMemoryLimits same as DefaultMemoryRequests
 	DefaultMemoryLimits = DefaultMemoryRequests
 	// defaultDiskRequests should be plenty for a large amount of replicas for any service

--- a/pkg/controller/webhooks/default_handler_test.go
+++ b/pkg/controller/webhooks/default_handler_test.go
@@ -72,13 +72,13 @@ func TestSetupWebhookHandlerWithManager_ValidateCreate(t *testing.T) {
 	// When quota breached
 	// CPU Requests
 	keycloakInvalid := keycloakOrig.DeepCopy()
-	keycloakInvalid.Spec.Parameters.Size.Requests.CPU = "5000m"
+	keycloakInvalid.Spec.Parameters.Size.Requests.CPU = "6000m"
 	_, err = handler.ValidateCreate(ctx, keycloakInvalid)
 	assert.Error(t, err)
 
 	// CPU Limit
 	keycloakInvalid = keycloakOrig.DeepCopy()
-	keycloakInvalid.Spec.Parameters.Size.CPU = "5000m"
+	keycloakInvalid.Spec.Parameters.Size.CPU = "6000m"
 	_, err = handler.ValidateCreate(ctx, keycloakInvalid)
 	assert.Error(t, err)
 

--- a/pkg/controller/webhooks/postgresql_test.go
+++ b/pkg/controller/webhooks/postgresql_test.go
@@ -181,7 +181,7 @@ func TestPostgreSQLWebhookHandler_ValidateCreate(t *testing.T) {
 
 	// Memory Limits
 	pgInvalid = pgOrig.DeepCopy()
-	pgInvalid.Spec.Parameters.Size.Memory = "25Gi"
+	pgInvalid.Spec.Parameters.Size.Memory = "30Gi"
 	_, err = handler.ValidateCreate(ctx, pgInvalid)
 	assert.Error(t, err)
 

--- a/pkg/controller/webhooks/redis_test.go
+++ b/pkg/controller/webhooks/redis_test.go
@@ -72,13 +72,13 @@ func TestSetupRedisWebhookHandlerWithManager_ValidateCreate(t *testing.T) {
 	// When quota breached
 	// CPU Requests
 	redisInvalid = redisOrig.DeepCopy()
-	redisInvalid.Spec.Parameters.Size.CPURequests = "5000m"
+	redisInvalid.Spec.Parameters.Size.CPURequests = "6000m"
 	_, err = handler.ValidateCreate(ctx, redisInvalid)
 	assert.Error(t, err)
 
 	// CPU Limit
 	redisInvalid = redisOrig.DeepCopy()
-	redisInvalid.Spec.Parameters.Size.CPULimits = "5000m"
+	redisInvalid.Spec.Parameters.Size.CPULimits = "6000m"
 	_, err = handler.ValidateCreate(ctx, redisInvalid)
 	assert.Error(t, err)
 


### PR DESCRIPTION
## Summary

- Raise default namespace quotas to 22Gi memory and 5 CPU (agreed with aldebaran)
- Set terminating quota annotations for all CPU/memory dimensions so Jobs like `initdb` and maintenance have sufficient headroom
- Previously only `organization-compute-terminating` CPU requests was set (hardcoded to 1000m), causing standard-4 provisioning to fail when initdb and maintenance ran concurrently

## Checklist

- [x] Update tests.
- [ ] Link this PR to related issues.
- [ ] Merge with `/merge` comment.

Component PR: https://github.com/vshn/component-appcat/pull/1130