### PR TITLE
Add HTTPRoute as alternative to ingress

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -57,6 +57,7 @@ require (
 	sigs.k8s.io/apiserver-runtime v1.1.1
 	sigs.k8s.io/controller-runtime v0.19.0
 	sigs.k8s.io/controller-tools v0.16.5
+	sigs.k8s.io/gateway-api v1.2.1
 	sigs.k8s.io/kind v0.20.0
 	sigs.k8s.io/yaml v1.4.0
 )
@@ -197,7 +198,6 @@ require (
 	k8s.io/kms v0.31.2 // indirect
 	k8s.io/metrics v0.29.1 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.30.3 // indirect
-	sigs.k8s.io/gateway-api v0.8.0 // indirect
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -885,8 +885,8 @@ sigs.k8s.io/controller-runtime v0.19.0 h1:nWVM7aq+Il2ABxwiCizrVDSlmDcshi9llbaFbC
 sigs.k8s.io/controller-runtime v0.19.0/go.mod h1:iRmWllt8IlaLjvTTDLhRBXIEtkCK6hwVBJJsYS9Ajf4=
 sigs.k8s.io/controller-tools v0.16.5 h1:5k9FNRqziBPwqr17AMEPPV/En39ZBplLAdOwwQHruP4=
 sigs.k8s.io/controller-tools v0.16.5/go.mod h1:8vztuRVzs8IuuJqKqbXCSlXcw+lkAv/M2sTpg55qjMY=
-sigs.k8s.io/gateway-api v0.8.0 h1:isQQ3Jx2qFP7vaA3ls0846F0Amp9Eq14P08xbSwVbQg=
-sigs.k8s.io/gateway-api v0.8.0/go.mod h1:okOnjPNBFbIS/Rw9kAhuIUaIkLhTKEu+ARIuXk2dgaM=
+sigs.k8s.io/gateway-api v1.2.1 h1:fZZ/+RyRb+Y5tGkwxFKuYuSRQHu9dZtbjenblleOLHM=
+sigs.k8s.io/gateway-api v1.2.1/go.mod h1:EpNfEXNjiYfUJypf0eZ0P5iXA9ekSGWaS1WgPaM42X0=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
 sigs.k8s.io/kind v0.20.0 h1:f0sc3v9mQbGnjBUaqSFST1dwIuiikKVGgoTwpoP33a8=

--- a/pkg/comp-functions/functions/common/httproute.go
+++ b/pkg/comp-functions/functions/common/httproute.go
@@ -1,0 +1,306 @@
+package common
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	cmv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	cmmetav1 "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	"github.com/vshn/appcat/v4/pkg/comp-functions/runtime"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+const (
+	clusterIssuerAnnotation = "cert-manager.io/cluster-issuer"
+	issuerAnnotation        = "cert-manager.io/issuer"
+	issuerKindAnnotation    = "cert-manager.io/issuer-kind"
+	issuerGroupAnnotation   = "cert-manager.io/issuer-group"
+)
+
+const (
+	xListenerSetGroup   = "gateway.networking.x-k8s.io"
+	xListenerSetVersion = "v1alpha1"
+	xListenerSetKind    = "XListenerSet"
+
+	gatewayGroup = "gateway.networking.k8s.io"
+	gatewayKind  = "Gateway"
+
+	maxK8sNameLen = 63
+)
+
+// HTTPRouteConfig contains configuration for generating an HTTPRoute and its
+// accompanying XListenerSet.
+type HTTPRouteConfig struct {
+	AdditionalLabels map[string]string
+	FQDNs            []string
+	GatewayName      string
+	GatewayNamespace string
+	NameSuffix       string
+	ServiceConfig    IngressRuleConfig
+}
+
+func validateHTTPRouteConfig(cfg HTTPRouteConfig) error {
+	if len(cfg.FQDNs) == 0 {
+		return fmt.Errorf("no FQDNs have been defined")
+	}
+	for _, f := range cfg.FQDNs {
+		if f == "" {
+			return fmt.Errorf("an empty FQDN has been passed, FQDNs: %v", cfg.FQDNs)
+		}
+	}
+	if cfg.ServiceConfig.ServicePortNumber == 0 {
+		return fmt.Errorf("ServicePortNumber is required for HTTPRoute")
+	}
+	if cfg.GatewayName == "" || cfg.GatewayNamespace == "" {
+		return fmt.Errorf("GatewayName and GatewayNamespace must be set")
+	}
+	return nil
+}
+
+// compBaseName returns the shared prefix used for the HTTPRoute, XListenerSet,
+// and any other per-composite Gateway API objects: "<comp>[-<nameSuffix>]".
+func compBaseName(comp InfoGetter, cfg HTTPRouteConfig) string {
+	name := comp.GetName()
+	if cfg.NameSuffix != "" {
+		name = name + "-" + strings.Trim(cfg.NameSuffix, "-")
+	}
+	return name
+}
+
+func routeName(comp InfoGetter, cfg HTTPRouteConfig) string {
+	return runtime.EscapeDNS1123Label(compBaseName(comp, cfg)+"-httproute", maxK8sNameLen)
+}
+
+func listenerSetName(comp InfoGetter, cfg HTTPRouteConfig) string {
+	return runtime.EscapeDNS1123Label(compBaseName(comp, cfg)+"-listenerset", maxK8sNameLen)
+}
+
+func fqdnHash8(fqdn string) string {
+	sum := sha256.Sum256([]byte(fqdn))
+	return hex.EncodeToString(sum[:])[:8]
+}
+
+func tlsSecretName(comp InfoGetter, fqdn string) string {
+	return runtime.EscapeDNS1123Label(fmt.Sprintf("%s-%s-tls", comp.GetName(), fqdnHash8(fqdn)), maxK8sNameLen)
+}
+
+func listenerName(fqdn string) string {
+	return "l-" + fqdnHash8(fqdn)
+}
+
+// GenerateHTTPRoute creates an HTTPRoute in the instance namespace, parented to
+// the XListenerSet (same ns) so no cross-namespace ref is needed.
+func GenerateHTTPRoute(comp InfoGetter, svc *runtime.ServiceRuntime, cfg HTTPRouteConfig) (*gatewayv1.HTTPRoute, error) {
+	if err := validateHTTPRouteConfig(cfg); err != nil {
+		return nil, err
+	}
+
+	rName := routeName(comp, cfg)
+	lsName := listenerSetName(comp, cfg)
+
+	svcNameSuffix := cfg.ServiceConfig.ServiceNameSuffix
+	if !strings.HasPrefix(svcNameSuffix, "-") && len(svcNameSuffix) > 0 {
+		svcNameSuffix = "-" + svcNameSuffix
+	}
+	serviceName := runtime.EscapeDNS1123Label(comp.GetName()+svcNameSuffix, maxK8sNameLen)
+
+	hostnames := make([]gatewayv1.Hostname, len(cfg.FQDNs))
+	for i, fqdn := range cfg.FQDNs {
+		hostnames[i] = gatewayv1.Hostname(fqdn)
+	}
+
+	parentGroup := gatewayv1.Group(xListenerSetGroup)
+	parentKind := gatewayv1.Kind(xListenerSetKind)
+	port := gatewayv1.PortNumber(cfg.ServiceConfig.ServicePortNumber)
+
+	labels := getIngressLabels(svc, cfg.AdditionalLabels)
+
+	route := &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      rName,
+			Namespace: comp.GetInstanceNamespace(),
+			Labels:    labels,
+		},
+		Spec: gatewayv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{
+					{
+						Group: &parentGroup,
+						Kind:  &parentKind,
+						Name:  gatewayv1.ObjectName(lsName),
+					},
+				},
+			},
+			Hostnames: hostnames,
+			Rules: []gatewayv1.HTTPRouteRule{
+				{
+					BackendRefs: []gatewayv1.HTTPBackendRef{
+						{
+							BackendRef: gatewayv1.BackendRef{
+								BackendObjectReference: gatewayv1.BackendObjectReference{
+									Name: gatewayv1.ObjectName(serviceName),
+									Port: &port,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	return route, nil
+}
+
+// GenerateXListenerSet creates an XListenerSet in the instance namespace,
+// attached to the shared Gateway. Annotations from ingress_annotations propagate
+// so cert-manager issues a Certificate per listener hostname.
+func GenerateXListenerSet(comp InfoGetter, svc *runtime.ServiceRuntime, cfg HTTPRouteConfig) (*unstructured.Unstructured, error) {
+	if err := validateHTTPRouteConfig(cfg); err != nil {
+		return nil, err
+	}
+
+	lsName := listenerSetName(comp, cfg)
+
+	listeners := make([]any, 0, len(cfg.FQDNs))
+	for _, fqdn := range cfg.FQDNs {
+		secretName := tlsSecretName(comp, fqdn)
+		listeners = append(listeners, map[string]any{
+			"name":     listenerName(fqdn),
+			"hostname": fqdn,
+			"port":     int64(443),
+			"protocol": "HTTPS",
+			"tls": map[string]any{
+				"mode": "Terminate",
+				"certificateRefs": []any{
+					map[string]any{"name": secretName},
+				},
+			},
+			"allowedRoutes": map[string]any{
+				"namespaces": map[string]any{"from": "Same"},
+			},
+		})
+	}
+
+	annotations := getIngressAnnotations(svc, nil)
+	labels := getIngressLabels(svc, cfg.AdditionalLabels)
+
+	ls := &unstructured.Unstructured{}
+	ls.SetAPIVersion(xListenerSetGroup + "/" + xListenerSetVersion)
+	ls.SetKind(xListenerSetKind)
+	ls.SetName(lsName)
+	ls.SetNamespace(comp.GetInstanceNamespace())
+	if len(annotations) > 0 {
+		ls.SetAnnotations(annotations)
+	}
+	if len(labels) > 0 {
+		ls.SetLabels(labels)
+	}
+	ls.Object["spec"] = map[string]any{
+		"parentRef": map[string]any{
+			"group":     gatewayGroup,
+			"kind":      gatewayKind,
+			"name":      cfg.GatewayName,
+			"namespace": cfg.GatewayNamespace,
+		},
+		"listeners": listeners,
+	}
+	return ls, nil
+}
+
+// CreateHTTPRoutes applies generated HTTPRoutes using svc.SetDesiredKubeObject().
+func CreateHTTPRoutes(svc *runtime.ServiceRuntime, routes []*gatewayv1.HTTPRoute, opts ...runtime.KubeObjectOption) error {
+	for _, route := range routes {
+		err := svc.SetDesiredKubeObject(route, route.Name, opts...)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// CreateXListenerSets applies generated XListenerSets using svc.SetDesiredKubeObject().
+func CreateXListenerSets(svc *runtime.ServiceRuntime, sets []*unstructured.Unstructured, opts ...runtime.KubeObjectOption) error {
+	for _, ls := range sets {
+		err := svc.SetDesiredKubeObject(ls, ls.GetName(), opts...)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// issuerRefFromAnnotations extracts a cert-manager issuerRef from the
+// ingress_annotations composition config. Returns nil if no cert-manager
+// issuer annotation is set.
+func issuerRefFromAnnotations(annotations map[string]string) *cmmetav1.ObjectReference {
+	if name, ok := annotations[clusterIssuerAnnotation]; ok && name != "" {
+		return &cmmetav1.ObjectReference{
+			Name:  name,
+			Kind:  "ClusterIssuer",
+			Group: "cert-manager.io",
+		}
+	}
+	if name, ok := annotations[issuerAnnotation]; ok && name != "" {
+		kind := "Issuer"
+		if v, ok := annotations[issuerKindAnnotation]; ok && v != "" {
+			kind = v
+		}
+		group := "cert-manager.io"
+		if v, ok := annotations[issuerGroupAnnotation]; ok && v != "" {
+			group = v
+		}
+		return &cmmetav1.ObjectReference{Name: name, Kind: kind, Group: group}
+	}
+	return nil
+}
+
+// GenerateCertificates creates cert-manager Certificate resources, one per
+// FQDN, with secret names matching the listeners produced by
+// GenerateXListenerSet. Returns (nil, nil) if no cert-manager issuer annotation
+// is configured (in that case the user is expected to provide the TLS secret
+// themselves). cert-manager's Gateway API shim does not yet understand
+// XListenerSet, so we create Certificates explicitly instead of relying on
+// annotation propagation.
+func GenerateCertificates(comp InfoGetter, svc *runtime.ServiceRuntime, cfg HTTPRouteConfig) ([]*cmv1.Certificate, error) {
+	if err := validateHTTPRouteConfig(cfg); err != nil {
+		return nil, err
+	}
+
+	issuerRef := issuerRefFromAnnotations(getIngressAnnotations(svc, nil))
+	if issuerRef == nil {
+		return nil, nil
+	}
+
+	labels := getIngressLabels(svc, cfg.AdditionalLabels)
+	certs := make([]*cmv1.Certificate, 0, len(cfg.FQDNs))
+	for _, fqdn := range cfg.FQDNs {
+		secretName := tlsSecretName(comp, fqdn)
+		certs = append(certs, &cmv1.Certificate{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: comp.GetInstanceNamespace(),
+				Labels:    labels,
+			},
+			Spec: cmv1.CertificateSpec{
+				SecretName: secretName,
+				DNSNames:   []string{fqdn},
+				IssuerRef:  *issuerRef,
+			},
+		})
+	}
+	return certs, nil
+}
+
+// CreateCertificates applies generated Certificates using svc.SetDesiredKubeObject().
+func CreateCertificates(svc *runtime.ServiceRuntime, certs []*cmv1.Certificate, opts ...runtime.KubeObjectOption) error {
+	for _, c := range certs {
+		if err := svc.SetDesiredKubeObject(c, c.Name, opts...); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/comp-functions/functions/common/httproute.go
+++ b/pkg/comp-functions/functions/common/httproute.go
@@ -3,11 +3,13 @@ package common
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"strings"
 
 	cmv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmetav1 "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	xfnproto "github.com/crossplane/function-sdk-go/proto/v1"
 	"github.com/vshn/appcat/v4/pkg/comp-functions/runtime"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -30,7 +32,17 @@ const (
 	gatewayKind  = "Gateway"
 
 	maxK8sNameLen = 63
+
+	// RouteTypeHTTPRoute is the svc.Config.Data["routeType"] value that
+	// selects Gateway API HTTPRoute over classic Ingress.
+	RouteTypeHTTPRoute = "HTTPRoute"
 )
+
+// IsHTTPRouteMode reports whether the composition is configured to render
+// HTTPRoute/XListenerSet objects instead of Ingress.
+func IsHTTPRouteMode(svc *runtime.ServiceRuntime) bool {
+	return svc.Config.Data["routeType"] == RouteTypeHTTPRoute
+}
 
 // HTTPRouteConfig contains configuration for generating an HTTPRoute and its
 // accompanying XListenerSet.
@@ -119,6 +131,20 @@ func GenerateHTTPRoute(comp InfoGetter, svc *runtime.ServiceRuntime, cfg HTTPRou
 
 	labels := getIngressLabels(svc, cfg.AdditionalLabels)
 
+	relPath := cfg.ServiceConfig.RelPath
+	if relPath == "" {
+		relPath = "/"
+	}
+	pathMatchType := gatewayv1.PathMatchPathPrefix
+	matches := []gatewayv1.HTTPRouteMatch{
+		{
+			Path: &gatewayv1.HTTPPathMatch{
+				Type:  &pathMatchType,
+				Value: &relPath,
+			},
+		},
+	}
+
 	route := &gatewayv1.HTTPRoute{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      rName,
@@ -138,6 +164,7 @@ func GenerateHTTPRoute(comp InfoGetter, svc *runtime.ServiceRuntime, cfg HTTPRou
 			Hostnames: hostnames,
 			Rules: []gatewayv1.HTTPRouteRule{
 				{
+					Matches: matches,
 					BackendRefs: []gatewayv1.HTTPBackendRef{
 						{
 							BackendRef: gatewayv1.BackendRef{
@@ -156,8 +183,9 @@ func GenerateHTTPRoute(comp InfoGetter, svc *runtime.ServiceRuntime, cfg HTTPRou
 }
 
 // GenerateXListenerSet creates an XListenerSet in the instance namespace,
-// attached to the shared Gateway. Annotations from ingress_annotations propagate
-// so cert-manager issues a Certificate per listener hostname.
+// attached to the shared Gateway. TLS secrets per listener are produced by
+// GenerateCertificates (see that func for why ingress_annotations aren't
+// propagated here).
 func GenerateXListenerSet(comp InfoGetter, svc *runtime.ServiceRuntime, cfg HTTPRouteConfig) (*unstructured.Unstructured, error) {
 	if err := validateHTTPRouteConfig(cfg); err != nil {
 		return nil, err
@@ -185,7 +213,6 @@ func GenerateXListenerSet(comp InfoGetter, svc *runtime.ServiceRuntime, cfg HTTP
 		})
 	}
 
-	annotations := getIngressAnnotations(svc, nil)
 	labels := getIngressLabels(svc, cfg.AdditionalLabels)
 
 	ls := &unstructured.Unstructured{}
@@ -193,9 +220,6 @@ func GenerateXListenerSet(comp InfoGetter, svc *runtime.ServiceRuntime, cfg HTTP
 	ls.SetKind(xListenerSetKind)
 	ls.SetName(lsName)
 	ls.SetNamespace(comp.GetInstanceNamespace())
-	if len(annotations) > 0 {
-		ls.SetAnnotations(annotations)
-	}
 	if len(labels) > 0 {
 		ls.SetLabels(labels)
 	}
@@ -303,4 +327,60 @@ func CreateCertificates(svc *runtime.ServiceRuntime, certs []*cmv1.Certificate, 
 		}
 	}
 	return nil
+}
+
+// ErrHTTPGatewayNotConfigured signals a pipeline misconfig — callers
+// returning *xfnproto.Result should surface it as Fatal.
+var ErrHTTPGatewayNotConfigured = errors.New("httpGatewayName and httpGatewayNamespace must be set when routeType=HTTPRoute")
+
+// ApplyHTTPRoute applies the XListenerSet, HTTPRoute, and Certificates for
+// comp. cfg.GatewayName/Namespace default to svc.Config.Data if empty.
+func ApplyHTTPRoute(comp InfoGetter, svc *runtime.ServiceRuntime, cfg HTTPRouteConfig, opts ...runtime.KubeObjectOption) error {
+	if cfg.GatewayName == "" {
+		cfg.GatewayName = svc.Config.Data["httpGatewayName"]
+	}
+	if cfg.GatewayNamespace == "" {
+		cfg.GatewayNamespace = svc.Config.Data["httpGatewayNamespace"]
+	}
+	if cfg.GatewayName == "" || cfg.GatewayNamespace == "" {
+		return ErrHTTPGatewayNotConfigured
+	}
+
+	ls, err := GenerateXListenerSet(comp, svc, cfg)
+	if err != nil {
+		return fmt.Errorf("cannot generate XListenerSet: %w", err)
+	}
+	if err := CreateXListenerSets(svc, []*unstructured.Unstructured{ls}, opts...); err != nil {
+		return fmt.Errorf("cannot create XListenerSet: %w", err)
+	}
+
+	route, err := GenerateHTTPRoute(comp, svc, cfg)
+	if err != nil {
+		return fmt.Errorf("cannot generate HTTPRoute: %w", err)
+	}
+	if err := CreateHTTPRoutes(svc, []*gatewayv1.HTTPRoute{route}, opts...); err != nil {
+		return fmt.Errorf("cannot create HTTPRoute: %w", err)
+	}
+
+	certs, err := GenerateCertificates(comp, svc, cfg)
+	if err != nil {
+		return fmt.Errorf("cannot generate Certificates: %w", err)
+	}
+	if err := CreateCertificates(svc, certs, opts...); err != nil {
+		return fmt.Errorf("cannot create Certificates: %w", err)
+	}
+	return nil
+}
+
+// ApplyHTTPRouteAsResult is ApplyHTTPRoute wrapped as *xfnproto.Result:
+// Fatal on ErrHTTPGatewayNotConfigured, Warning otherwise, nil on success.
+func ApplyHTTPRouteAsResult(comp InfoGetter, svc *runtime.ServiceRuntime, cfg HTTPRouteConfig, opts ...runtime.KubeObjectOption) *xfnproto.Result {
+	err := ApplyHTTPRoute(comp, svc, cfg, opts...)
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, ErrHTTPGatewayNotConfigured) {
+		return runtime.NewFatalResult(err)
+	}
+	return runtime.NewWarningResult(err.Error())
 }

--- a/pkg/comp-functions/functions/common/httproute_test.go
+++ b/pkg/comp-functions/functions/common/httproute_test.go
@@ -52,6 +52,33 @@ func TestGenerateHTTPRoute(t *testing.T) {
 		assert.Equal(t, gatewayv1.ObjectName(compName+"-"+svcNameSuffix), be.Name)
 		assert.Nil(t, be.Namespace, "backendRef must have no Namespace (same-ns)")
 		assert.Equal(t, gatewayv1.PortNumber(443), *be.Port)
+
+		assert.Len(t, route.Spec.Rules[0].Matches, 1)
+		path := route.Spec.Rules[0].Matches[0].Path
+		assert.Equal(t, gatewayv1.PathMatchPathPrefix, *path.Type)
+		assert.Equal(t, "/", *path.Value, "empty RelPath must default to /")
+	})
+
+	t.Run("GivenRelPath_ExpectPathPrefixMatch", func(t *testing.T) {
+		svc := commontest.LoadRuntimeFromFile(t, "common/03_httproute.yaml")
+		comp := &baaSComposite{ObjectMeta: metav1.ObjectMeta{Name: compName}}
+
+		route, err := GenerateHTTPRoute(comp, svc, HTTPRouteConfig{
+			FQDNs: []string{"my-domain.com"},
+			ServiceConfig: IngressRuleConfig{
+				RelPath:           "/auth",
+				ServiceNameSuffix: svcNameSuffix,
+				ServicePortNumber: 443,
+			},
+			GatewayName:      httpGatewayName,
+			GatewayNamespace: httpGatewayNamespace,
+		})
+		assert.NoError(t, err)
+		assert.Len(t, route.Spec.Rules, 1)
+		assert.Len(t, route.Spec.Rules[0].Matches, 1)
+		path := route.Spec.Rules[0].Matches[0].Path
+		assert.Equal(t, gatewayv1.PathMatchPathPrefix, *path.Type)
+		assert.Equal(t, "/auth", *path.Value)
 	})
 
 	t.Run("GivenMultipleFQDNs_ExpectAllHostnames", func(t *testing.T) {
@@ -164,8 +191,10 @@ func TestGenerateXListenerSet(t *testing.T) {
 		assert.Equal(t, compName+"-listenerset", ls.GetName())
 		assert.Equal(t, "vshn-"+compName, ls.GetNamespace())
 
-		annos := ls.GetAnnotations()
-		assert.Equal(t, "letsencrypt-production", annos["cert-manager.io/cluster-issuer"])
+		// ingress_annotations must not propagate to the XListenerSet:
+		// cert-manager's Gateway API shim doesn't understand XListenerSet,
+		// so Certificates are created explicitly by GenerateCertificates.
+		assert.Empty(t, ls.GetAnnotations())
 
 		parentRef, found, err := unstructuredNestedMap(ls.Object, "spec", "parentRef")
 		assert.NoError(t, err)

--- a/pkg/comp-functions/functions/common/httproute_test.go
+++ b/pkg/comp-functions/functions/common/httproute_test.go
@@ -1,0 +1,359 @@
+package common
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/vshn/appcat/v4/pkg/comp-functions/functions/commontest"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+const (
+	httpGatewayName      = "http-gateway"
+	httpGatewayNamespace = "syn-kgateway"
+)
+
+func TestGenerateHTTPRoute(t *testing.T) {
+	t.Run("GivenSingleFQDN_ExpectHTTPRouteInInstanceNs", func(t *testing.T) {
+		svc := commontest.LoadRuntimeFromFile(t, "common/03_httproute.yaml")
+		comp := &baaSComposite{ObjectMeta: metav1.ObjectMeta{Name: compName}}
+
+		route, err := GenerateHTTPRoute(comp, svc, HTTPRouteConfig{
+			FQDNs: []string{"my-domain.com"},
+			ServiceConfig: IngressRuleConfig{
+				ServiceNameSuffix: svcNameSuffix,
+				ServicePortNumber: 443,
+			},
+			GatewayName:      httpGatewayName,
+			GatewayNamespace: httpGatewayNamespace,
+		})
+
+		assert.NoError(t, err)
+		assert.Equal(t, compName+"-httproute", route.Name)
+		assert.Equal(t, "vshn-"+compName, route.Namespace, "HTTPRoute must be in instance ns")
+
+		assert.Len(t, route.Spec.ParentRefs, 1)
+		pr := route.Spec.ParentRefs[0]
+		assert.NotNil(t, pr.Group)
+		assert.Equal(t, gatewayv1.Group("gateway.networking.x-k8s.io"), *pr.Group)
+		assert.NotNil(t, pr.Kind)
+		assert.Equal(t, gatewayv1.Kind("XListenerSet"), *pr.Kind)
+		assert.Equal(t, gatewayv1.ObjectName(compName+"-listenerset"), pr.Name)
+		assert.Nil(t, pr.Namespace, "parentRef must have no Namespace (same-ns)")
+
+		assert.Len(t, route.Spec.Hostnames, 1)
+		assert.Equal(t, gatewayv1.Hostname("my-domain.com"), route.Spec.Hostnames[0])
+
+		assert.Len(t, route.Spec.Rules, 1)
+		assert.Len(t, route.Spec.Rules[0].BackendRefs, 1)
+		be := route.Spec.Rules[0].BackendRefs[0]
+		assert.Equal(t, gatewayv1.ObjectName(compName+"-"+svcNameSuffix), be.Name)
+		assert.Nil(t, be.Namespace, "backendRef must have no Namespace (same-ns)")
+		assert.Equal(t, gatewayv1.PortNumber(443), *be.Port)
+	})
+
+	t.Run("GivenMultipleFQDNs_ExpectAllHostnames", func(t *testing.T) {
+		svc := commontest.LoadRuntimeFromFile(t, "common/03_httproute.yaml")
+		comp := &baaSComposite{ObjectMeta: metav1.ObjectMeta{Name: compName}}
+
+		route, err := GenerateHTTPRoute(comp, svc, HTTPRouteConfig{
+			FQDNs: []string{"a.example.com", "b.example.com", "c.example.com"},
+			ServiceConfig: IngressRuleConfig{
+				ServiceNameSuffix: svcNameSuffix,
+				ServicePortNumber: 8080,
+			},
+			GatewayName:      httpGatewayName,
+			GatewayNamespace: httpGatewayNamespace,
+		})
+		assert.NoError(t, err)
+		assert.Len(t, route.Spec.Hostnames, 3)
+	})
+
+	t.Run("GivenNameSuffix_ExpectSuffixedNames", func(t *testing.T) {
+		svc := commontest.LoadRuntimeFromFile(t, "common/03_httproute.yaml")
+		comp := &baaSComposite{ObjectMeta: metav1.ObjectMeta{Name: compName}}
+
+		route, err := GenerateHTTPRoute(comp, svc, HTTPRouteConfig{
+			FQDNs:      []string{"collabora.example.com"},
+			NameSuffix: "collabora-code",
+			ServiceConfig: IngressRuleConfig{
+				ServiceNameSuffix: "collabora-code",
+				ServicePortNumber: 9980,
+			},
+			GatewayName:      httpGatewayName,
+			GatewayNamespace: httpGatewayNamespace,
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, compName+"-collabora-code-httproute", route.Name)
+		assert.Equal(t, gatewayv1.ObjectName(compName+"-collabora-code-listenerset"), route.Spec.ParentRefs[0].Name)
+	})
+
+	t.Run("GivenNoFQDNs_ExpectError", func(t *testing.T) {
+		svc := commontest.LoadRuntimeFromFile(t, "common/03_httproute.yaml")
+		comp := &baaSComposite{ObjectMeta: metav1.ObjectMeta{Name: compName}}
+		_, err := GenerateHTTPRoute(comp, svc, HTTPRouteConfig{
+			FQDNs:            []string{},
+			ServiceConfig:    IngressRuleConfig{ServicePortNumber: 8080},
+			GatewayName:      httpGatewayName,
+			GatewayNamespace: httpGatewayNamespace,
+		})
+		assert.Error(t, err)
+	})
+
+	t.Run("GivenEmptyFQDN_ExpectError", func(t *testing.T) {
+		svc := commontest.LoadRuntimeFromFile(t, "common/03_httproute.yaml")
+		comp := &baaSComposite{ObjectMeta: metav1.ObjectMeta{Name: compName}}
+		_, err := GenerateHTTPRoute(comp, svc, HTTPRouteConfig{
+			FQDNs:            []string{""},
+			ServiceConfig:    IngressRuleConfig{ServicePortNumber: 8080},
+			GatewayName:      httpGatewayName,
+			GatewayNamespace: httpGatewayNamespace,
+		})
+		assert.Error(t, err)
+	})
+
+	t.Run("GivenZeroPort_ExpectError", func(t *testing.T) {
+		svc := commontest.LoadRuntimeFromFile(t, "common/03_httproute.yaml")
+		comp := &baaSComposite{ObjectMeta: metav1.ObjectMeta{Name: compName}}
+		_, err := GenerateHTTPRoute(comp, svc, HTTPRouteConfig{
+			FQDNs:            []string{"example.com"},
+			ServiceConfig:    IngressRuleConfig{ServiceNameSuffix: svcNameSuffix},
+			GatewayName:      httpGatewayName,
+			GatewayNamespace: httpGatewayNamespace,
+		})
+		assert.Error(t, err)
+	})
+
+	t.Run("GivenTooLongName_ExpectSanitizedNames", func(t *testing.T) {
+		svc := commontest.LoadRuntimeFromFile(t, "common/03_httproute.yaml")
+		longName := "looooonggloooooonggggmaaaaaaaaaaaaaan" // 37 chars
+		comp := &baaSComposite{ObjectMeta: metav1.ObjectMeta{Name: longName}}
+		route, err := GenerateHTTPRoute(comp, svc, HTTPRouteConfig{
+			FQDNs:            []string{"example.com"},
+			NameSuffix:       "collabora-code",
+			ServiceConfig:    IngressRuleConfig{ServiceNameSuffix: "x", ServicePortNumber: 80},
+			GatewayName:      httpGatewayName,
+			GatewayNamespace: httpGatewayNamespace,
+		})
+		assert.NoError(t, err)
+		assert.LessOrEqual(t, len(route.Name), 63)
+		assert.LessOrEqual(t, len(string(route.Spec.ParentRefs[0].Name)), 63)
+		assert.LessOrEqual(t, len(string(route.Spec.Rules[0].BackendRefs[0].Name)), 63)
+	})
+}
+
+func TestGenerateXListenerSet(t *testing.T) {
+	t.Run("GivenSingleFQDN_ExpectXListenerSetInInstanceNs", func(t *testing.T) {
+		svc := commontest.LoadRuntimeFromFile(t, "common/03_httproute.yaml")
+		comp := &baaSComposite{ObjectMeta: metav1.ObjectMeta{Name: compName}}
+
+		ls, err := GenerateXListenerSet(comp, svc, HTTPRouteConfig{
+			FQDNs: []string{"my-domain.com"},
+			ServiceConfig: IngressRuleConfig{
+				ServiceNameSuffix: svcNameSuffix,
+				ServicePortNumber: 443,
+			},
+			GatewayName:      httpGatewayName,
+			GatewayNamespace: httpGatewayNamespace,
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, "gateway.networking.x-k8s.io/v1alpha1", ls.GetAPIVersion())
+		assert.Equal(t, "XListenerSet", ls.GetKind())
+		assert.Equal(t, compName+"-listenerset", ls.GetName())
+		assert.Equal(t, "vshn-"+compName, ls.GetNamespace())
+
+		annos := ls.GetAnnotations()
+		assert.Equal(t, "letsencrypt-production", annos["cert-manager.io/cluster-issuer"])
+
+		parentRef, found, err := unstructuredNestedMap(ls.Object, "spec", "parentRef")
+		assert.NoError(t, err)
+		assert.True(t, found)
+		assert.Equal(t, "gateway.networking.k8s.io", parentRef["group"])
+		assert.Equal(t, "Gateway", parentRef["kind"])
+		assert.Equal(t, httpGatewayName, parentRef["name"])
+		assert.Equal(t, httpGatewayNamespace, parentRef["namespace"])
+
+		listeners, found, err := unstructuredNestedSlice(ls.Object, "spec", "listeners")
+		assert.NoError(t, err)
+		assert.True(t, found)
+		assert.Len(t, listeners, 1)
+		l := listeners[0].(map[string]any)
+		assert.Equal(t, "my-domain.com", l["hostname"])
+		assert.Equal(t, int64(443), l["port"])
+		assert.Equal(t, "HTTPS", l["protocol"])
+		tls := l["tls"].(map[string]any)
+		assert.Equal(t, "Terminate", tls["mode"])
+		certRefs := tls["certificateRefs"].([]any)
+		assert.Len(t, certRefs, 1)
+		certRef := certRefs[0].(map[string]any)
+		secretName := certRef["name"].(string)
+		assert.True(t, len(secretName) <= 63)
+		assert.True(t, len(secretName) > len(compName)+4)
+		assert.True(t, len(l["name"].(string)) == 10)
+		assert.Equal(t, "l-", l["name"].(string)[:2])
+	})
+
+	t.Run("GivenThreeFQDNs_ExpectThreeListeners", func(t *testing.T) {
+		svc := commontest.LoadRuntimeFromFile(t, "common/03_httproute.yaml")
+		comp := &baaSComposite{ObjectMeta: metav1.ObjectMeta{Name: compName}}
+
+		ls, err := GenerateXListenerSet(comp, svc, HTTPRouteConfig{
+			FQDNs: []string{"a.example.com", "b.example.com", "c.example.com"},
+			ServiceConfig: IngressRuleConfig{
+				ServiceNameSuffix: svcNameSuffix,
+				ServicePortNumber: 443,
+			},
+			GatewayName:      httpGatewayName,
+			GatewayNamespace: httpGatewayNamespace,
+		})
+		assert.NoError(t, err)
+		listeners, _, _ := unstructuredNestedSlice(ls.Object, "spec", "listeners")
+		assert.Len(t, listeners, 3)
+	})
+
+	t.Run("GivenNameSuffix_ExpectSuffixedName", func(t *testing.T) {
+		svc := commontest.LoadRuntimeFromFile(t, "common/03_httproute.yaml")
+		comp := &baaSComposite{ObjectMeta: metav1.ObjectMeta{Name: compName}}
+		ls, err := GenerateXListenerSet(comp, svc, HTTPRouteConfig{
+			FQDNs:            []string{"collabora.example.com"},
+			NameSuffix:       "collabora-code",
+			ServiceConfig:    IngressRuleConfig{ServiceNameSuffix: "collabora-code", ServicePortNumber: 9980},
+			GatewayName:      httpGatewayName,
+			GatewayNamespace: httpGatewayNamespace,
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, compName+"-collabora-code-listenerset", ls.GetName())
+	})
+
+	t.Run("GivenMissingGatewayName_ExpectError", func(t *testing.T) {
+		svc := commontest.LoadRuntimeFromFile(t, "common/03_httproute.yaml")
+		comp := &baaSComposite{ObjectMeta: metav1.ObjectMeta{Name: compName}}
+		_, err := GenerateXListenerSet(comp, svc, HTTPRouteConfig{
+			FQDNs:            []string{"example.com"},
+			ServiceConfig:    IngressRuleConfig{ServiceNameSuffix: "x", ServicePortNumber: 80},
+			GatewayNamespace: httpGatewayNamespace,
+		})
+		assert.Error(t, err)
+	})
+
+	t.Run("GivenTooLongName_ExpectSanitizedName", func(t *testing.T) {
+		svc := commontest.LoadRuntimeFromFile(t, "common/03_httproute.yaml")
+		longName := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+		comp := &baaSComposite{ObjectMeta: metav1.ObjectMeta{Name: longName}}
+		ls, err := GenerateXListenerSet(comp, svc, HTTPRouteConfig{
+			FQDNs:            []string{"example.com"},
+			NameSuffix:       "collabora-code",
+			ServiceConfig:    IngressRuleConfig{ServiceNameSuffix: "x", ServicePortNumber: 80},
+			GatewayName:      httpGatewayName,
+			GatewayNamespace: httpGatewayNamespace,
+		})
+		assert.NoError(t, err)
+		assert.LessOrEqual(t, len(ls.GetName()), 63)
+	})
+}
+
+func TestGenerateCertificates(t *testing.T) {
+	cfg := HTTPRouteConfig{
+		FQDNs:            []string{"a.example.com", "b.example.com"},
+		ServiceConfig:    IngressRuleConfig{ServiceNameSuffix: svcNameSuffix, ServicePortNumber: 443},
+		GatewayName:      httpGatewayName,
+		GatewayNamespace: httpGatewayNamespace,
+	}
+
+	t.Run("GivenClusterIssuerAnnotation_ExpectCertificatePerFQDN", func(t *testing.T) {
+		svc := commontest.LoadRuntimeFromFile(t, "common/03_httproute.yaml")
+		comp := &baaSComposite{ObjectMeta: metav1.ObjectMeta{Name: compName}}
+
+		certs, err := GenerateCertificates(comp, svc, cfg)
+		assert.NoError(t, err)
+		assert.Len(t, certs, 2)
+
+		for i, fqdn := range cfg.FQDNs {
+			c := certs[i]
+			wantSecret := tlsSecretName(comp, fqdn)
+			assert.Equal(t, wantSecret, c.Name)
+			assert.Equal(t, wantSecret, c.Spec.SecretName)
+			assert.Equal(t, "vshn-"+compName, c.Namespace)
+			assert.Equal(t, []string{fqdn}, c.Spec.DNSNames)
+			assert.Equal(t, "letsencrypt-production", c.Spec.IssuerRef.Name)
+			assert.Equal(t, "ClusterIssuer", c.Spec.IssuerRef.Kind)
+			assert.Equal(t, "cert-manager.io", c.Spec.IssuerRef.Group)
+		}
+	})
+
+	t.Run("GivenNoIssuerAnnotation_ExpectNilCerts", func(t *testing.T) {
+		svc := commontest.LoadRuntimeFromFile(t, "common/03_httproute.yaml")
+		svc.Config.Data["ingress_annotations"] = ""
+		comp := &baaSComposite{ObjectMeta: metav1.ObjectMeta{Name: compName}}
+
+		certs, err := GenerateCertificates(comp, svc, cfg)
+		assert.NoError(t, err)
+		assert.Nil(t, certs)
+	})
+
+	t.Run("GivenNamespacedIssuerAnnotation_ExpectIssuerKind", func(t *testing.T) {
+		svc := commontest.LoadRuntimeFromFile(t, "common/03_httproute.yaml")
+		svc.Config.Data["ingress_annotations"] = "cert-manager.io/issuer: my-issuer"
+		comp := &baaSComposite{ObjectMeta: metav1.ObjectMeta{Name: compName}}
+
+		certs, err := GenerateCertificates(comp, svc, cfg)
+		assert.NoError(t, err)
+		assert.Len(t, certs, 2)
+		assert.Equal(t, "my-issuer", certs[0].Spec.IssuerRef.Name)
+		assert.Equal(t, "Issuer", certs[0].Spec.IssuerRef.Kind)
+	})
+
+	t.Run("GivenInvalidConfig_ExpectError", func(t *testing.T) {
+		svc := commontest.LoadRuntimeFromFile(t, "common/03_httproute.yaml")
+		comp := &baaSComposite{ObjectMeta: metav1.ObjectMeta{Name: compName}}
+
+		_, err := GenerateCertificates(comp, svc, HTTPRouteConfig{
+			ServiceConfig:    IngressRuleConfig{ServiceNameSuffix: svcNameSuffix, ServicePortNumber: 443},
+			GatewayName:      httpGatewayName,
+			GatewayNamespace: httpGatewayNamespace,
+		})
+		assert.Error(t, err)
+	})
+}
+
+func unstructuredNestedMap(obj map[string]any, keys ...string) (map[string]any, bool, error) {
+	var cur any = obj
+	for _, k := range keys {
+		m, ok := cur.(map[string]any)
+		if !ok {
+			return nil, false, fmt.Errorf("key %q: parent is not map[string]any", k)
+		}
+		v, ok := m[k]
+		if !ok {
+			return nil, false, nil
+		}
+		cur = v
+	}
+	result, ok := cur.(map[string]any)
+	if !ok {
+		return nil, false, fmt.Errorf("terminal value is not map[string]any")
+	}
+	return result, true, nil
+}
+
+func unstructuredNestedSlice(obj map[string]any, keys ...string) ([]any, bool, error) {
+	var cur any = obj
+	for _, k := range keys {
+		m, ok := cur.(map[string]any)
+		if !ok {
+			return nil, false, fmt.Errorf("key %q: parent is not map[string]any", k)
+		}
+		v, ok := m[k]
+		if !ok {
+			return nil, false, nil
+		}
+		cur = v
+	}
+	result, ok := cur.([]any)
+	if !ok {
+		return nil, false, fmt.Errorf("terminal value is not []any")
+	}
+	return result, true, nil
+}

--- a/pkg/comp-functions/functions/vshnforgejo/deploy.go
+++ b/pkg/comp-functions/functions/vshnforgejo/deploy.go
@@ -13,6 +13,8 @@ import (
 	"github.com/vshn/appcat/v4/pkg/comp-functions/functions/common"
 	"github.com/vshn/appcat/v4/pkg/comp-functions/functions/common/maintenance"
 	"github.com/vshn/appcat/v4/pkg/comp-functions/runtime"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
 // DeployForgejo deploys a Forgejo instance via the Helm Chart.
@@ -239,29 +241,69 @@ func addForgejo(ctx context.Context, svc *runtime.ServiceRuntime, comp *vshnv1.V
 		}
 	}
 
-	// Ingress
+	// Ingress / HTTPRoute
 	svcNameSuffix := "http"
 	if !strings.Contains(comp.GetName(), "forgejo") {
 		svcNameSuffix = "forgejo-" + svcNameSuffix
 	}
 
-	svc.Log.Info("Adding ingress")
-	ingressConfig := common.IngressConfig{
-		FQDNs: comp.Spec.Parameters.Service.FQDN,
-		ServiceConfig: common.IngressRuleConfig{
-			ServiceNameSuffix: svcNameSuffix,
-			ServicePortNumber: 3000,
-		},
-		TlsCertBaseName: "forgejo",
-	}
-	ingresses, err := common.GenerateBundledIngresses(comp, svc, ingressConfig)
-	if err != nil {
-		return err
-	}
+	if svc.Config.Data["routeType"] == "HTTPRoute" {
+		gatewayName := svc.Config.Data["httpGatewayName"]
+		gatewayNamespace := svc.Config.Data["httpGatewayNamespace"]
 
-	err = common.CreateIngresses(comp, svc, ingresses)
-	if err != nil {
-		return err
+		svc.Log.Info("Adding HTTPRoute for Forgejo")
+
+		cfg := common.HTTPRouteConfig{
+			FQDNs: comp.Spec.Parameters.Service.FQDN,
+			ServiceConfig: common.IngressRuleConfig{
+				ServiceNameSuffix: svcNameSuffix,
+				ServicePortNumber: 3000,
+			},
+			GatewayName:      gatewayName,
+			GatewayNamespace: gatewayNamespace,
+		}
+
+		ls, err := common.GenerateXListenerSet(comp, svc, cfg)
+		if err != nil {
+			return err
+		}
+		if err := common.CreateXListenerSets(svc, []*unstructured.Unstructured{ls}); err != nil {
+			return err
+		}
+
+		route, err := common.GenerateHTTPRoute(comp, svc, cfg)
+		if err != nil {
+			return err
+		}
+		if err := common.CreateHTTPRoutes(svc, []*gatewayv1.HTTPRoute{route}); err != nil {
+			return err
+		}
+
+		certs, err := common.GenerateCertificates(comp, svc, cfg)
+		if err != nil {
+			return err
+		}
+		if err := common.CreateCertificates(svc, certs); err != nil {
+			return err
+		}
+	} else {
+		svc.Log.Info("Adding ingress")
+		ingressConfig := common.IngressConfig{
+			FQDNs: comp.Spec.Parameters.Service.FQDN,
+			ServiceConfig: common.IngressRuleConfig{
+				ServiceNameSuffix: svcNameSuffix,
+				ServicePortNumber: 3000,
+			},
+			TlsCertBaseName: "forgejo",
+		}
+		ingresses, err := common.GenerateBundledIngresses(comp, svc, ingressConfig)
+		if err != nil {
+			return err
+		}
+		err = common.CreateIngresses(comp, svc, ingresses)
+		if err != nil {
+			return err
+		}
 	}
 
 	if svc.Config.Data["isOpenshift"] == "true" {

--- a/pkg/comp-functions/functions/vshnforgejo/deploy.go
+++ b/pkg/comp-functions/functions/vshnforgejo/deploy.go
@@ -13,8 +13,6 @@ import (
 	"github.com/vshn/appcat/v4/pkg/comp-functions/functions/common"
 	"github.com/vshn/appcat/v4/pkg/comp-functions/functions/common/maintenance"
 	"github.com/vshn/appcat/v4/pkg/comp-functions/runtime"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
 // DeployForgejo deploys a Forgejo instance via the Helm Chart.
@@ -52,6 +50,9 @@ func DeployForgejo(ctx context.Context, comp *vshnv1.VSHNForgejo, svc *runtime.S
 
 	svc.Log.Info("Adding forgejo release")
 	err = addForgejo(ctx, svc, comp, secretName)
+	if errors.Is(err, common.ErrHTTPGatewayNotConfigured) {
+		return runtime.NewFatalResult(fmt.Errorf("cannot add forgejo release: %w", err))
+	}
 	if err != nil {
 		return runtime.NewWarningResult(fmt.Sprintf("cannot add forgejo release: %s", err))
 	}
@@ -247,43 +248,15 @@ func addForgejo(ctx context.Context, svc *runtime.ServiceRuntime, comp *vshnv1.V
 		svcNameSuffix = "forgejo-" + svcNameSuffix
 	}
 
-	if svc.Config.Data["routeType"] == "HTTPRoute" {
-		gatewayName := svc.Config.Data["httpGatewayName"]
-		gatewayNamespace := svc.Config.Data["httpGatewayNamespace"]
-
+	if common.IsHTTPRouteMode(svc) {
 		svc.Log.Info("Adding HTTPRoute for Forgejo")
-
-		cfg := common.HTTPRouteConfig{
+		if err := common.ApplyHTTPRoute(comp, svc, common.HTTPRouteConfig{
 			FQDNs: comp.Spec.Parameters.Service.FQDN,
 			ServiceConfig: common.IngressRuleConfig{
 				ServiceNameSuffix: svcNameSuffix,
 				ServicePortNumber: 3000,
 			},
-			GatewayName:      gatewayName,
-			GatewayNamespace: gatewayNamespace,
-		}
-
-		ls, err := common.GenerateXListenerSet(comp, svc, cfg)
-		if err != nil {
-			return err
-		}
-		if err := common.CreateXListenerSets(svc, []*unstructured.Unstructured{ls}); err != nil {
-			return err
-		}
-
-		route, err := common.GenerateHTTPRoute(comp, svc, cfg)
-		if err != nil {
-			return err
-		}
-		if err := common.CreateHTTPRoutes(svc, []*gatewayv1.HTTPRoute{route}); err != nil {
-			return err
-		}
-
-		certs, err := common.GenerateCertificates(comp, svc, cfg)
-		if err != nil {
-			return err
-		}
-		if err := common.CreateCertificates(svc, certs); err != nil {
+		}); err != nil {
 			return err
 		}
 	} else {

--- a/pkg/comp-functions/functions/vshnforgejo/deploy_test.go
+++ b/pkg/comp-functions/functions/vshnforgejo/deploy_test.go
@@ -110,6 +110,43 @@ func TestDeployment(t *testing.T) {
 	})
 }
 
+func TestDeploymentHTTPRoute(t *testing.T) {
+	t.Run("GivenHTTPRouteMode_ExpectHTTPRouteAndListenerSet", func(t *testing.T) {
+		svc := commontest.LoadRuntimeFromFile(t, "vshnforgejo/03_httproute.yaml")
+		svc.Config.Data["routeType"] = "HTTPRoute"
+		svc.Config.Data["httpGatewayName"] = "http-gateway"
+		svc.Config.Data["httpGatewayNamespace"] = "syn-kgateway"
+
+		comp := &vshnv1.VSHNForgejo{}
+		err := svc.GetObservedComposite(comp)
+		assert.NoError(t, err)
+
+		secretName, err := common.AddCredentialsSecret(comp, svc, []string{"password"}, common.DisallowDeletion, common.AddStaticFieldToSecret(map[string]string{
+			"username": "forgejo_admin",
+		}))
+		assert.NoError(t, err)
+		assert.NoError(t, addForgejo(context.TODO(), svc, comp, secretName))
+
+		allDesired := svc.GetAllDesired()
+		foundRoute, foundLS, foundGrant := false, false, false
+		for _, d := range allDesired {
+			name := d.Resource.GetName()
+			if name == comp.GetName()+"-httproute" {
+				foundRoute = true
+			}
+			if name == comp.GetName()+"-listenerset" {
+				foundLS = true
+			}
+			if name == comp.GetName()+"-httpgrant" {
+				foundGrant = true
+			}
+		}
+		assert.True(t, foundRoute)
+		assert.True(t, foundLS)
+		assert.False(t, foundGrant)
+	})
+}
+
 func getReleaseValues(t *testing.T, release xhelmv1.Release) map[string]any {
 	values := map[string]any{}
 	assert.NoError(t, json.Unmarshal(release.Spec.ForProvider.Values.Raw, &values))

--- a/pkg/comp-functions/functions/vshnforgejo/deploy_test.go
+++ b/pkg/comp-functions/functions/vshnforgejo/deploy_test.go
@@ -113,7 +113,7 @@ func TestDeployment(t *testing.T) {
 func TestDeploymentHTTPRoute(t *testing.T) {
 	t.Run("GivenHTTPRouteMode_ExpectHTTPRouteAndListenerSet", func(t *testing.T) {
 		svc := commontest.LoadRuntimeFromFile(t, "vshnforgejo/03_httproute.yaml")
-		svc.Config.Data["routeType"] = "HTTPRoute"
+		svc.Config.Data["routeType"] = common.RouteTypeHTTPRoute
 		svc.Config.Data["httpGatewayName"] = "http-gateway"
 		svc.Config.Data["httpGatewayNamespace"] = "syn-kgateway"
 

--- a/pkg/comp-functions/functions/vshnkeycloak/ingress.go
+++ b/pkg/comp-functions/functions/vshnkeycloak/ingress.go
@@ -13,6 +13,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
 // AddIngress adds an inrgess to the Keycloak instance.
@@ -26,6 +28,10 @@ func AddIngress(_ context.Context, comp *vshnv1.VSHNKeycloak, svc *runtime.Servi
 	fqdn := comp.Spec.Parameters.Service.FQDN
 	if fqdn == "" {
 		return nil
+	}
+
+	if svc.Config.Data["routeType"] == "HTTPRoute" {
+		return addKeycloakHTTPRoute(comp, svc, fqdn)
 	}
 
 	values, err := common.GetDesiredReleaseValues(svc, comp.GetName()+"-release")
@@ -108,4 +114,69 @@ func addOpenShiftCa(svc *runtime.ServiceRuntime, comp *vshnv1.VSHNKeycloak) erro
 	}
 
 	return svc.SetDesiredKubeObject(secret, comp.GetName()+"-route-ca", runtime.KubeOptionAllowDeletion)
+}
+
+func addKeycloakHTTPRoute(comp *vshnv1.VSHNKeycloak, svc *runtime.ServiceRuntime, fqdn string) *xfnproto.Result {
+	gatewayName := svc.Config.Data["httpGatewayName"]
+	gatewayNamespace := svc.Config.Data["httpGatewayNamespace"]
+
+	svc.Log.Info("Adding HTTPRoute for Keycloak")
+
+	cfg := common.HTTPRouteConfig{
+		FQDNs: []string{fqdn},
+		ServiceConfig: common.IngressRuleConfig{
+			ServiceNameSuffix: "keycloakx-http",
+			ServicePortNumber: 8443,
+		},
+		GatewayName:      gatewayName,
+		GatewayNamespace: gatewayNamespace,
+	}
+
+	ls, err := common.GenerateXListenerSet(comp, svc, cfg)
+	if err != nil {
+		return runtime.NewWarningResult(fmt.Sprintf("cannot generate XListenerSet: %s", err))
+	}
+	if err := common.CreateXListenerSets(svc, []*unstructured.Unstructured{ls}, runtime.KubeOptionAllowDeletion); err != nil {
+		return runtime.NewWarningResult(fmt.Sprintf("cannot create XListenerSet: %s", err))
+	}
+
+	route, err := common.GenerateHTTPRoute(comp, svc, cfg)
+	if err != nil {
+		return runtime.NewWarningResult(fmt.Sprintf("cannot generate HTTPRoute: %s", err))
+	}
+	if err := common.CreateHTTPRoutes(svc, []*gatewayv1.HTTPRoute{route}, runtime.KubeOptionAllowDeletion); err != nil {
+		return runtime.NewWarningResult(fmt.Sprintf("cannot create HTTPRoute: %s", err))
+	}
+
+	certs, err := common.GenerateCertificates(comp, svc, cfg)
+	if err != nil {
+		return runtime.NewWarningResult(fmt.Sprintf("cannot generate Certificates: %s", err))
+	}
+	if err := common.CreateCertificates(svc, certs, runtime.KubeOptionAllowDeletion); err != nil {
+		return runtime.NewWarningResult(fmt.Sprintf("cannot create Certificates: %s", err))
+	}
+
+	// Keycloak serves TLS on port 8443 directly. kgateway defaults to plain
+	// HTTP upstream, so attach a BackendConfigPolicy that originates TLS to
+	// the keycloakx-http Service, validating against the CA secret created
+	// by common.CreateTLSCerts ("tls-ca-certificate" in the instance ns).
+	svcName := comp.GetName() + "-keycloakx-http"
+	bcp := &unstructured.Unstructured{}
+	bcp.SetAPIVersion("gateway.kgateway.dev/v1alpha1")
+	bcp.SetKind("BackendConfigPolicy")
+	bcp.SetName(comp.GetName() + "-backend-tls")
+	bcp.SetNamespace(comp.GetInstanceNamespace())
+	bcp.Object["spec"] = map[string]any{
+		"targetRefs": []any{
+			map[string]any{"group": "", "kind": "Service", "name": svcName},
+		},
+		"tls": map[string]any{
+			"secretRef": map[string]any{"name": "tls-ca-certificate"},
+		},
+	}
+	if err := svc.SetDesiredKubeObject(bcp, bcp.GetName(), runtime.KubeOptionAllowDeletion); err != nil {
+		return runtime.NewWarningResult(fmt.Sprintf("cannot create BackendConfigPolicy: %s", err))
+	}
+
+	return nil
 }

--- a/pkg/comp-functions/functions/vshnkeycloak/ingress.go
+++ b/pkg/comp-functions/functions/vshnkeycloak/ingress.go
@@ -14,7 +14,6 @@ import (
 	netv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
 // AddIngress adds an inrgess to the Keycloak instance.
@@ -30,7 +29,7 @@ func AddIngress(_ context.Context, comp *vshnv1.VSHNKeycloak, svc *runtime.Servi
 		return nil
 	}
 
-	if svc.Config.Data["routeType"] == "HTTPRoute" {
+	if common.IsHTTPRouteMode(svc) {
 		return addKeycloakHTTPRoute(comp, svc, fqdn)
 	}
 
@@ -117,43 +116,17 @@ func addOpenShiftCa(svc *runtime.ServiceRuntime, comp *vshnv1.VSHNKeycloak) erro
 }
 
 func addKeycloakHTTPRoute(comp *vshnv1.VSHNKeycloak, svc *runtime.ServiceRuntime, fqdn string) *xfnproto.Result {
-	gatewayName := svc.Config.Data["httpGatewayName"]
-	gatewayNamespace := svc.Config.Data["httpGatewayNamespace"]
-
 	svc.Log.Info("Adding HTTPRoute for Keycloak")
 
-	cfg := common.HTTPRouteConfig{
+	if res := common.ApplyHTTPRouteAsResult(comp, svc, common.HTTPRouteConfig{
 		FQDNs: []string{fqdn},
 		ServiceConfig: common.IngressRuleConfig{
+			RelPath:           comp.Spec.Parameters.Service.RelativePath,
 			ServiceNameSuffix: "keycloakx-http",
 			ServicePortNumber: 8443,
 		},
-		GatewayName:      gatewayName,
-		GatewayNamespace: gatewayNamespace,
-	}
-
-	ls, err := common.GenerateXListenerSet(comp, svc, cfg)
-	if err != nil {
-		return runtime.NewWarningResult(fmt.Sprintf("cannot generate XListenerSet: %s", err))
-	}
-	if err := common.CreateXListenerSets(svc, []*unstructured.Unstructured{ls}, runtime.KubeOptionAllowDeletion); err != nil {
-		return runtime.NewWarningResult(fmt.Sprintf("cannot create XListenerSet: %s", err))
-	}
-
-	route, err := common.GenerateHTTPRoute(comp, svc, cfg)
-	if err != nil {
-		return runtime.NewWarningResult(fmt.Sprintf("cannot generate HTTPRoute: %s", err))
-	}
-	if err := common.CreateHTTPRoutes(svc, []*gatewayv1.HTTPRoute{route}, runtime.KubeOptionAllowDeletion); err != nil {
-		return runtime.NewWarningResult(fmt.Sprintf("cannot create HTTPRoute: %s", err))
-	}
-
-	certs, err := common.GenerateCertificates(comp, svc, cfg)
-	if err != nil {
-		return runtime.NewWarningResult(fmt.Sprintf("cannot generate Certificates: %s", err))
-	}
-	if err := common.CreateCertificates(svc, certs, runtime.KubeOptionAllowDeletion); err != nil {
-		return runtime.NewWarningResult(fmt.Sprintf("cannot create Certificates: %s", err))
+	}); res != nil {
+		return res
 	}
 
 	// Keycloak serves TLS on port 8443 directly. kgateway defaults to plain
@@ -174,7 +147,7 @@ func addKeycloakHTTPRoute(comp *vshnv1.VSHNKeycloak, svc *runtime.ServiceRuntime
 			"secretRef": map[string]any{"name": "tls-ca-certificate"},
 		},
 	}
-	if err := svc.SetDesiredKubeObject(bcp, bcp.GetName(), runtime.KubeOptionAllowDeletion); err != nil {
+	if err := svc.SetDesiredKubeObject(bcp, bcp.GetName()); err != nil {
 		return runtime.NewWarningResult(fmt.Sprintf("cannot create BackendConfigPolicy: %s", err))
 	}
 

--- a/pkg/comp-functions/functions/vshnkeycloak/ingress_test.go
+++ b/pkg/comp-functions/functions/vshnkeycloak/ingress_test.go
@@ -1,6 +1,7 @@
 package vshnkeycloak
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 
@@ -163,4 +164,54 @@ func TestCreateIngress(t *testing.T) {
 			assert.Equal(t, string(want), string(got))
 		})
 	}
+}
+
+func TestCreateHTTPRoute(t *testing.T) {
+	t.Run("GivenHTTPRouteMode_ExpectHTTPRouteAndListenerSet", func(t *testing.T) {
+		svc := commontest.LoadRuntimeFromFile(t, "vshnkeycloak/02_httproute.yaml")
+
+		comp := &vshnv1.VSHNKeycloak{
+			ObjectMeta: metav1.ObjectMeta{Name: "keycloak"},
+			Spec: vshnv1.VSHNKeycloakSpec{
+				Parameters: vshnv1.VSHNKeycloakParameters{
+					Service: vshnv1.VSHNKeycloakServiceSpec{
+						FQDN:         "example.com",
+						RelativePath: "/path",
+					},
+				},
+			},
+		}
+
+		result := AddIngress(context.Background(), comp, svc)
+		assert.Nil(t, result)
+
+		allDesired := svc.GetAllDesired()
+		foundRoute, foundLS, foundGrant, foundBCP := false, false, false, false
+		for _, d := range allDesired {
+			name := d.Resource.GetName()
+			if name == "keycloak-httproute" {
+				foundRoute = true
+			}
+			if name == "keycloak-listenerset" {
+				foundLS = true
+			}
+			if name == "keycloak-httpgrant" {
+				foundGrant = true
+			}
+			if name == "keycloak-backend-tls" {
+				foundBCP = true
+			}
+		}
+		assert.True(t, foundRoute, "HTTPRoute must be created")
+		assert.True(t, foundLS, "XListenerSet must be created")
+		assert.False(t, foundGrant, "ReferenceGrant must NOT be created")
+		assert.True(t, foundBCP, "BackendConfigPolicy must be created for TLS backend")
+	})
+
+	t.Run("GivenHTTPRouteMode_NoFQDN_ExpectNil", func(t *testing.T) {
+		svc := commontest.LoadRuntimeFromFile(t, "vshnkeycloak/02_httproute.yaml")
+		comp := &vshnv1.VSHNKeycloak{}
+		result := AddIngress(context.Background(), comp, svc)
+		assert.Nil(t, result)
+	})
 }

--- a/pkg/comp-functions/functions/vshnkeycloak/ingress_test.go
+++ b/pkg/comp-functions/functions/vshnkeycloak/ingress_test.go
@@ -12,6 +12,7 @@ import (
 	v1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
 func TestCreateIngress(t *testing.T) {
@@ -206,6 +207,14 @@ func TestCreateHTTPRoute(t *testing.T) {
 		assert.True(t, foundLS, "XListenerSet must be created")
 		assert.False(t, foundGrant, "ReferenceGrant must NOT be created")
 		assert.True(t, foundBCP, "BackendConfigPolicy must be created for TLS backend")
+
+		route := &gatewayv1.HTTPRoute{}
+		assert.NoError(t, svc.GetDesiredKubeObject(route, "keycloak-httproute"))
+		assert.Len(t, route.Spec.Rules, 1)
+		assert.Len(t, route.Spec.Rules[0].Matches, 1)
+		path := route.Spec.Rules[0].Matches[0].Path
+		assert.Equal(t, gatewayv1.PathMatchPathPrefix, *path.Type)
+		assert.Equal(t, "/path", *path.Value, "RelativePath from claim must propagate to HTTPRoute match")
 	})
 
 	t.Run("GivenHTTPRouteMode_NoFQDN_ExpectNil", func(t *testing.T) {

--- a/pkg/comp-functions/functions/vshnnextcloud/collabora.go
+++ b/pkg/comp-functions/functions/vshnnextcloud/collabora.go
@@ -8,6 +8,7 @@ import (
 	"crypto/x509"
 	_ "embed"
 	"encoding/pem"
+	"errors"
 	"fmt"
 
 	cmv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
@@ -24,10 +25,8 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
-	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
 var (
@@ -134,6 +133,9 @@ func DeployCollabora(ctx context.Context, comp *vshnv1.VSHNNextcloud, svc *runti
 	}
 
 	err = AddCollaboraIngress(comp, svc)
+	if errors.Is(err, common.ErrHTTPGatewayNotConfigured) {
+		return runtime.NewFatalResult(fmt.Errorf("Failed to add Collabora Ingress: %w", err))
+	}
 	if err != nil {
 		return runtime.NewWarningResult("Failed to add Collabora Ingress: " + err.Error())
 	}
@@ -333,7 +335,11 @@ func AddCollaboraService(comp *vshnv1.VSHNNextcloud, svc *runtime.ServiceRuntime
 }
 func AddCollaboraIngress(comp *vshnv1.VSHNNextcloud, svc *runtime.ServiceRuntime) error {
 
-	if svc.Config.Data["routeType"] == "HTTPRoute" {
+	if comp.Spec.Parameters.Service.Collabora.FQDN == "" {
+		return fmt.Errorf("collabora FQDN is not set")
+	}
+
+	if common.IsHTTPRouteMode(svc) {
 		return addCollaboraHTTPRoute(comp, svc)
 	}
 
@@ -541,43 +547,16 @@ func createInstallCollaboraJob(comp *vshnv1.VSHNNextcloud, svc *runtime.ServiceR
 }
 
 func addCollaboraHTTPRoute(comp *vshnv1.VSHNNextcloud, svc *runtime.ServiceRuntime) error {
-	gatewayName := svc.Config.Data["httpGatewayName"]
-	gatewayNamespace := svc.Config.Data["httpGatewayNamespace"]
-
 	svc.Log.Info("Adding HTTPRoute for Collabora")
 
-	cfg := common.HTTPRouteConfig{
+	return common.ApplyHTTPRoute(comp, svc, common.HTTPRouteConfig{
 		FQDNs: []string{comp.Spec.Parameters.Service.Collabora.FQDN},
 		ServiceConfig: common.IngressRuleConfig{
 			ServiceNameSuffix: "collabora-code",
 			ServicePortNumber: 9980,
 		},
-		NameSuffix:       "collabora-code",
-		GatewayName:      gatewayName,
-		GatewayNamespace: gatewayNamespace,
-	}
-
-	ls, err := common.GenerateXListenerSet(comp, svc, cfg)
-	if err != nil {
-		return err
-	}
-	if err := common.CreateXListenerSets(svc, []*unstructured.Unstructured{ls}, runtime.KubeOptionAddLabels(labelMap)); err != nil {
-		return err
-	}
-
-	route, err := common.GenerateHTTPRoute(comp, svc, cfg)
-	if err != nil {
-		return err
-	}
-	if err := common.CreateHTTPRoutes(svc, []*gatewayv1.HTTPRoute{route}, runtime.KubeOptionAddLabels(labelMap)); err != nil {
-		return err
-	}
-
-	certs, err := common.GenerateCertificates(comp, svc, cfg)
-	if err != nil {
-		return err
-	}
-	return common.CreateCertificates(svc, certs, runtime.KubeOptionAddLabels(labelMap))
+		NameSuffix: "collabora-code",
+	}, runtime.KubeOptionAddLabels(labelMap))
 }
 
 // ssh-keygen -t rsa -N "" -m PEM

--- a/pkg/comp-functions/functions/vshnnextcloud/collabora.go
+++ b/pkg/comp-functions/functions/vshnnextcloud/collabora.go
@@ -24,8 +24,10 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
 var (
@@ -331,6 +333,10 @@ func AddCollaboraService(comp *vshnv1.VSHNNextcloud, svc *runtime.ServiceRuntime
 }
 func AddCollaboraIngress(comp *vshnv1.VSHNNextcloud, svc *runtime.ServiceRuntime) error {
 
+	if svc.Config.Data["routeType"] == "HTTPRoute" {
+		return addCollaboraHTTPRoute(comp, svc)
+	}
+
 	annotations := map[string]string{}
 
 	if svc.Config.Data["isOpenshift"] == "true" {
@@ -532,6 +538,46 @@ func createInstallCollaboraJob(comp *vshnv1.VSHNNextcloud, svc *runtime.ServiceR
 	}
 
 	return svc.SetDesiredKubeObject(job, comp.GetName()+"-collabora-install-job", runtime.KubeOptionAddLabels(labelMap))
+}
+
+func addCollaboraHTTPRoute(comp *vshnv1.VSHNNextcloud, svc *runtime.ServiceRuntime) error {
+	gatewayName := svc.Config.Data["httpGatewayName"]
+	gatewayNamespace := svc.Config.Data["httpGatewayNamespace"]
+
+	svc.Log.Info("Adding HTTPRoute for Collabora")
+
+	cfg := common.HTTPRouteConfig{
+		FQDNs: []string{comp.Spec.Parameters.Service.Collabora.FQDN},
+		ServiceConfig: common.IngressRuleConfig{
+			ServiceNameSuffix: "collabora-code",
+			ServicePortNumber: 9980,
+		},
+		NameSuffix:       "collabora-code",
+		GatewayName:      gatewayName,
+		GatewayNamespace: gatewayNamespace,
+	}
+
+	ls, err := common.GenerateXListenerSet(comp, svc, cfg)
+	if err != nil {
+		return err
+	}
+	if err := common.CreateXListenerSets(svc, []*unstructured.Unstructured{ls}, runtime.KubeOptionAddLabels(labelMap)); err != nil {
+		return err
+	}
+
+	route, err := common.GenerateHTTPRoute(comp, svc, cfg)
+	if err != nil {
+		return err
+	}
+	if err := common.CreateHTTPRoutes(svc, []*gatewayv1.HTTPRoute{route}, runtime.KubeOptionAddLabels(labelMap)); err != nil {
+		return err
+	}
+
+	certs, err := common.GenerateCertificates(comp, svc, cfg)
+	if err != nil {
+		return err
+	}
+	return common.CreateCertificates(svc, certs, runtime.KubeOptionAddLabels(labelMap))
 }
 
 // ssh-keygen -t rsa -N "" -m PEM

--- a/pkg/comp-functions/functions/vshnnextcloud/collabora_test.go
+++ b/pkg/comp-functions/functions/vshnnextcloud/collabora_test.go
@@ -67,6 +67,34 @@ func Test_addCollabora(t *testing.T) {
 	assert.True(t, res.Severity == v1.Severity_SEVERITY_NORMAL && res.Message == "Collabora not enabled")
 }
 
+func Test_addCollaboraHTTPRoute(t *testing.T) {
+	svc, comp := getNextcloudComp(t, "vshnnextcloud/03_httproute.yaml")
+	comp.Spec.Parameters.Service.Collabora.Enabled = true
+	comp.Spec.Parameters.Service.Collabora.FQDN = "collabora.example.com"
+	ctx := context.TODO()
+	assert.Nil(t, DeployNextcloud(ctx, comp, svc))
+	res := DeployCollabora(ctx, comp, svc)
+	assert.True(t, res.Severity == v1.Severity_SEVERITY_NORMAL)
+
+	allDesired := svc.GetAllDesired()
+	foundRoute, foundLS, foundGrant := false, false, false
+	for _, d := range allDesired {
+		name := d.Resource.GetName()
+		if strings.Contains(name, "collabora") && strings.Contains(name, "httproute") {
+			foundRoute = true
+		}
+		if strings.Contains(name, "collabora") && strings.Contains(name, "listenerset") {
+			foundLS = true
+		}
+		if strings.Contains(name, "collabora") && strings.Contains(name, "httpgrant") {
+			foundGrant = true
+		}
+	}
+	assert.True(t, foundRoute, "Collabora HTTPRoute must be created")
+	assert.True(t, foundLS, "Collabora XListenerSet must be created")
+	assert.False(t, foundGrant, "Collabora ReferenceGrant must NOT be created")
+}
+
 func Test_addCollaboraDefaultVersion(t *testing.T) {
 	svc, comp := getNextcloudComp(t, "vshnnextcloud/01_default.yaml")
 	ctx := context.TODO()

--- a/pkg/comp-functions/functions/vshnnextcloud/ingress.go
+++ b/pkg/comp-functions/functions/vshnnextcloud/ingress.go
@@ -10,8 +10,6 @@ import (
 	vshnv1 "github.com/vshn/appcat/v4/apis/vshn/v1"
 	"github.com/vshn/appcat/v4/pkg/comp-functions/functions/common"
 	"github.com/vshn/appcat/v4/pkg/comp-functions/runtime"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
 // AddIngress adds an inrgess to the Nextcloud instance.
@@ -26,7 +24,7 @@ func AddIngress(_ context.Context, comp *vshnv1.VSHNNextcloud, svc *runtime.Serv
 		return runtime.NewFatalResult(fmt.Errorf("FQDN array is empty, but requires at least one entry, %w", errors.New("empty fqdn")))
 	}
 
-	if svc.Config.Data["routeType"] == "HTTPRoute" {
+	if common.IsHTTPRouteMode(svc) {
 		return addNextcloudHTTPRoute(comp, svc)
 	}
 
@@ -55,9 +53,6 @@ func AddIngress(_ context.Context, comp *vshnv1.VSHNNextcloud, svc *runtime.Serv
 }
 
 func addNextcloudHTTPRoute(comp *vshnv1.VSHNNextcloud, svc *runtime.ServiceRuntime) *xfnproto.Result {
-	gatewayName := svc.Config.Data["httpGatewayName"]
-	gatewayNamespace := svc.Config.Data["httpGatewayNamespace"]
-
 	var svcNameSuffix string
 	if !strings.Contains(comp.GetName(), "nextcloud") {
 		svcNameSuffix = "nextcloud"
@@ -65,39 +60,11 @@ func addNextcloudHTTPRoute(comp *vshnv1.VSHNNextcloud, svc *runtime.ServiceRunti
 
 	svc.Log.Info("Adding HTTPRoute for Nextcloud")
 
-	cfg := common.HTTPRouteConfig{
+	return common.ApplyHTTPRouteAsResult(comp, svc, common.HTTPRouteConfig{
 		FQDNs: comp.Spec.Parameters.Service.FQDN,
 		ServiceConfig: common.IngressRuleConfig{
 			ServiceNameSuffix: svcNameSuffix,
 			ServicePortNumber: 8080,
 		},
-		GatewayName:      gatewayName,
-		GatewayNamespace: gatewayNamespace,
-	}
-
-	ls, err := common.GenerateXListenerSet(comp, svc, cfg)
-	if err != nil {
-		return runtime.NewFatalResult(fmt.Errorf("cannot generate XListenerSet: %w", err))
-	}
-	if err := common.CreateXListenerSets(svc, []*unstructured.Unstructured{ls}); err != nil {
-		return runtime.NewFatalResult(fmt.Errorf("cannot create XListenerSet: %w", err))
-	}
-
-	route, err := common.GenerateHTTPRoute(comp, svc, cfg)
-	if err != nil {
-		return runtime.NewFatalResult(fmt.Errorf("cannot generate HTTPRoute: %w", err))
-	}
-	if err := common.CreateHTTPRoutes(svc, []*gatewayv1.HTTPRoute{route}); err != nil {
-		return runtime.NewFatalResult(fmt.Errorf("cannot create HTTPRoute: %w", err))
-	}
-
-	certs, err := common.GenerateCertificates(comp, svc, cfg)
-	if err != nil {
-		return runtime.NewFatalResult(fmt.Errorf("cannot generate Certificates: %w", err))
-	}
-	if err := common.CreateCertificates(svc, certs); err != nil {
-		return runtime.NewFatalResult(fmt.Errorf("cannot create Certificates: %w", err))
-	}
-
-	return nil
+	})
 }

--- a/pkg/comp-functions/functions/vshnnextcloud/ingress.go
+++ b/pkg/comp-functions/functions/vshnnextcloud/ingress.go
@@ -10,6 +10,8 @@ import (
 	vshnv1 "github.com/vshn/appcat/v4/apis/vshn/v1"
 	"github.com/vshn/appcat/v4/pkg/comp-functions/functions/common"
 	"github.com/vshn/appcat/v4/pkg/comp-functions/runtime"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
 // AddIngress adds an inrgess to the Nextcloud instance.
@@ -22,6 +24,10 @@ func AddIngress(_ context.Context, comp *vshnv1.VSHNNextcloud, svc *runtime.Serv
 
 	if len(comp.Spec.Parameters.Service.FQDN) == 0 {
 		return runtime.NewFatalResult(fmt.Errorf("FQDN array is empty, but requires at least one entry, %w", errors.New("empty fqdn")))
+	}
+
+	if svc.Config.Data["routeType"] == "HTTPRoute" {
+		return addNextcloudHTTPRoute(comp, svc)
 	}
 
 	var svcNameSuffix string
@@ -44,6 +50,54 @@ func AddIngress(_ context.Context, comp *vshnv1.VSHNNextcloud, svc *runtime.Serv
 	}
 
 	common.CreateIngresses(comp, svc, ingresses)
+
+	return nil
+}
+
+func addNextcloudHTTPRoute(comp *vshnv1.VSHNNextcloud, svc *runtime.ServiceRuntime) *xfnproto.Result {
+	gatewayName := svc.Config.Data["httpGatewayName"]
+	gatewayNamespace := svc.Config.Data["httpGatewayNamespace"]
+
+	var svcNameSuffix string
+	if !strings.Contains(comp.GetName(), "nextcloud") {
+		svcNameSuffix = "nextcloud"
+	}
+
+	svc.Log.Info("Adding HTTPRoute for Nextcloud")
+
+	cfg := common.HTTPRouteConfig{
+		FQDNs: comp.Spec.Parameters.Service.FQDN,
+		ServiceConfig: common.IngressRuleConfig{
+			ServiceNameSuffix: svcNameSuffix,
+			ServicePortNumber: 8080,
+		},
+		GatewayName:      gatewayName,
+		GatewayNamespace: gatewayNamespace,
+	}
+
+	ls, err := common.GenerateXListenerSet(comp, svc, cfg)
+	if err != nil {
+		return runtime.NewFatalResult(fmt.Errorf("cannot generate XListenerSet: %w", err))
+	}
+	if err := common.CreateXListenerSets(svc, []*unstructured.Unstructured{ls}); err != nil {
+		return runtime.NewFatalResult(fmt.Errorf("cannot create XListenerSet: %w", err))
+	}
+
+	route, err := common.GenerateHTTPRoute(comp, svc, cfg)
+	if err != nil {
+		return runtime.NewFatalResult(fmt.Errorf("cannot generate HTTPRoute: %w", err))
+	}
+	if err := common.CreateHTTPRoutes(svc, []*gatewayv1.HTTPRoute{route}); err != nil {
+		return runtime.NewFatalResult(fmt.Errorf("cannot create HTTPRoute: %w", err))
+	}
+
+	certs, err := common.GenerateCertificates(comp, svc, cfg)
+	if err != nil {
+		return runtime.NewFatalResult(fmt.Errorf("cannot generate Certificates: %w", err))
+	}
+	if err := common.CreateCertificates(svc, certs); err != nil {
+		return runtime.NewFatalResult(fmt.Errorf("cannot create Certificates: %w", err))
+	}
 
 	return nil
 }

--- a/pkg/comp-functions/functions/vshnnextcloud/ingress_test.go
+++ b/pkg/comp-functions/functions/vshnnextcloud/ingress_test.go
@@ -1,0 +1,42 @@
+package vshnnextcloud
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	vshnv1 "github.com/vshn/appcat/v4/apis/vshn/v1"
+	"github.com/vshn/appcat/v4/pkg/comp-functions/functions/commontest"
+)
+
+func TestAddIngressHTTPRoute(t *testing.T) {
+	t.Run("GivenHTTPRouteMode_ExpectHTTPRouteAndListenerSet", func(t *testing.T) {
+		svc := commontest.LoadRuntimeFromFile(t, "vshnnextcloud/03_httproute.yaml")
+
+		comp := &vshnv1.VSHNNextcloud{}
+		err := svc.GetObservedComposite(comp)
+		assert.NoError(t, err)
+		comp.Spec.Parameters.Service.FQDN = []string{"nc.example.com", "nc2.example.com"}
+
+		result := AddIngress(context.Background(), comp, svc)
+		assert.Nil(t, result)
+
+		allDesired := svc.GetAllDesired()
+		foundRoute, foundLS, foundGrant := false, false, false
+		for _, d := range allDesired {
+			name := d.Resource.GetName()
+			if name == comp.GetName()+"-httproute" {
+				foundRoute = true
+			}
+			if name == comp.GetName()+"-listenerset" {
+				foundLS = true
+			}
+			if name == comp.GetName()+"-httpgrant" {
+				foundGrant = true
+			}
+		}
+		assert.True(t, foundRoute)
+		assert.True(t, foundLS)
+		assert.False(t, foundGrant)
+	})
+}

--- a/pkg/scheme.go
+++ b/pkg/scheme.go
@@ -38,6 +38,8 @@ import (
 	pdbv1 "k8s.io/api/policy/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 func SetupScheme() *runtime.Scheme {
@@ -79,4 +81,6 @@ func AddToScheme(s *runtime.Scheme) {
 	_ = codey.SchemeBuilder.AddToScheme(s)
 	_ = coordinationv1.AddToScheme(s)
 	_ = s3v1.SchemeBuilder.AddToScheme(s)
+	_ = gatewayv1.Install(s)
+	_ = gatewayv1beta1.Install(s)
 }

--- a/test/functions/common/03_httproute.yaml
+++ b/test/functions/common/03_httproute.yaml
@@ -1,0 +1,16 @@
+desired: {}
+input:
+  apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    annotations: {}
+    labels:
+      name: xfn-config
+    name: xfn-config
+  data:
+    routeType: "HTTPRoute"
+    httpGatewayName: "http-gateway"
+    httpGatewayNamespace: "syn-kgateway"
+    ocpDefaultAppsDomain: ""
+    ingress_annotations: |
+      cert-manager.io/cluster-issuer: letsencrypt-production

--- a/test/functions/vshnforgejo/03_httproute.yaml
+++ b/test/functions/vshnforgejo/03_httproute.yaml
@@ -1,0 +1,67 @@
+desired: {}
+input:
+  apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    annotations: {}
+    labels:
+      name: xfn-config
+    name: xfn-config
+  data:
+    defaultPlan: mini
+    controlNamespace: appcat-control
+    routeType: "HTTPRoute"
+    httpGatewayName: "http-gateway"
+    httpGatewayNamespace: "syn-kgateway"
+    plans: |
+      {"large": {"size": {"cpu": "4", "disk": "500Gi", "enabled": true, "memory": "16Gi"}}, "medium": {"size": {"cpu": "2", "disk": "200Gi", "enabled": true, "memory": "8Gi"}}, "mini": {"size": {"cpu": "500m", "disk": "10Gi", "enabled": true, "memory": "2Gi"}}, "small": {"size": {"cpu": "1", "disk": "50Gi", "enabled": true, "memory": "4Gi"}}}
+    ingress_annotations: |
+      cert-manager.io/cluster-issuer: letsencrypt-production
+observed:
+  composite:
+    resource:
+      apiVersion: vshn.appcat.vshn.io/v1
+      kind: XVSHNForgejo
+      metadata:
+        annotations: null
+        creationTimestamp: "2024-07-08T16:30:28Z"
+        finalizers:
+          - composite.apiextensions.crossplane.io
+        generateName: forgejo-
+        generation: 1
+        labels:
+          crossplane.io/claim-name: forgejo
+          crossplane.io/claim-namespace: unit-test
+          crossplane.io/composite: forgejo-unit-test
+        name: forgejo-unit-test
+      spec:
+        parameters:
+          service:
+            forgejoSettings:
+              APP_NAME: "My_App"
+              config:
+                actions:
+                  ENABLED: "true"
+                openid:
+                  ENABLE_OPENID_SIGNIN: "false"
+                oauth2:
+                  ENABLE: "true"
+                oauth2_client:
+                  ENABLE_AUTO_REGISTRATION: "true"
+                service:
+                  REGISTER_EMAIL_CONFIRM: "true"
+                mailer:
+                  ENABLED: "true"
+                  PROTOCOL: sendmail # Field should be removed due to bad value
+            fqdn: ["forgejo.example.com"]
+            majorVersion: "14.0.0"
+        claimRef:
+          apiVersion: vshn.appcat.vshn.io/v1
+          kind: VSHNForgejo
+          name: forgejo
+          namespace: unit-test
+        compositionRef:
+          name: VSHNForgejo.vshn.appcat.vshn.io
+        compositionRevisionRef:
+          name: VSHNForgejo.vshn.appcat.vshn.io-ce52f13
+        compositionUpdatePolicy: Automatic

--- a/test/functions/vshnkeycloak/02_httproute.yaml
+++ b/test/functions/vshnkeycloak/02_httproute.yaml
@@ -1,0 +1,75 @@
+desired: {}
+input:
+  apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    annotations: {}
+    labels:
+      name: xfn-config
+    name: xfn-config
+  data:
+    defaultPlan: standard-2
+    controlNamespace: appcat-control
+    plans: '{"standard-2": {"size": {"cpu": "500m", "disk": "16Gi", "enabled":
+            true, "memory": "2Gi"}}, "standard-4": {"size": {"cpu": "1", "disk": "16Gi",
+            "enabled": true, "memory": "4Gi"}}, "standard-8": {"size": {"cpu": "2",
+            "disk": "16Gi", "enabled": true, "memory": "8Gi"}}}'
+    ocpDefaultAppsDomain: "apps.example.com"
+    routeType: "HTTPRoute"
+    httpGatewayName: "http-gateway"
+    httpGatewayNamespace: "syn-kgateway"
+    ingress_annotations: |
+      cert-manager.io/cluster-issuer: letsencrypt-production
+observed:
+  resources:
+    mycloak-pg:
+      resource:
+        apiVersion: vshn.appcat.vshn.io/v1
+        kind: XVSHNPostgreSQL
+        metadata:
+          name: mycloak-pg
+        spec:
+          compositionRef:
+            name: vshnpostgrescnpg.vshn.appcat.vshn.io
+      connection_details:
+        foo: YmFyCg==
+    # necessary for keycloak custom env variables
+    mycloak-env-cm-my-configmap-claim-observer:
+      resource:
+        apiVersion: v1
+        kind: Object
+        metadata:
+          name: unit-test
+        status:
+          atProvider:
+            manifest:
+              apiVersion: v1
+              kind: ConfigMap
+              metadata:
+                name: unit-test
+    mycloak-env-secret-my-secret-1-claim-observer:
+      resource:
+        apiVersion: v1
+        kind: Object
+        metadata:
+          name: unit-test
+        status:
+          atProvider:
+            manifest:
+              apiVersion: v1
+              kind: Secret
+              metadata:
+                name: unit-test
+    mycloak-env-secret-my-secret-2-claim-observer:
+      resource:
+        apiVersion: v1
+        kind: Object
+        metadata:
+          name: unit-test
+        status:
+          atProvider:
+            manifest:
+              apiVersion: v1
+              kind: Secret
+              metadata:
+                name: unit-test

--- a/test/functions/vshnnextcloud/03_httproute.yaml
+++ b/test/functions/vshnnextcloud/03_httproute.yaml
@@ -1,0 +1,142 @@
+desired:
+  resources:
+    nextcloud-app1-prod-release:
+      resource:
+        apiVersion: helm.crossplane.io/v1beta1
+        kind: Release
+        metadata:
+          name: nextcloud-app1-prod
+        spec: {}
+input:
+  apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    annotations: {}
+    labels:
+      name: xfn-config
+    name: xfn-config
+  data:
+    defaultPlan: standard-2
+    collabora_image: docker.io/collabora/code
+    collabora_image_tag: latest
+    collaboraCPULimit: "1"
+    collaboraCPURequests: 250m
+    collaboraMemoryLimit: 1Gi
+    collaboraMemoryRequests: 256Mi
+    imageTag: nextcloud_collabora
+    controlNamespace: appcat-control
+    plans: '{"standard-2": {"size": {"cpu": "500m", "disk": "16Gi", "enabled":
+            true, "memory": "2Gi"}}, "standard-4": {"size": {"cpu": "1", "disk": "16Gi",
+            "enabled": true, "memory": "4Gi"}}, "standard-8": {"size": {"cpu": "2",
+            "disk": "16Gi", "enabled": true, "memory": "8Gi"}}}'
+    isOpenshift: "false"
+    routeType: "HTTPRoute"
+    httpGatewayName: "http-gateway"
+    httpGatewayNamespace: "syn-kgateway"
+    ingress_annotations: |
+      cert-manager.io/cluster-issuer: letsencrypt-production
+observed:
+  composite:
+    resource:
+      apiVersion: vshn.appcat.vshn.io/v1
+      kind: XVSHNNextcloud
+      metadata:
+        annotations: null
+        creationTimestamp: "2024-07-08T16:30:28Z"
+        finalizers:
+          - composite.apiextensions.crossplane.io
+        generateName: nextcloud-
+        generation: 1
+        labels:
+          crossplane.io/claim-name: nextcloud
+          crossplane.io/claim-namespace: unit-test
+          crossplane.io/composite: nextcloud-gc9x4
+        name: nextcloud-gc9x4
+      spec:
+        parameters:
+          service:
+            fqdn:
+              - nextcloud.example.com
+            useExternalPostgreSQL: true
+            version: "29"
+        claimRef:
+          apiVersion: vshn.appcat.vshn.io/v1
+          kind: VSHNNextcloud
+          name: nextcloud
+          namespace: unit-test
+        compositionRef:
+          name: vshnnextcloud.vshn.appcat.vshn.io
+        compositionRevisionRef:
+          name: vshnnextcloud.vshn.appcat.vshn.io-ce52f13
+        compositionUpdatePolicy: Automatic
+  resources:
+    # necessary for collabora tests
+    nextcloud-gc9x4-release:
+      resource:
+        apiVersion: helm.crossplane.io/v1beta1
+        kind: Release
+        metadata:
+          name: nextcloud-gc9x4
+        spec: {}
+        status:
+          atProvider:
+            conditions:
+            - lastTransitionTime: "2024-07-08T14:50:19Z"
+              reason: Available
+              status: "True"
+              type: Ready
+            - lastTransitionTime: "2024-07-08T14:50:18Z"
+              reason: ReconcileSuccess
+              status: "True"
+              type: Synced
+    nextcloud-gc9x4-claim-ns-observer:
+      resource:
+        apiVersion: v1
+        kind: Object
+        metadata:
+          name: unit-test
+        spec:
+          forProvider:
+            manifest:
+              apiVersion: v1
+              kind: Namespace
+              metadata:
+                name: unit-test
+        status:
+          atProvider:
+            manifest:
+              apiVersion: v1
+              kind: Namespace
+              metadata:
+                name: unit-test
+                labels:
+                  appuio.io/organization: vshn
+    nextcloud-gc9x4-credentials-secret:
+      connection_details:
+        admin: czNjcjN0UGFzcwo=
+    nextcloud-gc9x4-pg:
+      resource:
+        apiVersion: vshn.appcat.vshn.io/v1
+        kind: XVSHNPostgreSQL
+        metadata:
+          name: "nextcloud-gc9x4-pg"
+        spec:
+          compositionRef:
+            name: vshnpostgres.vshn.appcat.vshn.io
+      connection_details:
+        POSTGRESQL_HOST: bmV4dGNsb3VkLWdjOXg0LnZzaG4tcG9zdGdyZXNxbC1uZXh0Y2xvdWQtZ2N4NC5zdmMuY2x1c3Rlci5sb2NhbAo=
+        POSTGRESQL_DB: cG9zdGdyZXMK
+        POSTGRESQL_URL: cG9zdGdyZXM6Ly9wb3N0Z3Jlczo0YTcwLWY2OTItNGE5YS1iMzBAbmV4dGNsb3VkLWdjOXg0LnZzaG4tcG9zdGdyZXNxbC1uZXh0Y2xvdWQtZ2N4NC5zdmMuY2x1c3Rlci5sb2NhbC9wb3N0Z3Jlcwo=
+        POSTGRESQL_USER: cG9zdGdyZXMK
+        POSTGRESQL_PORT: NTQzMgo=
+        POSTGRESQL_PASSWORD: NGE3MC1mNjkyLTRhOWEtYjMwCg==
+      status:
+        conditions:
+        - lastTransitionTime: "2024-07-08T14:50:19Z"
+          reason: Available
+          status: "True"
+          type: Ready
+        - lastTransitionTime: "2024-07-08T14:50:18Z"
+          reason: ReconcileSuccess
+          status: "True"
+          type: Synced


### PR DESCRIPTION
## Summary

Adds `HTTPRoute` (Gateway API) as an alternative to `Ingress` for Forgejo, Keycloak, and Nextcloud (incl. Collabora). Shared helper lives in `pkg/comp-functions/functions/common/httproute.go`. Enables Servala clusters to route via Gateway API.

Component PR: https://github.com/vshn/component-appcat/pull/1147

## Checklist

- [x] Update tests.
- [ ] Link this PR to related issues.
- [ ] Merge with `/merge` comment.