### PR TITLE
Fix memory leaks

### DIFF
--- a/pkg/sliexporter/probes/http.go
+++ b/pkg/sliexporter/probes/http.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"io"
 	"net/http"
 
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -19,7 +20,7 @@ type HTTP struct {
 }
 
 func NewHTTP(url string, tlsEnabled bool, cacert *x509.Certificate, service, name, claimNamespace, instanceNamespace, organization, servicelevel, compositionName string, ha bool) *HTTP {
-	transport := http.DefaultTransport
+	transport := http.DefaultTransport.(*http.Transport).Clone()
 	if tlsEnabled {
 		caPool := x509.NewCertPool()
 		caPool.AddCert(cacert)
@@ -48,6 +49,10 @@ func NewHTTP(url string, tlsEnabled bool, cacert *x509.Certificate, service, nam
 }
 
 func (h *HTTP) Close() error {
+	// Release idle connections held by the transport.
+	// Without this, stopping a probe leaves the transport's connection pool
+	// open with connections to the remote endpoint.
+	h.client.CloseIdleConnections()
 	return nil
 }
 
@@ -60,10 +65,21 @@ func (h *HTTP) Probe(ctx context.Context) error {
 	l := log.FromContext(ctx).WithValues("http_prober", h.url)
 
 	l.V(1).Info("Starting get request")
-	resp, err := h.client.Get(h.url)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, h.url, nil)
 	if err != nil {
 		return err
 	}
+	resp, err := h.client.Do(req)
+	if err != nil {
+		return err
+	}
+
+	// Not closing response body prevents the HTTP transport from reusing the underlying
+	// TCP connection. Draining before closing allows connection reuse.
+	defer func() {
+		io.Copy(io.Discard, resp.Body) //nolint:errcheck
+		resp.Body.Close()
+	}()
 
 	l.V(1).Info("Checking response")
 	if resp.StatusCode != http.StatusOK {

--- a/pkg/sliexporter/probes/manager.go
+++ b/pkg/sliexporter/probes/manager.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"k8s.io/apimachinery/pkg/types"
@@ -127,6 +128,8 @@ func (m Manager) StopProbe(pi ProbeInfo) {
 	cancel, ok := m.probers[probeKey]
 	if ok {
 		cancel()
+		// Remove the entry so the map doesn't grow unboundedly.
+		delete(m.probers, probeKey)
 	}
 }
 
@@ -136,12 +139,23 @@ func (m Manager) runProbe(ctx context.Context, p Prober) {
 	defer stop()
 	defer p.Close()
 
+	// Guard against unbounded goroutine accumulation.
+	// We spawn a goroutine per tick (preserving 1-second SLI resolution
+	// for fast probes), but skip the tick if the previous probe is still
+	// running.  This caps in-flight probes to 1 per instance at all times.
+	var probeRunning atomic.Bool
+
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-ticker:
-			go m.sendProbe(ctx, p)
+			if probeRunning.CompareAndSwap(false, true) {
+				go func() {
+					defer probeRunning.Store(false)
+					m.sendProbe(ctx, p)
+				}()
+			}
 		}
 	}
 }

--- a/pkg/sliexporter/probes/manager_test.go
+++ b/pkg/sliexporter/probes/manager_test.go
@@ -32,15 +32,17 @@ func TestManger_Simple(t *testing.T) {
 	}
 
 	m.StartProbe(p)
-	p.tick(nil)
-	p.tick(nil)
-	p.tick(errors.New("ups"))
-	p.tick(nil)
-	p.tick(nil)
+	// Fire ticks one at a time and wait for each probe to complete before
+	// sending the next tick.  This reflects real production timing (1-second
+	// intervals) and is required now that runProbe skips a tick when the
+	// previous probe goroutine is still running.
+	for i, err := range []error{nil, nil, errors.New("ups"), nil, nil} {
+		p.tick(err)
+		assert.Eventually(t, func() bool {
+			return p.getCount() == uint64(i+1)
+		}, time.Second, 10*time.Millisecond)
+	}
 
-	assert.Eventually(t, func() bool {
-		return p.getCount() == 5
-	}, time.Second, 10*time.Millisecond)
 	assert.EqualValues(t, 5, p.getCount())
 
 	m.StopProbe(p.GetInfo())
@@ -77,23 +79,30 @@ func TestManger_Multi(t *testing.T) {
 	tickerChan <- pa.ticker
 	m.StartProbe(pb)
 	tickerChan <- pb.ticker
-	pa.tick(nil)
-	pb.tick(errors.New("Failure"))
-	pa.tick(nil)
-	pb.tick(nil)
-	pa.tick(nil)
-	pa.tick(nil)
-	pa.tick(errors.New("Failure"))
-	pa.tick(errors.New("Failure"))
-	pb.tick(nil)
-	pa.tick(errors.New("Failure"))
-	pb.tick(nil)
-	pa.tick(nil)
-	pa.tick(nil)
+	// Fire ticks one at a time per probe and wait for completion between each,
+	// consistent with the new skip-if-busy behaviour in runProbe.
+	tickAndWait := func(p *fakeProbe, err error) {
+		prev := p.getCount()
+		p.tick(err)
+		assert.Eventually(t, func() bool {
+			return p.getCount() == prev+1
+		}, time.Second, 10*time.Millisecond)
+	}
 
-	assert.Eventually(t, func() bool {
-		return pa.getCount() == 9
-	}, time.Second, 10*time.Millisecond)
+	tickAndWait(pa, nil)
+	tickAndWait(pb, errors.New("Failure"))
+	tickAndWait(pa, nil)
+	tickAndWait(pb, nil)
+	tickAndWait(pa, nil)
+	tickAndWait(pa, nil)
+	tickAndWait(pa, errors.New("Failure"))
+	tickAndWait(pa, errors.New("Failure"))
+	tickAndWait(pb, nil)
+	tickAndWait(pa, errors.New("Failure"))
+	tickAndWait(pb, nil)
+	tickAndWait(pa, nil)
+	tickAndWait(pa, nil)
+
 	assert.EqualValues(t, 9, pa.getCount())
 	m.StopProbe(ProbeInfo{
 		Service:           "fake",
@@ -102,13 +111,11 @@ func TestManger_Multi(t *testing.T) {
 		Name:              "alice",
 	})
 
-	pb.tick(nil)
-	pb.tick(nil)
+	tickAndWait(pb, nil)
+	tickAndWait(pb, nil)
+	// pa is stopped; its tick should be ignored
 	pa.tick(errors.New("Failure"))
 
-	assert.Eventually(t, func() bool {
-		return pb.getCount() == 6
-	}, time.Second, 10*time.Millisecond)
 	assert.EqualValues(t, 6, pb.getCount())
 	m.StopProbe(pb.GetInfo())
 


### PR DESCRIPTION
## Summary

* Fix 1 - probers map never shrinks. StopProbe called cancel() to stop a probe goroutine but never removed the key from the map. Every deleted or suspended service instance left a dead entry permanently.
* FIX 2 - Unbounded goroutine accumulation. `runProbe` spawned `go m.sendProbe()` every second unconditionally. When a database endpoint is unreachable, each goroutine blocks for the full 5-second timeout. With a 1-second tick and 5-second drain rate, 5 goroutines pile up per instance at steady state. This was the main issue that triggered the OOM that I noticed.
* Fix 3 — HTTP response body never closed. The Go HTTP transport cannot reuse a TCP connection unless the body is drained and closed, so a new TCP connection was opened on every probe call.
* Fix 4 - HTTP probe ignores context. Using now `http.NewRequestWithContext(ctx, ...) `+ `h.client.Do(req)`.

## Checklist

- [x] Update tests.
- [ ] Link this PR to related issues.
- [ ] Merge with `/merge` comment.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->


Component PR: https://github.com/vshn/component-appcat/pull/1137