### PR TITLE
Disable walStorage for CNPG

### DIFF
--- a/pkg/comp-functions/functions/vshnpostgrescnpg/deploy.go
+++ b/pkg/comp-functions/functions/vshnpostgrescnpg/deploy.go
@@ -229,9 +229,6 @@ func createCnpgHelmValues(ctx context.Context, svc *runtime.ServiceRuntime, comp
 				"serverCASecret":  certificateSecretName,
 				"serverTLSSecret": certificateSecretName,
 			},
-			"walStorage": map[string]any{
-				"enabled": true,
-			},
 			// The following will be overwritten by setResources() later
 			"storage": map[string]any{},
 			"resources": map[string]any{
@@ -255,10 +252,6 @@ func createCnpgHelmValues(ctx context.Context, svc *runtime.ServiceRuntime, comp
 		err := common.SetNestedObjectValue(values, []string{"cluster", "storage", "storageClass"}, encryptedPvcSc)
 		if err != nil {
 			return map[string]any{}, fmt.Errorf("cannot set storageClass (normal data) for cluster: %w", err)
-		}
-		err = common.SetNestedObjectValue(values, []string{"cluster", "walStorage", "storageClass"}, encryptedPvcSc)
-		if err != nil {
-			return map[string]any{}, fmt.Errorf("cannot set storageClass (WAL) for cluster: %w", err)
 		}
 	}
 


### PR DESCRIPTION
## Summary

* We don't want to use a dedicated PVC for wal files as it adds more complexity to the service and may confuse users.

## Checklist

- [ ] Update tests.
- [ ] Link this PR to related issues.
- [ ] Merge with `/merge` comment.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->


Component PR: https://github.com/vshn/component-appcat/pull/1140