### PR TITLE
Move TCPRoute to instance namespace and scope XListenerSet to it

### DIFF
--- a/pkg/comp-functions/functions/vshnforgejo/ssh.go
+++ b/pkg/comp-functions/functions/vshnforgejo/ssh.go
@@ -59,7 +59,7 @@ func ConfigureSSHAccess(ctx context.Context, comp *vshnv1.VSHNForgejo, svc *runt
 		effectiveGatewayNamespace = observed.gatewayNamespace
 	}
 
-	err = createXListenerSet(svc, resourceBaseName, effectiveGatewayNamespace, effectiveGatewayName, observed.port)
+	err = createXListenerSet(svc, resourceBaseName, effectiveGatewayNamespace, effectiveGatewayName, comp.GetInstanceNamespace(), observed.port)
 	if err != nil {
 		return runtime.NewWarningResult(fmt.Sprintf("cannot create XListenerSet: %s", err))
 	}
@@ -67,11 +67,6 @@ func ConfigureSSHAccess(ctx context.Context, comp *vshnv1.VSHNForgejo, svc *runt
 	err = createTCPRoute(svc, comp, resourceBaseName, effectiveGatewayNamespace)
 	if err != nil {
 		return runtime.NewWarningResult(fmt.Sprintf("cannot create TCPRoute: %s", err))
-	}
-
-	err = createReferenceGrant(svc, comp, resourceBaseName, effectiveGatewayNamespace)
-	if err != nil {
-		return runtime.NewWarningResult(fmt.Sprintf("cannot create ReferenceGrant: %s", err))
 	}
 
 	err = createGatewayNetworkPolicy(svc, comp, resourceBaseName, effectiveGatewayNamespace)
@@ -99,7 +94,7 @@ func ConfigureSSHAccess(ctx context.Context, comp *vshnv1.VSHNForgejo, svc *runt
 	return nil
 }
 
-func createXListenerSet(svc *runtime.ServiceRuntime, name, namespace, gatewayName string, port int32) error {
+func createXListenerSet(svc *runtime.ServiceRuntime, name, namespace, gatewayName, instanceNamespace string, port int32) error {
 	xls := &unstructured.Unstructured{
 		Object: map[string]any{},
 	}
@@ -125,10 +120,16 @@ func createXListenerSet(svc *runtime.ServiceRuntime, name, namespace, gatewayNam
 		"protocol": "TCP",
 	}
 
-	err = unstructured.SetNestedField(listener, "All", "allowedRoutes", "namespaces", "from")
-
+	err = unstructured.SetNestedField(listener, "Selector", "allowedRoutes", "namespaces", "from")
 	if err != nil {
-		return fmt.Errorf("setting allowedRoutes.namespaces: %w", err)
+		return fmt.Errorf("setting allowedRoutes.namespaces.from: %w", err)
+	}
+
+	err = unstructured.SetNestedMap(listener, map[string]any{
+		"kubernetes.io/metadata.name": instanceNamespace,
+	}, "allowedRoutes", "namespaces", "selector", "matchLabels")
+	if err != nil {
+		return fmt.Errorf("setting allowedRoutes.namespaces.selector: %w", err)
 	}
 
 	err = unstructured.SetNestedSlice(listener, []any{
@@ -163,7 +164,7 @@ func createTCPRoute(svc *runtime.ServiceRuntime, comp *vshnv1.VSHNForgejo, name,
 	tcpRoute.SetAPIVersion("gateway.networking.k8s.io/v1alpha2")
 	tcpRoute.SetKind("TCPRoute")
 	tcpRoute.SetName(name)
-	tcpRoute.SetNamespace(gatewayNamespace)
+	tcpRoute.SetNamespace(instanceNs)
 
 	err := unstructured.SetNestedSlice(tcpRoute.Object, []any{
 		map[string]any{
@@ -198,45 +199,6 @@ func createTCPRoute(svc *runtime.ServiceRuntime, comp *vshnv1.VSHNForgejo, name,
 	}
 
 	return svc.SetDesiredKubeObject(tcpRoute, name+"-tcproute")
-}
-
-func createReferenceGrant(svc *runtime.ServiceRuntime, comp *vshnv1.VSHNForgejo, name, gatewayNamespace string) error {
-	instanceNs := comp.GetInstanceNamespace()
-	sshServiceName := helmFullname(comp) + "-ssh"
-
-	refGrant := &unstructured.Unstructured{
-		Object: map[string]any{},
-	}
-	refGrant.SetAPIVersion("gateway.networking.k8s.io/v1beta1")
-	refGrant.SetKind("ReferenceGrant")
-	refGrant.SetName(name)
-	refGrant.SetNamespace(instanceNs)
-
-	err := unstructured.SetNestedSlice(refGrant.Object, []any{
-		map[string]any{
-			"group":     "gateway.networking.k8s.io",
-			"kind":      "TCPRoute",
-			"namespace": gatewayNamespace,
-		},
-	}, "spec", "from")
-
-	if err != nil {
-		return fmt.Errorf("setting from: %w", err)
-	}
-
-	err = unstructured.SetNestedSlice(refGrant.Object, []any{
-		map[string]any{
-			"group": "",
-			"kind":  "Service",
-			"name":  sshServiceName,
-		},
-	}, "spec", "to")
-
-	if err != nil {
-		return fmt.Errorf("setting to: %w", err)
-	}
-
-	return svc.SetDesiredKubeObject(refGrant, name+"-refgrant")
 }
 
 func createGatewayNetworkPolicy(svc *runtime.ServiceRuntime, comp *vshnv1.VSHNForgejo, name, gatewayNamespace string) error {

--- a/pkg/comp-functions/functions/vshnforgejo/ssh_test.go
+++ b/pkg/comp-functions/functions/vshnforgejo/ssh_test.go
@@ -61,13 +61,19 @@ func TestSSH(t *testing.T) {
 		assert.Equal(t, "TCP", l0["protocol"])
 		assert.Equal(t, int64(0), l0["port"]) // 0 on first create, webhook assigns
 
+		// Verify allowedRoutes scoped to instance namespace
+		fromMode, _, _ := unstructured.NestedString(l0, "allowedRoutes", "namespaces", "from")
+		assert.Equal(t, "Selector", fromMode)
+		selectorLabel, _, _ := unstructured.NestedString(l0, "allowedRoutes", "namespaces", "selector", "matchLabels", "kubernetes.io/metadata.name")
+		assert.Equal(t, instanceNs, selectorLabel)
+
 		// Verify TCPRoute
 		tcpRoute := &unstructured.Unstructured{}
 		tcpRoute.SetAPIVersion("gateway.networking.k8s.io/v1alpha2")
 		tcpRoute.SetKind("TCPRoute")
 		require.NoError(t, svc.GetDesiredKubeObject(tcpRoute, resourceBaseName+"-tcproute"))
 		assert.Equal(t, resourceBaseName, tcpRoute.GetName())
-		assert.Equal(t, "gateway-system", tcpRoute.GetNamespace())
+		assert.Equal(t, instanceNs, tcpRoute.GetNamespace())
 
 		parentRefs, _, _ := unstructured.NestedSlice(tcpRoute.Object, "spec", "parentRefs")
 		require.Len(t, parentRefs, 1)
@@ -85,26 +91,6 @@ func TestSSH(t *testing.T) {
 		assert.Equal(t, resourceBaseName, backend["name"]) // <comp-name>-ssh
 		assert.Equal(t, instanceNs, backend["namespace"])
 		assert.Equal(t, int64(22), backend["port"])
-
-		// Verify ReferenceGrant
-		refGrant := &unstructured.Unstructured{}
-		refGrant.SetAPIVersion("gateway.networking.k8s.io/v1beta1")
-		refGrant.SetKind("ReferenceGrant")
-		require.NoError(t, svc.GetDesiredKubeObject(refGrant, resourceBaseName+"-refgrant"))
-		assert.Equal(t, resourceBaseName, refGrant.GetName())
-		assert.Equal(t, instanceNs, refGrant.GetNamespace())
-
-		from, _, _ := unstructured.NestedSlice(refGrant.Object, "spec", "from")
-		require.Len(t, from, 1)
-		fromEntry := from[0].(map[string]any)
-		assert.Equal(t, "TCPRoute", fromEntry["kind"])
-		assert.Equal(t, "gateway-system", fromEntry["namespace"])
-
-		to, _, _ := unstructured.NestedSlice(refGrant.Object, "spec", "to")
-		require.Len(t, to, 1)
-		toEntry := to[0].(map[string]any)
-		assert.Equal(t, "Service", toEntry["kind"])
-		assert.Equal(t, resourceBaseName, toEntry["name"], "ReferenceGrant should be scoped to the SSH service")
 
 		// Verify Helm release does not have SSH enabled yet
 		release := &xhelmv1.Release{}


### PR DESCRIPTION
## Summary

* The TCPRoute for Forgejo SSH should live close to the service 
* XListenerSet continues to be created in in gateway namespace, but locked it down to only accept routes from the namespace selector
* Removed ReferenceGrant, not needed

## Checklist

- [x] Update tests.
- [ ] Link this PR to related issues.
- [ ] Merge with `/merge` comment.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->


Component PR: https://github.com/vshn/component-appcat/pull/1148