### PR TITLE
Fix an early return when bringing your own bucket

### DIFF
--- a/pkg/comp-functions/functions/common/backup/backup.go
+++ b/pkg/comp-functions/functions/common/backup/backup.go
@@ -92,10 +92,6 @@ func AddK8upBackup(ctx context.Context, svc *runtime.ServiceRuntime, comp common
 func CreateObjectBucket(ctx context.Context, comp common.InfoGetter, svc *runtime.ServiceRuntime) error {
 	l := controllerruntime.LoggerFrom(ctx)
 
-	if comp.GetUnmanagedBucket() != nil {
-		return nil
-	}
-
 	if comp.GetName() == "" {
 		return fmt.Errorf("could not get composite name")
 	}
@@ -105,9 +101,9 @@ func CreateObjectBucket(ctx context.Context, comp common.InfoGetter, svc *runtim
 		runtime.ProviderConfigIgnoreLabel: "true",
 	}
 
-	// Check if backup is disabled and we need to preserve an existing bucket for retention
-	if !comp.IsBackupEnabled() {
-		l.Info("Backup disabled - checking if bucket needs retention timestamp label")
+	// Check if backup is disabled or a custom bucket is being used and we need to preserve an existing bucket for retention
+	if !comp.IsBackupEnabled() || comp.GetUnmanagedBucket() != nil {
+		l.Info("Backup disabled or unmanaged bucket used - checking if bucket needs retention timestamp label")
 
 		// Check if bucket exists in observed state (from when backup was enabled)
 		observedBucket := &appcatv1.XObjectBucket{}


### PR DESCRIPTION


## Summary

This fixes an early return when an instance switches from a managed to an unmanaged bucket. This will engage the same logic as a disabled backup.

Tis makes sure that the switch from a managed to an unmanaged bucket is seamless

## Checklist

- [ ] Update tests.
- [ ] Link this PR to related issues.
- [ ] Merge with `/merge` comment.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->


Component PR: https://github.com/vshn/component-appcat/pull/1142