### PR TITLE
Fix updated schedules not being reflected in status

### DIFF
--- a/pkg/comp-functions/functions/common/schedule.go
+++ b/pkg/comp-functions/functions/common/schedule.go
@@ -30,6 +30,7 @@ type MaintenanceScheduler interface {
 	GetMaintenanceDayOfWeek() string
 	SetMaintenanceDayOfWeek(string)
 	GetMaintenanceTimeOfDay() *v1.TimeOfDay
+	SetMaintenanceTimeOfDay(v1.TimeOfDay)
 }
 
 // SetRandomMaintenanceSchedule sets a random maintenance schedule if not already set.
@@ -56,9 +57,16 @@ func SetRandomMaintenanceSchedule(maintenance MaintenanceScheduler) time.Time {
 		timeOfDay.SetTime(maintTime)
 	}
 
-	if maintenance.GetMaintenanceDayOfWeek() == "" {
-		maintenance.SetMaintenanceDayOfWeek(selectedDay)
+	dayOfWeek := maintenance.GetMaintenanceDayOfWeek()
+	if dayOfWeek == "" {
+		dayOfWeek = selectedDay
 	}
+
+	// Always sync effective values to status. The getters return spec values
+	// when set, falling back to status. Without this, status retains stale
+	// initial values when a user later configures schedules in spec.
+	maintenance.SetMaintenanceDayOfWeek(dayOfWeek)
+	maintenance.SetMaintenanceTimeOfDay(*maintenance.GetMaintenanceTimeOfDay())
 
 	return maintTime
 }
@@ -79,7 +87,7 @@ func SetRandomBackupSchedule(backup BackupScheduler, maintenanceTime *time.Time)
 	}
 
 	if backup.GetBackupSchedule() != "" {
-		// Backup schedule already set
+		backup.SetBackupSchedule(backup.GetBackupSchedule())
 		return
 	}
 

--- a/pkg/comp-functions/functions/common/schedule_test.go
+++ b/pkg/comp-functions/functions/common/schedule_test.go
@@ -44,6 +44,10 @@ func (t *testMaintenanceScheduler) GetMaintenanceTimeOfDay() *v1.TimeOfDay {
 	return &t.timeOfDay
 }
 
+func (t *testMaintenanceScheduler) SetMaintenanceTimeOfDay(tod v1.TimeOfDay) {
+	t.timeOfDay = tod
+}
+
 func TestSetRandomSchedules_EmptySchedules(t *testing.T) {
 	backup := &testBackupScheduler{enabled: true}
 	maintenance := &testMaintenanceScheduler{}

--- a/pkg/comp-functions/functions/common/schedule_test.go
+++ b/pkg/comp-functions/functions/common/schedule_test.go
@@ -48,6 +48,60 @@ func (t *testMaintenanceScheduler) SetMaintenanceTimeOfDay(tod v1.TimeOfDay) {
 	t.timeOfDay = tod
 }
 
+// cascadeBackupScheduler mimics the real service types where the getter
+// checks spec first and falls back to status, but the setter only writes to status.
+type cascadeBackupScheduler struct {
+	specSchedule   string
+	statusSchedule string
+	enabled        bool
+}
+
+func (c *cascadeBackupScheduler) GetBackupSchedule() string {
+	if c.specSchedule != "" {
+		return c.specSchedule
+	}
+	return c.statusSchedule
+}
+
+func (c *cascadeBackupScheduler) SetBackupSchedule(schedule string) {
+	c.statusSchedule = schedule
+}
+
+func (c *cascadeBackupScheduler) IsBackupEnabled() bool {
+	return c.enabled
+}
+
+// cascadeMaintenanceScheduler mimics the real service types where getters
+// check spec first and fall back to status, but setters only write to status.
+type cascadeMaintenanceScheduler struct {
+	specDayOfWeek   string
+	statusDayOfWeek string
+	specTimeOfDay   v1.TimeOfDay
+	statusTimeOfDay v1.TimeOfDay
+}
+
+func (c *cascadeMaintenanceScheduler) GetMaintenanceDayOfWeek() string {
+	if c.specDayOfWeek != "" {
+		return c.specDayOfWeek
+	}
+	return c.statusDayOfWeek
+}
+
+func (c *cascadeMaintenanceScheduler) SetMaintenanceDayOfWeek(day string) {
+	c.statusDayOfWeek = day
+}
+
+func (c *cascadeMaintenanceScheduler) GetMaintenanceTimeOfDay() *v1.TimeOfDay {
+	if c.specTimeOfDay != "" {
+		return &c.specTimeOfDay
+	}
+	return &c.statusTimeOfDay
+}
+
+func (c *cascadeMaintenanceScheduler) SetMaintenanceTimeOfDay(tod v1.TimeOfDay) {
+	c.statusTimeOfDay = tod
+}
+
 func TestSetRandomSchedules_EmptySchedules(t *testing.T) {
 	backup := &testBackupScheduler{enabled: true}
 	maintenance := &testMaintenanceScheduler{}
@@ -279,6 +333,55 @@ func TestSetRandomSchedules_SundayTimeRestriction(t *testing.T) {
 	}
 
 	t.Logf("Tested %d Sunday maintenance schedules out of %d total iterations", sundayCount, iterations)
+}
+
+func TestSetRandomSchedules_StatusSyncsWhenSpecUpdated(t *testing.T) {
+	// Step 1: Simulate initial provisioning with no spec values.
+	// Both spec and status are empty, so random values should be generated.
+	maintenance := &cascadeMaintenanceScheduler{}
+	backup := &cascadeBackupScheduler{enabled: true}
+
+	maintTime := SetRandomMaintenanceSchedule(maintenance)
+	SetRandomBackupSchedule(backup, &maintTime)
+
+	// Verify random values were written to status
+	if maintenance.statusDayOfWeek == "" {
+		t.Fatal("Expected status day of week to be set after initial provisioning")
+	}
+	if maintenance.statusTimeOfDay == "" {
+		t.Fatal("Expected status time of day to be set after initial provisioning")
+	}
+	if backup.statusSchedule == "" {
+		t.Fatal("Expected status backup schedule to be set after initial provisioning")
+	}
+
+	initialDay := maintenance.statusDayOfWeek
+	initialTime := maintenance.statusTimeOfDay
+	initialBackup := backup.statusSchedule
+
+	// Step 2: Simulate user updating spec with explicit values.
+	// This mimics what happens when a user edits their VSHNPostgreSQL spec.
+	maintenance.specDayOfWeek = "friday"
+	maintenance.specTimeOfDay = "19:34:00"
+	backup.specSchedule = "0 22 * * *"
+
+	// Step 3: Run the schedule functions again (as the composition function would).
+	maintTime = SetRandomMaintenanceSchedule(maintenance)
+	SetRandomBackupSchedule(backup, &maintTime)
+
+	// Step 4: Verify status now reflects the spec values, not the old random ones.
+	if maintenance.statusDayOfWeek != "friday" {
+		t.Errorf("Expected status day of week to be synced to spec value 'friday', got '%s' (was '%s' before update)",
+			maintenance.statusDayOfWeek, initialDay)
+	}
+	if maintenance.statusTimeOfDay != "19:34:00" {
+		t.Errorf("Expected status time of day to be synced to spec value '19:34:00', got '%s' (was '%s' before update)",
+			maintenance.statusTimeOfDay, initialTime)
+	}
+	if backup.statusSchedule != "0 22 * * *" {
+		t.Errorf("Expected status backup schedule to be synced to spec value '0 22 * * *', got '%s' (was '%s' before update)",
+			backup.statusSchedule, initialBackup)
+	}
 }
 
 func TestSetRandomSchedules_DayDistribution(t *testing.T) {


### PR DESCRIPTION
## Summary

The schedule functions used getters to check if the value was present, but the getters cascade from `spec.parameters` to `status.schedules`. When a user sets spec values after initial provisioning, the getter returns the spec value (non-empty), so the setter is skipped. But the setter is the only thing that writes to status, which results in it staying frozen at the initial random values forever.

We can fix this by always sync the effective value (what the getter returns) back to status, regardless of whether it came from spec or was already in status. This is idempotent. If nothing changed, the same value gets written. If the user updated spec, the new value flows into status.

## Checklist

- [x] Update tests.
- [ ] Link this PR to related issues.
- [ ] Merge with `/merge` comment.

Component PR: https://github.com/vshn/component-appcat/pull/1139