### PR TITLE
Duplicate billing events sent to Odoo on status update failure

### DIFF
--- a/apis/vshn/v1/billing_service.go
+++ b/apis/vshn/v1/billing_service.go
@@ -95,7 +95,7 @@ type BillingEventStatus struct {
 	Type string `json:"type"`
 
 	// ProductID identifies the product in the billing system
-	ProductID string `json:"productId"`
+	ProductID string `json:"productID"`
 
 	// InstanceID uniquely identifies this product event in Odoo. Format: <composite-name>-<shortSHA(productID)>
 	InstanceID string `json:"instanceID,omitempty"`

--- a/crds/vshn.appcat.vshn.io_billingservices.yaml
+++ b/crds/vshn.appcat.vshn.io_billingservices.yaml
@@ -190,7 +190,7 @@ spec:
                         event
                       format: date-time
                       type: string
-                    productId:
+                    productID:
                       description: ProductID identifies the product in the billing
                         system
                       type: string
@@ -227,7 +227,7 @@ spec:
                         Generic field supporting replica count, disk size, percentages, etc.
                       type: string
                   required:
-                  - productId
+                  - productID
                   - state
                   - timestamp
                   - type

--- a/pkg/controller/billing/billing_handler.go
+++ b/pkg/controller/billing/billing_handler.go
@@ -153,7 +153,7 @@ func (b *BillingHandler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		}
 
 		canRemoveFinalizer, requeueAfter := shouldRemoveFinalizer(&billingService)
-		if canRemoveFinalizer && controllerutil.ContainsFinalizer(&billingService, vshnv1.BillingServiceFinalizer) {
+		if canRemoveFinalizer && !hasBacklog(&billingService) && controllerutil.ContainsFinalizer(&billingService, vshnv1.BillingServiceFinalizer) {
 			controllerutil.RemoveFinalizer(&billingService, vshnv1.BillingServiceFinalizer)
 			if err := b.Update(ctx, &billingService); err != nil {
 				return ctrl.Result{}, err

--- a/pkg/controller/billing/delete.go
+++ b/pkg/controller/billing/delete.go
@@ -5,40 +5,76 @@ import (
 	"time"
 
 	vshnv1 "github.com/vshn/appcat/v4/apis/vshn/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
+// handleDeletion enqueues delete events for every item that was ever sent to Odoo.
+//
+// It processes two sources to ensure no instance is missed:
+//  1. Current spec items — the normal case where all items are present.
+//  2. Sent created/scaled events in status — catches items transiently absent from spec.
+//     Crossplane applies the composed BillingService in two steps: first sets DeletionTimestamp,
+//     then may still update spec via provider-kubernetes. If the spec momentarily has N-1 items
+//     while status shows N sent events, relying on spec alone permanently misses the Nth delete.
+//     Scaled events are included to handle cases where the original create event was pruned.
 func (b *BillingHandler) handleDeletion(ctx context.Context, billingService *vshnv1.BillingService) error {
 	if billingService.DeletionTimestamp.IsZero() {
 		return nil
 	}
 
 	delTime := *billingService.DeletionTimestamp
+	seen := make(map[string]bool)
 
-	// Delete all items/products currently in spec
+	// Spec items first (normal path).
 	for _, item := range billingService.Spec.Odoo.Items {
-		if !hasEventByInstanceID(billingService, BillingEventTypeDeleted, item.InstanceID) {
-			lastValue := lastObservedValueForInstanceID(billingService, item.InstanceID, item.Value)
-			event := vshnv1.BillingEventStatus{
-				Type:                 string(BillingEventTypeDeleted),
-				ProductID:            item.ProductID,
-				InstanceID:           item.InstanceID,
-				Value:                lastValue,
-				ItemDescription:      item.ItemDescription,
-				ItemGroupDescription: item.ItemGroupDescription,
-				Timestamp:            delTime,
-				State:                string(BillingEventStatePending),
-				RetryCount:           0,
-			}
-			if err := enqueueEvent(ctx, b, billingService, event); err != nil {
-				return err
-			}
+		if err := b.enqueueDeleteIfNeeded(ctx, billingService, item, delTime, seen); err != nil {
+			return err
 		}
 	}
 
-	// Finalizer removal is performed in Reconcile once the delete events are sent
+	// Sent created/scaled events not already covered by spec (transient spec gap).
+	// seen prevents double-enqueue when both a create and scale exist for the same instanceID.
+	for _, event := range billingService.Status.Events {
+		if seen[event.InstanceID] {
+			continue
+		}
+		if event.State != string(BillingEventStateSent) {
+			continue
+		}
+		if event.Type != string(BillingEventTypeCreated) && event.Type != string(BillingEventTypeScaled) {
+			continue
+		}
+		if err := b.enqueueDeleteIfNeeded(ctx, billingService, vshnv1.ItemSpec{
+			ProductID:            event.ProductID,
+			InstanceID:           event.InstanceID,
+			Value:                event.Value,
+			ItemDescription:      event.ItemDescription,
+			ItemGroupDescription: event.ItemGroupDescription,
+		}, delTime, seen); err != nil {
+			return err
+		}
+	}
+
 	_ = controllerutil.AddFinalizer(billingService, vshnv1.BillingServiceFinalizer)
 	return nil
+}
+
+func (b *BillingHandler) enqueueDeleteIfNeeded(ctx context.Context, billingService *vshnv1.BillingService, it vshnv1.ItemSpec, delTime metav1.Time, seen map[string]bool) error {
+	if seen[it.InstanceID] || hasEventByInstanceID(billingService, BillingEventTypeDeleted, it.InstanceID) {
+		return nil
+	}
+	seen[it.InstanceID] = true
+	return enqueueEvent(ctx, b, billingService, vshnv1.BillingEventStatus{
+		Type:                 string(BillingEventTypeDeleted),
+		ProductID:            it.ProductID,
+		InstanceID:           it.InstanceID,
+		Value:                lastObservedValueForInstanceID(billingService, it.InstanceID, it.Value),
+		ItemDescription:      it.ItemDescription,
+		ItemGroupDescription: it.ItemGroupDescription,
+		Timestamp:            delTime,
+		State:                string(BillingEventStatePending),
+	})
 }
 
 // shouldRemoveFinalizer determines if the finalizer can be removed based on whether the KeepAfterDeletion grace period has elapsed

--- a/pkg/controller/billing/delete.go
+++ b/pkg/controller/billing/delete.go
@@ -17,8 +17,8 @@ func (b *BillingHandler) handleDeletion(ctx context.Context, billingService *vsh
 
 	// Delete all items/products currently in spec
 	for _, item := range billingService.Spec.Odoo.Items {
-		if !hasEvent(billingService, BillingEventTypeDeleted, item.ProductID) {
-			lastValue := lastObservedValueForProduct(billingService, item.ProductID, item.Value)
+		if !hasEventByInstanceID(billingService, BillingEventTypeDeleted, item.InstanceID) {
+			lastValue := lastObservedValueForInstanceID(billingService, item.InstanceID, item.Value)
 			event := vshnv1.BillingEventStatus{
 				Type:                 string(BillingEventTypeDeleted),
 				ProductID:            item.ProductID,

--- a/pkg/controller/billing/delete_test.go
+++ b/pkg/controller/billing/delete_test.go
@@ -1,13 +1,279 @@
 package billing
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	vshnv1 "github.com/vshn/appcat/v4/apis/vshn/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
+
+func TestHandleDeletion(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, vshnv1.AddToScheme(scheme))
+
+	now := metav1.Now()
+
+	tests := []struct {
+		name                  string
+		billingService        *vshnv1.BillingService
+		expectedDeleteCount   int
+		expectedInstanceIDs   []string          // instanceIDs that must have a delete event
+		unexpectedInstanceIDs []string          // instanceIDs that must NOT have a delete event
+		expectedDeleteValues  map[string]string // instanceID → expected delete event Value
+	}{
+		{
+			name: "creates delete events for all spec items",
+			billingService: &vshnv1.BillingService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-svc",
+					Namespace:         "test-ns",
+					DeletionTimestamp: &now,
+					Finalizers:        []string{vshnv1.BillingServiceFinalizer},
+				},
+				Spec: vshnv1.BillingServiceSpec{
+					Odoo: vshnv1.OdooSpec{
+						Items: []vshnv1.ItemSpec{
+							{ProductID: "prod-a", InstanceID: "inst-a", Value: "1", ItemDescription: "A", ItemGroupDescription: "G"},
+							{ProductID: "prod-b", InstanceID: "inst-b", Value: "2", ItemDescription: "B", ItemGroupDescription: "G"},
+						},
+					},
+				},
+				Status: vshnv1.BillingServiceStatus{
+					Events: []vshnv1.BillingEventStatus{
+						{Type: string(BillingEventTypeCreated), InstanceID: "inst-a", ProductID: "prod-a", Value: "1", State: string(BillingEventStateSent)},
+						{Type: string(BillingEventTypeCreated), InstanceID: "inst-b", ProductID: "prod-b", Value: "2", State: string(BillingEventStateSent)},
+					},
+				},
+			},
+			expectedDeleteCount: 2,
+			expectedInstanceIDs: []string{"inst-a", "inst-b"},
+		},
+		{
+			name: "catches item absent from spec but present in sent creates (transient spec gap)",
+			billingService: &vshnv1.BillingService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-svc",
+					Namespace:         "test-ns",
+					DeletionTimestamp: &now,
+					Finalizers:        []string{vshnv1.BillingServiceFinalizer},
+				},
+				Spec: vshnv1.BillingServiceSpec{
+					Odoo: vshnv1.OdooSpec{
+						// Only 1 item in spec — inst-b temporarily absent
+						Items: []vshnv1.ItemSpec{
+							{ProductID: "prod-a", InstanceID: "inst-a", Value: "1", ItemDescription: "A", ItemGroupDescription: "G"},
+						},
+					},
+				},
+				Status: vshnv1.BillingServiceStatus{
+					Events: []vshnv1.BillingEventStatus{
+						// Both were sent to Odoo
+						{Type: string(BillingEventTypeCreated), InstanceID: "inst-a", ProductID: "prod-a", Value: "1", State: string(BillingEventStateSent)},
+						{Type: string(BillingEventTypeCreated), InstanceID: "inst-b", ProductID: "prod-b", Value: "2", State: string(BillingEventStateSent)},
+					},
+				},
+			},
+			expectedDeleteCount: 2,
+			expectedInstanceIDs: []string{"inst-a", "inst-b"},
+		},
+		{
+			name: "does not delete item with only pending create (never reached Odoo)",
+			billingService: &vshnv1.BillingService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-svc",
+					Namespace:         "test-ns",
+					DeletionTimestamp: &now,
+					Finalizers:        []string{vshnv1.BillingServiceFinalizer},
+				},
+				Spec: vshnv1.BillingServiceSpec{
+					Odoo: vshnv1.OdooSpec{
+						Items: []vshnv1.ItemSpec{
+							{ProductID: "prod-a", InstanceID: "inst-a", Value: "1", ItemDescription: "A", ItemGroupDescription: "G"},
+						},
+					},
+				},
+				Status: vshnv1.BillingServiceStatus{
+					Events: []vshnv1.BillingEventStatus{
+						{Type: string(BillingEventTypeCreated), InstanceID: "inst-a", ProductID: "prod-a", Value: "1", State: string(BillingEventStateSent)},
+						// inst-b create is pending — never reached Odoo
+						{Type: string(BillingEventTypeCreated), InstanceID: "inst-b", ProductID: "prod-b", Value: "2", State: string(BillingEventStatePending)},
+					},
+				},
+			},
+			expectedDeleteCount:   1,
+			expectedInstanceIDs:   []string{"inst-a"},
+			unexpectedInstanceIDs: []string{"inst-b"},
+		},
+		{
+			name: "does not create duplicate delete event",
+			billingService: &vshnv1.BillingService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-svc",
+					Namespace:         "test-ns",
+					DeletionTimestamp: &now,
+					Finalizers:        []string{vshnv1.BillingServiceFinalizer},
+				},
+				Spec: vshnv1.BillingServiceSpec{
+					Odoo: vshnv1.OdooSpec{
+						Items: []vshnv1.ItemSpec{
+							{ProductID: "prod-a", InstanceID: "inst-a", Value: "1", ItemDescription: "A", ItemGroupDescription: "G"},
+						},
+					},
+				},
+				Status: vshnv1.BillingServiceStatus{
+					Events: []vshnv1.BillingEventStatus{
+						// Delete already enqueued (previous reconcile)
+						{Type: string(BillingEventTypeDeleted), InstanceID: "inst-a", ProductID: "prod-a", Value: "1", State: string(BillingEventStatePending)},
+						{Type: string(BillingEventTypeCreated), InstanceID: "inst-a", ProductID: "prod-a", Value: "1", State: string(BillingEventStateSent)},
+					},
+				},
+			},
+			expectedDeleteCount: 1, // still 1 — no duplicate
+		},
+		{
+			name: "does not delete item with superseded create",
+			billingService: &vshnv1.BillingService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-svc",
+					Namespace:         "test-ns",
+					DeletionTimestamp: &now,
+					Finalizers:        []string{vshnv1.BillingServiceFinalizer},
+				},
+				Spec: vshnv1.BillingServiceSpec{
+					Odoo: vshnv1.OdooSpec{Items: []vshnv1.ItemSpec{}},
+				},
+				Status: vshnv1.BillingServiceStatus{
+					Events: []vshnv1.BillingEventStatus{
+						{Type: string(BillingEventTypeCreated), InstanceID: "inst-a", ProductID: "prod-a", Value: "1", State: string(BillingEventStateSuperseded)},
+					},
+				},
+			},
+			expectedDeleteCount:   0,
+			unexpectedInstanceIDs: []string{"inst-a"},
+		},
+		{
+			name: "uses last scaled value for delete",
+			billingService: &vshnv1.BillingService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-svc",
+					Namespace:         "test-ns",
+					DeletionTimestamp: &now,
+					Finalizers:        []string{vshnv1.BillingServiceFinalizer},
+				},
+				Spec: vshnv1.BillingServiceSpec{
+					Odoo: vshnv1.OdooSpec{
+						Items: []vshnv1.ItemSpec{
+							{ProductID: "prod-a", InstanceID: "inst-a", Value: "1", ItemDescription: "A", ItemGroupDescription: "G"},
+						},
+					},
+				},
+				Status: vshnv1.BillingServiceStatus{
+					Events: []vshnv1.BillingEventStatus{
+						{Type: string(BillingEventTypeScaled), InstanceID: "inst-a", ProductID: "prod-a", Value: "5", State: string(BillingEventStateSent)},
+						{Type: string(BillingEventTypeCreated), InstanceID: "inst-a", ProductID: "prod-a", Value: "1", State: string(BillingEventStateSent)},
+					},
+				},
+			},
+			expectedDeleteCount:  1,
+			expectedInstanceIDs:  []string{"inst-a"},
+			expectedDeleteValues: map[string]string{"inst-a": "5"},
+		},
+		{
+			name: "catches instance with only scaled event (create was pruned)",
+			billingService: &vshnv1.BillingService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-svc",
+					Namespace:         "test-ns",
+					DeletionTimestamp: &now,
+					Finalizers:        []string{vshnv1.BillingServiceFinalizer},
+				},
+				Spec: vshnv1.BillingServiceSpec{
+					Odoo: vshnv1.OdooSpec{Items: []vshnv1.ItemSpec{}},
+				},
+				Status: vshnv1.BillingServiceStatus{
+					Events: []vshnv1.BillingEventStatus{
+						// create event was pruned; only scale event remains
+						{Type: string(BillingEventTypeScaled), InstanceID: "inst-a", ProductID: "prod-a", Value: "5", State: string(BillingEventStateSent)},
+					},
+				},
+			},
+			expectedDeleteCount:  1,
+			expectedInstanceIDs:  []string{"inst-a"},
+			expectedDeleteValues: map[string]string{"inst-a": "5"},
+		},
+		{
+			name: "no-op when DeletionTimestamp not set",
+			billingService: &vshnv1.BillingService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-svc",
+					Namespace: "test-ns",
+				},
+				Spec: vshnv1.BillingServiceSpec{
+					Odoo: vshnv1.OdooSpec{
+						Items: []vshnv1.ItemSpec{
+							{ProductID: "prod-a", InstanceID: "inst-a", Value: "1"},
+						},
+					},
+				},
+				Status: vshnv1.BillingServiceStatus{
+					Events: []vshnv1.BillingEventStatus{
+						{Type: string(BillingEventTypeCreated), InstanceID: "inst-a", State: string(BillingEventStateSent)},
+					},
+				},
+			},
+			expectedDeleteCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(tt.billingService).
+				WithStatusSubresource(tt.billingService).
+				Build()
+
+			handler := &BillingHandler{Client: client, Scheme: scheme, maxEvents: 100}
+
+			err := handler.handleDeletion(context.Background(), tt.billingService)
+			require.NoError(t, err)
+
+			deleteCount := 0
+			for _, e := range tt.billingService.Status.Events {
+				if e.Type == string(BillingEventTypeDeleted) {
+					deleteCount++
+					assert.Equal(t, string(BillingEventStatePending), e.State)
+					assert.NotEmpty(t, e.InstanceID)
+					assert.NotEmpty(t, e.ProductID)
+				}
+			}
+			assert.Equal(t, tt.expectedDeleteCount, deleteCount)
+
+			for _, id := range tt.expectedInstanceIDs {
+				assert.True(t, hasEventByInstanceID(tt.billingService, BillingEventTypeDeleted, id),
+					"expected delete event for instanceID %s", id)
+			}
+			for _, id := range tt.unexpectedInstanceIDs {
+				assert.False(t, hasEventByInstanceID(tt.billingService, BillingEventTypeDeleted, id),
+					"unexpected delete event for instanceID %s", id)
+			}
+			for _, e := range tt.billingService.Status.Events {
+				if e.Type != string(BillingEventTypeDeleted) {
+					continue
+				}
+				if want, ok := tt.expectedDeleteValues[e.InstanceID]; ok {
+					assert.Equal(t, want, e.Value, "delete value mismatch for instanceID %s", e.InstanceID)
+				}
+			}
+		})
+	}
+}
 
 func TestShouldRemoveFinalizer(t *testing.T) {
 	now := time.Now()

--- a/pkg/controller/billing/delivery.go
+++ b/pkg/controller/billing/delivery.go
@@ -76,12 +76,20 @@ func (b *BillingHandler) persistEventSent(ctx context.Context, billingService *v
 	if err := b.Get(ctx, client.ObjectKeyFromObject(billingService), fresh); err != nil {
 		return nil, err
 	}
+	found := false
 	for i, e := range fresh.Status.Events {
 		if e.InstanceID == event.InstanceID && e.Type == event.Type && e.Timestamp.Time.Equal(event.Timestamp.Time) {
 			fresh.Status.Events[i].State = string(BillingEventStateSent)
 			fresh.Status.Events[i].LastAttemptTime = event.LastAttemptTime
+			found = true
 			break
 		}
+	}
+	if !found {
+		// Event was pruned between Odoo delivery and this status persist. This is a known
+		// rare race: the next reconcile will re-enqueue the event as pending and re-send it
+		// to Odoo. Odoo deduplicates duplicate events on its side, so this is acceptable.
+		return nil, fmt.Errorf("event for instanceID %q type %q not found after re-fetch (pruned?)", event.InstanceID, event.Type)
 	}
 	return fresh, b.Status().Update(ctx, fresh)
 }

--- a/pkg/controller/billing/delivery.go
+++ b/pkg/controller/billing/delivery.go
@@ -7,7 +7,10 @@ import (
 
 	vshnv1 "github.com/vshn/appcat/v4/apis/vshn/v1"
 	"github.com/vshn/appcat/v4/pkg/odoo"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // processQueue delivers at most one event per call with priority: resend, failed, pending deletes, any pending.
@@ -54,12 +57,41 @@ func (b *BillingHandler) deliverQueuedEvent(ctx context.Context, billingService 
 		return false, err
 	}
 
-	event.State = string(BillingEventStateSent)
-	billingService.Status.Events[idx] = event
-	if err := b.Status().Update(ctx, billingService); err != nil {
+	var fresh *vshnv1.BillingService
+	if err := retry.OnError(retry.DefaultRetry, isTransientAPIError, func() error {
+		var err error
+		fresh, err = b.persistEventSent(ctx, billingService, event)
+		return err
+	}); err != nil {
 		return true, err
 	}
+	*billingService = *fresh
 	return true, nil
+}
+
+// persistEventSent re-fetches billingService from the cluster, marks the event matching
+// event.InstanceID as sent, and persists the status. Returns the updated object on success.
+func (b *BillingHandler) persistEventSent(ctx context.Context, billingService *vshnv1.BillingService, event vshnv1.BillingEventStatus) (*vshnv1.BillingService, error) {
+	fresh := &vshnv1.BillingService{}
+	if err := b.Get(ctx, client.ObjectKeyFromObject(billingService), fresh); err != nil {
+		return nil, err
+	}
+	for i, e := range fresh.Status.Events {
+		if e.InstanceID == event.InstanceID && e.Type == event.Type && e.Timestamp.Time.Equal(event.Timestamp.Time) {
+			fresh.Status.Events[i].State = string(BillingEventStateSent)
+			fresh.Status.Events[i].LastAttemptTime = event.LastAttemptTime
+			break
+		}
+	}
+	return fresh, b.Status().Update(ctx, fresh)
+}
+
+// isTransientAPIError returns true for transient k8s API errors that are safe to retry.
+func isTransientAPIError(err error) bool {
+	return apierrors.IsConflict(err) ||
+		apierrors.IsServerTimeout(err) ||
+		apierrors.IsTooManyRequests(err) ||
+		apierrors.IsServiceUnavailable(err)
 }
 
 func (b *BillingHandler) sendEventToOdoo(ctx context.Context, billingService *vshnv1.BillingService, event vshnv1.BillingEventStatus) error {

--- a/pkg/controller/billing/events.go
+++ b/pkg/controller/billing/events.go
@@ -7,9 +7,8 @@ import (
 )
 
 type findEventOpts struct {
-	States    []BillingEventState
-	Type      *BillingEventType
-	ProductID *string
+	States []BillingEventState
+	Type   *BillingEventType
 }
 
 // enqueueEvent prepends a billing event to the list and updates the BillingService status.
@@ -32,32 +31,31 @@ func enqueueEvent(ctx context.Context, b *BillingHandler, billingService *vshnv1
 // pruneEventsIfNeeded removes oldest sent events per product when limit exceeded
 // maxEvents applies globally to all products (same limit for each product)
 func pruneEventsIfNeeded(billingService *vshnv1.BillingService, maxEvents int) int {
-	// Count events per product
-	eventCountPerProduct := make(map[string]int)
+	// Count events per instance
+	eventCountPerInstance := make(map[string]int)
 	for _, event := range billingService.Status.Events {
-		eventCountPerProduct[event.ProductID]++
+		eventCountPerInstance[event.InstanceID]++
 	}
 
-	// Build pruning list per product
+	// Build pruning list per instance
 	eventsToRemove := make(map[int]bool)
 	totalPruned := 0
 
-	// Prune events for ALL products (including removed ones)
-	// This prevents unbounded growth of events for products that were removed from spec
-	for productID := range eventCountPerProduct {
-		currentCount := eventCountPerProduct[productID]
+	// Prune events for ALL instances (including removed ones)
+	// This prevents unbounded growth of events for instances that were removed from spec
+	for instanceID := range eventCountPerInstance {
+		currentCount := eventCountPerInstance[instanceID]
 		if currentCount <= maxEvents {
-			continue // no pruning needed for this product
+			continue // no pruning needed for this instance
 		}
 
 		toPrune := currentCount - maxEvents
 
-		// Find oldest sent events for this product
-		// Only prune events with status "sent"
+		// Find oldest sent events for this instance — only sent events are prunable
 		prunableIndices := []int{}
 		for i := len(billingService.Status.Events) - 1; i >= 0; i-- {
 			event := billingService.Status.Events[i]
-			if event.ProductID != productID {
+			if event.InstanceID != instanceID {
 				continue
 			}
 			if event.State == string(BillingEventStateSent) {
@@ -65,7 +63,6 @@ func pruneEventsIfNeeded(billingService *vshnv1.BillingService, maxEvents int) i
 			}
 		}
 
-		// Prune oldest events for this product
 		pruneCount := toPrune
 		if pruneCount > len(prunableIndices) {
 			pruneCount = len(prunableIndices)
@@ -116,44 +113,12 @@ func findEvent(billingService *vshnv1.BillingService, opts findEventOpts) (int, 
 		if opts.Type != nil && event.Type != string(*opts.Type) {
 			continue
 		}
-		if opts.ProductID != nil && event.ProductID != *opts.ProductID {
-			continue
-		}
 		return i, event, true
 	}
 	return -1, vshnv1.BillingEventStatus{}, false
 }
 
-// hasSentEvent returns true if there is a sent event of the given type optionally filtered by productID and value.
-func hasSentEvent(billingService *vshnv1.BillingService, eventType BillingEventType, productID string, value string) bool {
-	for _, event := range billingService.Status.Events {
-		if event.Type != string(eventType) || event.State != string(BillingEventStateSent) {
-			continue
-		}
-		if productID != "" && event.ProductID != productID {
-			continue
-		}
-		if value != "" && event.Value != value {
-			continue
-		}
-		return true
-	}
-	return false
-}
-
-// hasEvent returns true if an event exists for the given productID.
-func hasEvent(billingService *vshnv1.BillingService, eventType BillingEventType, productID string) bool {
-	for _, event := range billingService.Status.Events {
-		if event.Type == string(eventType) && event.ProductID == productID {
-			return true
-		}
-	}
-	return false
-}
-
 // hasEventByInstanceID returns true if an event of the given type exists for the given instanceID.
-// Use this instead of hasEvent when multiple items can share the same productID (e.g. Servala
-// deployments that bill two storage volumes under the same productID but distinct descriptions).
 func hasEventByInstanceID(billingService *vshnv1.BillingService, eventType BillingEventType, instanceID string) bool {
 	for _, event := range billingService.Status.Events {
 		if event.Type == string(eventType) && event.InstanceID == instanceID {
@@ -163,95 +128,23 @@ func hasEventByInstanceID(billingService *vshnv1.BillingService, eventType Billi
 	return false
 }
 
-// hasEventWithValue returns true if an event of type t exists for (productID,value) (any state).
-func hasEventWithValue(billingService *vshnv1.BillingService, eventType BillingEventType, productID, value string) bool {
+// hasEventWithValueByInstanceID returns true if an event of type t exists for (instanceID,value) (any state).
+func hasEventWithValueByInstanceID(billingService *vshnv1.BillingService, eventType BillingEventType, instanceID, value string) bool {
 	for _, event := range billingService.Status.Events {
-		if event.Type == string(eventType) && event.ProductID == productID && event.Value == value {
+		if event.Type == string(eventType) && event.InstanceID == instanceID && event.Value == value {
 			return true
 		}
 	}
 	return false
 }
 
-// hasOpenCreated returns true if there is a created for productID that is not superseded.
-func hasOpenCreated(billingService *vshnv1.BillingService, productID string) bool {
-	for _, event := range billingService.Status.Events {
-		if event.Type == string(BillingEventTypeCreated) && event.ProductID == productID && event.State != string(BillingEventStateSuperseded) {
-			return true
-		}
-	}
-	return false
-}
-
-// lastActiveSentProduct returns the most recent sent created event that has not been superseded.
-func lastActiveSentProduct(billingService *vshnv1.BillingService) (productID string, value string, ok bool) {
-	deleted := map[string]struct{}{}
-
+// lastSentValueForInstanceID returns the value from the most recent SENT created/scaled for instanceID.
+func lastSentValueForInstanceID(billingService *vshnv1.BillingService, instanceID string) (string, bool) {
 	for _, event := range billingService.Status.Events {
 		if event.State != string(BillingEventStateSent) {
 			continue
 		}
-		if event.Type == string(BillingEventTypeDeleted) {
-			deleted[event.ProductID] = struct{}{}
-			continue
-		}
-		if event.Type == string(BillingEventTypeCreated) {
-			if _, seen := deleted[event.ProductID]; !seen {
-				return event.ProductID, event.Value, true
-			}
-		}
-	}
-	return "", "", false
-}
-
-// supersedeCreatedForSLA marks obsolete created events as superseded.
-func supersedeCreatedForSLA(billingService *vshnv1.BillingService, currentProductID string) bool {
-	changed := false
-	keptCurrent := false
-
-	for i := range billingService.Status.Events {
-		event := billingService.Status.Events[i]
-		if event.Type != string(BillingEventTypeCreated) {
-			continue
-		}
-		if event.State == string(BillingEventStateSent) || event.State == string(BillingEventStateSuperseded) {
-			continue
-		}
-
-		if event.ProductID != currentProductID {
-			event.State = string(BillingEventStateSuperseded)
-			billingService.Status.Events[i] = event
-			changed = true
-			continue
-		}
-
-		// current product, keep only the newest open created
-		if keptCurrent {
-			event.State = string(BillingEventStateSuperseded)
-			billingService.Status.Events[i] = event
-			changed = true
-			continue
-		}
-		keptCurrent = true
-	}
-	return changed
-}
-
-// lastObservedValueForProduct returns last sent value for productID or fallback if none found.
-func lastObservedValueForProduct(billingService *vshnv1.BillingService, productID string, fallback string) string {
-	if value, ok := lastSentValueForProduct(billingService, productID); ok {
-		return value
-	}
-	return fallback
-}
-
-// lastSentValueForProduct returns the value from the most recent SENT created/scaled for productID.
-func lastSentValueForProduct(billingService *vshnv1.BillingService, productID string) (string, bool) {
-	for _, event := range billingService.Status.Events {
-		if event.State != string(BillingEventStateSent) {
-			continue
-		}
-		if event.ProductID != productID {
+		if event.InstanceID != instanceID {
 			continue
 		}
 		if event.Type == string(BillingEventTypeScaled) || event.Type == string(BillingEventTypeCreated) {
@@ -259,6 +152,14 @@ func lastSentValueForProduct(billingService *vshnv1.BillingService, productID st
 		}
 	}
 	return "", false
+}
+
+// lastObservedValueForInstanceID returns last sent value for instanceID or fallback if none found.
+func lastObservedValueForInstanceID(billingService *vshnv1.BillingService, instanceID string, fallback string) string {
+	if value, ok := lastSentValueForInstanceID(billingService, instanceID); ok {
+		return value
+	}
+	return fallback
 }
 
 // hasBacklog returns true if there are any events not in sent or superseded.

--- a/pkg/controller/billing/events_test.go
+++ b/pkg/controller/billing/events_test.go
@@ -133,7 +133,7 @@ func TestPruneEventsIfNeeded(t *testing.T) {
 			expectedRemaining: 2,
 		},
 		{
-			name: "does not prune pending events",
+			name: "prunes sent events but preserves pending events",
 			billingService: &vshnv1.BillingService{
 				Status: vshnv1.BillingServiceStatus{
 					Events: []vshnv1.BillingEventStatus{

--- a/pkg/controller/billing/events_test.go
+++ b/pkg/controller/billing/events_test.go
@@ -8,415 +8,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestHasEvent(t *testing.T) {
-	tests := []struct {
-		name           string
-		billingService *vshnv1.BillingService
-		eventType      BillingEventType
-		productID      string
-		expected       bool
-	}{
-		{
-			name: "returns true when event exists",
-			billingService: &vshnv1.BillingService{
-				Status: vshnv1.BillingServiceStatus{
-					Events: []vshnv1.BillingEventStatus{
-						{
-							Type:      string(BillingEventTypeCreated),
-							ProductID: "prod-123",
-							State:     string(BillingEventStatePending),
-						},
-					},
-				},
-			},
-			eventType: BillingEventTypeCreated,
-			productID: "prod-123",
-			expected:  true,
-		},
-		{
-			name: "returns false when event does not exist",
-			billingService: &vshnv1.BillingService{
-				Status: vshnv1.BillingServiceStatus{
-					Events: []vshnv1.BillingEventStatus{
-						{
-							Type:      string(BillingEventTypeCreated),
-							ProductID: "prod-123",
-							State:     string(BillingEventStatePending),
-						},
-					},
-				},
-			},
-			eventType: BillingEventTypeDeleted,
-			productID: "prod-123",
-			expected:  false,
-		},
-		{
-			name: "returns false for different productID",
-			billingService: &vshnv1.BillingService{
-				Status: vshnv1.BillingServiceStatus{
-					Events: []vshnv1.BillingEventStatus{
-						{
-							Type:      string(BillingEventTypeCreated),
-							ProductID: "prod-123",
-							State:     string(BillingEventStatePending),
-						},
-					},
-				},
-			},
-			eventType: BillingEventTypeCreated,
-			productID: "prod-456",
-			expected:  false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := hasEvent(tt.billingService, tt.eventType, tt.productID)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
-}
-
-func TestHasSentEvent(t *testing.T) {
-	tests := []struct {
-		name           string
-		billingService *vshnv1.BillingService
-		eventType      BillingEventType
-		productID      string
-		value          string
-		expected       bool
-	}{
-		{
-			name: "returns true for sent event",
-			billingService: &vshnv1.BillingService{
-				Status: vshnv1.BillingServiceStatus{
-					Events: []vshnv1.BillingEventStatus{
-						{
-							Type:      string(BillingEventTypeCreated),
-							ProductID: "prod-123",
-							Value:     "2",
-							State:     string(BillingEventStateSent),
-						},
-					},
-				},
-			},
-			eventType: BillingEventTypeCreated,
-			productID: "prod-123",
-			value:     "2",
-			expected:  true,
-		},
-		{
-			name: "returns false for pending event",
-			billingService: &vshnv1.BillingService{
-				Status: vshnv1.BillingServiceStatus{
-					Events: []vshnv1.BillingEventStatus{
-						{
-							Type:      string(BillingEventTypeCreated),
-							ProductID: "prod-123",
-							Value:     "2",
-							State:     string(BillingEventStatePending),
-						},
-					},
-				},
-			},
-			eventType: BillingEventTypeCreated,
-			productID: "prod-123",
-			value:     "2",
-			expected:  false,
-		},
-		{
-			name: "returns false for different value",
-			billingService: &vshnv1.BillingService{
-				Status: vshnv1.BillingServiceStatus{
-					Events: []vshnv1.BillingEventStatus{
-						{
-							Type:      string(BillingEventTypeCreated),
-							ProductID: "prod-123",
-							Value:     "2",
-							State:     string(BillingEventStateSent),
-						},
-					},
-				},
-			},
-			eventType: BillingEventTypeCreated,
-			productID: "prod-123",
-			value:     "3",
-			expected:  false,
-		},
-		{
-			name: "works with empty productID filter",
-			billingService: &vshnv1.BillingService{
-				Status: vshnv1.BillingServiceStatus{
-					Events: []vshnv1.BillingEventStatus{
-						{
-							Type:      string(BillingEventTypeCreated),
-							ProductID: "prod-123",
-							Value:     "2",
-							State:     string(BillingEventStateSent),
-						},
-					},
-				},
-			},
-			eventType: BillingEventTypeCreated,
-			productID: "",
-			value:     "",
-			expected:  true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := hasSentEvent(tt.billingService, tt.eventType, tt.productID, tt.value)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
-}
-
-func TestHasEventWithValue(t *testing.T) {
-	tests := []struct {
-		name           string
-		billingService *vshnv1.BillingService
-		eventType      BillingEventType
-		productID      string
-		value          string
-		expected       bool
-	}{
-		{
-			name: "returns true for matching event",
-			billingService: &vshnv1.BillingService{
-				Status: vshnv1.BillingServiceStatus{
-					Events: []vshnv1.BillingEventStatus{
-						{
-							Type:      string(BillingEventTypeScaled),
-							ProductID: "prod-123",
-							Value:     "5",
-							State:     string(BillingEventStatePending),
-						},
-					},
-				},
-			},
-			eventType: BillingEventTypeScaled,
-			productID: "prod-123",
-			value:     "5",
-			expected:  true,
-		},
-		{
-			name: "returns false for different value",
-			billingService: &vshnv1.BillingService{
-				Status: vshnv1.BillingServiceStatus{
-					Events: []vshnv1.BillingEventStatus{
-						{
-							Type:      string(BillingEventTypeScaled),
-							ProductID: "prod-123",
-							Value:     "5",
-							State:     string(BillingEventStatePending),
-						},
-					},
-				},
-			},
-			eventType: BillingEventTypeScaled,
-			productID: "prod-123",
-			value:     "3",
-			expected:  false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := hasEventWithValue(tt.billingService, tt.eventType, tt.productID, tt.value)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
-}
-
-func TestLastSentValueForProduct(t *testing.T) {
-	tests := []struct {
-		name           string
-		billingService *vshnv1.BillingService
-		productID      string
-		expectedValue  string
-		expectedOk     bool
-	}{
-		{
-			name: "returns value from sent created event",
-			billingService: &vshnv1.BillingService{
-				Status: vshnv1.BillingServiceStatus{
-					Events: []vshnv1.BillingEventStatus{
-						{
-							Type:      string(BillingEventTypeCreated),
-							ProductID: "prod-123",
-							Value:     "2",
-							State:     string(BillingEventStateSent),
-						},
-					},
-				},
-			},
-			productID:     "prod-123",
-			expectedValue: "2",
-			expectedOk:    true,
-		},
-		{
-			name: "returns value from most recent sent scaled event",
-			billingService: &vshnv1.BillingService{
-				Status: vshnv1.BillingServiceStatus{
-					Events: []vshnv1.BillingEventStatus{
-						{
-							Type:      string(BillingEventTypeScaled),
-							ProductID: "prod-123",
-							Value:     "5",
-							State:     string(BillingEventStateSent),
-						},
-						{
-							Type:      string(BillingEventTypeCreated),
-							ProductID: "prod-123",
-							Value:     "2",
-							State:     string(BillingEventStateSent),
-						},
-					},
-				},
-			},
-			productID:     "prod-123",
-			expectedValue: "5",
-			expectedOk:    true,
-		},
-		{
-			name: "returns false when no sent event exists",
-			billingService: &vshnv1.BillingService{
-				Status: vshnv1.BillingServiceStatus{
-					Events: []vshnv1.BillingEventStatus{
-						{
-							Type:      string(BillingEventTypeCreated),
-							ProductID: "prod-123",
-							Value:     "2",
-							State:     string(BillingEventStatePending),
-						},
-					},
-				},
-			},
-			productID:     "prod-123",
-			expectedValue: "",
-			expectedOk:    false,
-		},
-		{
-			name: "returns false for non-existent product",
-			billingService: &vshnv1.BillingService{
-				Status: vshnv1.BillingServiceStatus{
-					Events: []vshnv1.BillingEventStatus{
-						{
-							Type:      string(BillingEventTypeCreated),
-							ProductID: "prod-123",
-							Value:     "2",
-							State:     string(BillingEventStateSent),
-						},
-					},
-				},
-			},
-			productID:     "prod-456",
-			expectedValue: "",
-			expectedOk:    false,
-		},
-		{
-			name: "ignores delete events",
-			billingService: &vshnv1.BillingService{
-				Status: vshnv1.BillingServiceStatus{
-					Events: []vshnv1.BillingEventStatus{
-						{
-							Type:      string(BillingEventTypeDeleted),
-							ProductID: "prod-123",
-							Value:     "5",
-							State:     string(BillingEventStateSent),
-						},
-						{
-							Type:      string(BillingEventTypeCreated),
-							ProductID: "prod-123",
-							Value:     "2",
-							State:     string(BillingEventStateSent),
-						},
-					},
-				},
-			},
-			productID:     "prod-123",
-			expectedValue: "2",
-			expectedOk:    true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			value, ok := lastSentValueForProduct(tt.billingService, tt.productID)
-			assert.Equal(t, tt.expectedOk, ok)
-			if tt.expectedOk {
-				assert.Equal(t, tt.expectedValue, value)
-			}
-		})
-	}
-}
-
-func TestHasOpenCreated(t *testing.T) {
-	tests := []struct {
-		name           string
-		billingService *vshnv1.BillingService
-		productID      string
-		expected       bool
-	}{
-		{
-			name: "returns true for non-superseded created event",
-			billingService: &vshnv1.BillingService{
-				Status: vshnv1.BillingServiceStatus{
-					Events: []vshnv1.BillingEventStatus{
-						{
-							Type:      string(BillingEventTypeCreated),
-							ProductID: "prod-123",
-							State:     string(BillingEventStatePending),
-						},
-					},
-				},
-			},
-			productID: "prod-123",
-			expected:  true,
-		},
-		{
-			name: "returns false for superseded created event",
-			billingService: &vshnv1.BillingService{
-				Status: vshnv1.BillingServiceStatus{
-					Events: []vshnv1.BillingEventStatus{
-						{
-							Type:      string(BillingEventTypeCreated),
-							ProductID: "prod-123",
-							State:     string(BillingEventStateSuperseded),
-						},
-					},
-				},
-			},
-			productID: "prod-123",
-			expected:  false,
-		},
-		{
-			name: "returns false when no created event exists",
-			billingService: &vshnv1.BillingService{
-				Status: vshnv1.BillingServiceStatus{
-					Events: []vshnv1.BillingEventStatus{
-						{
-							Type:      string(BillingEventTypeScaled),
-							ProductID: "prod-123",
-							State:     string(BillingEventStatePending),
-						},
-					},
-				},
-			},
-			productID: "prod-123",
-			expected:  false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := hasOpenCreated(tt.billingService, tt.productID)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
-}
-
 func TestHasBacklog(t *testing.T) {
 	tests := []struct {
 		name           string
@@ -516,10 +107,10 @@ func TestPruneEventsIfNeeded(t *testing.T) {
 			billingService: &vshnv1.BillingService{
 				Status: vshnv1.BillingServiceStatus{
 					Events: []vshnv1.BillingEventStatus{
-						{Type: string(BillingEventTypeScaled), ProductID: "prod-123", Value: "5", State: string(BillingEventStateSent), Timestamp: metav1.Now()},
-						{Type: string(BillingEventTypeScaled), ProductID: "prod-123", Value: "4", State: string(BillingEventStateSent), Timestamp: metav1.Now()},
-						{Type: string(BillingEventTypeScaled), ProductID: "prod-123", Value: "3", State: string(BillingEventStateSent), Timestamp: metav1.Now()},
-						{Type: string(BillingEventTypeCreated), ProductID: "prod-123", Value: "2", State: string(BillingEventStateSent), Timestamp: metav1.Now()},
+						{Type: string(BillingEventTypeScaled), ProductID: "prod-123", InstanceID: "inst-123", Value: "5", State: string(BillingEventStateSent), Timestamp: metav1.Now()},
+						{Type: string(BillingEventTypeScaled), ProductID: "prod-123", InstanceID: "inst-123", Value: "4", State: string(BillingEventStateSent), Timestamp: metav1.Now()},
+						{Type: string(BillingEventTypeScaled), ProductID: "prod-123", InstanceID: "inst-123", Value: "3", State: string(BillingEventStateSent), Timestamp: metav1.Now()},
+						{Type: string(BillingEventTypeCreated), ProductID: "prod-123", InstanceID: "inst-123", Value: "2", State: string(BillingEventStateSent), Timestamp: metav1.Now()},
 					},
 				},
 			},
@@ -532,8 +123,8 @@ func TestPruneEventsIfNeeded(t *testing.T) {
 			billingService: &vshnv1.BillingService{
 				Status: vshnv1.BillingServiceStatus{
 					Events: []vshnv1.BillingEventStatus{
-						{Type: string(BillingEventTypeCreated), ProductID: "prod-123", Value: "2", State: string(BillingEventStateSent)},
-						{Type: string(BillingEventTypeCreated), ProductID: "prod-456", Value: "50Gi", State: string(BillingEventStateSent)},
+						{Type: string(BillingEventTypeCreated), ProductID: "prod-123", InstanceID: "inst-123", Value: "2", State: string(BillingEventStateSent)},
+						{Type: string(BillingEventTypeCreated), ProductID: "prod-456", InstanceID: "inst-456", Value: "50Gi", State: string(BillingEventStateSent)},
 					},
 				},
 			},
@@ -546,10 +137,10 @@ func TestPruneEventsIfNeeded(t *testing.T) {
 			billingService: &vshnv1.BillingService{
 				Status: vshnv1.BillingServiceStatus{
 					Events: []vshnv1.BillingEventStatus{
-						{Type: string(BillingEventTypeScaled), ProductID: "prod-123", Value: "5", State: string(BillingEventStatePending), Timestamp: metav1.Now()},
-						{Type: string(BillingEventTypeScaled), ProductID: "prod-123", Value: "4", State: string(BillingEventStateSent), Timestamp: metav1.Now()},
-						{Type: string(BillingEventTypeScaled), ProductID: "prod-123", Value: "3", State: string(BillingEventStateSent), Timestamp: metav1.Now()},
-						{Type: string(BillingEventTypeCreated), ProductID: "prod-123", Value: "2", State: string(BillingEventStateSent), Timestamp: metav1.Now()},
+						{Type: string(BillingEventTypeScaled), ProductID: "prod-123", InstanceID: "inst-123", Value: "5", State: string(BillingEventStatePending), Timestamp: metav1.Now()},
+						{Type: string(BillingEventTypeScaled), ProductID: "prod-123", InstanceID: "inst-123", Value: "4", State: string(BillingEventStateSent), Timestamp: metav1.Now()},
+						{Type: string(BillingEventTypeScaled), ProductID: "prod-123", InstanceID: "inst-123", Value: "3", State: string(BillingEventStateSent), Timestamp: metav1.Now()},
+						{Type: string(BillingEventTypeCreated), ProductID: "prod-123", InstanceID: "inst-123", Value: "2", State: string(BillingEventStateSent), Timestamp: metav1.Now()},
 					},
 				},
 			},
@@ -559,14 +150,14 @@ func TestPruneEventsIfNeeded(t *testing.T) {
 			checkRemainingState: true,
 		},
 		{
-			name: "prunes per-product independently",
+			name: "prunes per-instance independently",
 			billingService: &vshnv1.BillingService{
 				Status: vshnv1.BillingServiceStatus{
 					Events: []vshnv1.BillingEventStatus{
-						{Type: string(BillingEventTypeScaled), ProductID: "prod-123", Value: "5", State: string(BillingEventStateSent)},
-						{Type: string(BillingEventTypeCreated), ProductID: "prod-123", Value: "2", State: string(BillingEventStateSent)},
-						{Type: string(BillingEventTypeScaled), ProductID: "prod-456", Value: "100Gi", State: string(BillingEventStateSent)},
-						{Type: string(BillingEventTypeCreated), ProductID: "prod-456", Value: "50Gi", State: string(BillingEventStateSent)},
+						{Type: string(BillingEventTypeScaled), ProductID: "prod-123", InstanceID: "inst-123", Value: "5", State: string(BillingEventStateSent)},
+						{Type: string(BillingEventTypeCreated), ProductID: "prod-123", InstanceID: "inst-123", Value: "2", State: string(BillingEventStateSent)},
+						{Type: string(BillingEventTypeScaled), ProductID: "prod-456", InstanceID: "inst-456", Value: "100Gi", State: string(BillingEventStateSent)},
+						{Type: string(BillingEventTypeCreated), ProductID: "prod-456", InstanceID: "inst-456", Value: "50Gi", State: string(BillingEventStateSent)},
 					},
 				},
 			},

--- a/pkg/controller/billing/remove.go
+++ b/pkg/controller/billing/remove.go
@@ -14,52 +14,49 @@ func (b *BillingHandler) handleRemovedItems(ctx context.Context, billingService 
 		currentInstances[item.InstanceID] = true
 	}
 
-	// Single pass through events (newest-first order), keyed by instanceID
-	type eventInfo struct {
-		productID, value, itemDesc, itemGroupDesc string
-	}
+	// Single pass through events (newest-first order) to find the most recent sent
+	// created/scaled event per instanceID. Using sent events as the source of truth
+	// ensures we also catch instances whose create event was pruned but scale events remain.
+	lastSent := make(map[string]vshnv1.ItemSpec)
 	createdInstances := make(map[string]bool)
-	lastSent := make(map[string]eventInfo)
-
 	for _, event := range billingService.Status.Events {
-		if event.Type == string(BillingEventTypeCreated) &&
-			event.State != string(BillingEventStateSuperseded) {
+		if event.Type == string(BillingEventTypeCreated) && event.State != string(BillingEventStateSuperseded) {
 			createdInstances[event.InstanceID] = true
 		}
-
-		// Capture from first (most recent) sent created/scaled event per instanceID
 		if _, seen := lastSent[event.InstanceID]; !seen &&
 			event.State == string(BillingEventStateSent) &&
 			(event.Type == string(BillingEventTypeCreated) || event.Type == string(BillingEventTypeScaled)) {
-			lastSent[event.InstanceID] = eventInfo{
-				productID:     event.ProductID,
-				value:         event.Value,
-				itemDesc:      event.ItemDescription,
-				itemGroupDesc: event.ItemGroupDescription,
+			lastSent[event.InstanceID] = vshnv1.ItemSpec{
+				ProductID:            event.ProductID,
+				InstanceID:           event.InstanceID,
+				Value:                event.Value,
+				ItemDescription:      event.ItemDescription,
+				ItemGroupDescription: event.ItemGroupDescription,
 			}
 		}
 	}
 
 	for instanceID := range createdInstances {
-		if currentInstances[instanceID] || hasEventByInstanceID(billingService, BillingEventTypeDeleted, instanceID) {
-			continue
+		if !currentInstances[instanceID] && !hasEventByInstanceID(billingService, BillingEventTypeDeleted, instanceID) {
+			if _, sent := lastSent[instanceID]; !sent {
+				b.log.Info("Skipping delete event for instance never sent to Odoo",
+					"instanceID", instanceID,
+					"billingService", billingService.Name)
+			}
 		}
+	}
 
-		info, ok := lastSent[instanceID]
-		if !ok {
-			// Never sent to Odoo — nothing to delete
-			b.log.Info("Skipping delete event for instance never sent to Odoo",
-				"instanceID", instanceID,
-				"billingService", billingService.Name)
+	for instanceID, info := range lastSent {
+		if currentInstances[instanceID] || hasEventByInstanceID(billingService, BillingEventTypeDeleted, instanceID) {
 			continue
 		}
 		delEvent := vshnv1.BillingEventStatus{
 			Type:                 string(BillingEventTypeDeleted),
-			ProductID:            info.productID,
+			ProductID:            info.ProductID,
 			InstanceID:           instanceID,
-			Value:                info.value,
-			ItemDescription:      info.itemDesc,
-			ItemGroupDescription: info.itemGroupDesc,
+			Value:                info.Value,
+			ItemDescription:      info.ItemDescription,
+			ItemGroupDescription: info.ItemGroupDescription,
 			Timestamp:            metav1.Now(),
 			State:                string(BillingEventStatePending),
 			RetryCount:           0,

--- a/pkg/controller/billing/remove.go
+++ b/pkg/controller/billing/remove.go
@@ -9,54 +9,54 @@ import (
 
 // handleRemovedItems detects items removed from spec and enqueues delete events
 func (b *BillingHandler) handleRemovedItems(ctx context.Context, billingService *vshnv1.BillingService) error {
-	currentProducts := make(map[string]bool)
+	currentInstances := make(map[string]bool)
 	for _, item := range billingService.Spec.Odoo.Items {
-		currentProducts[item.ProductID] = true
+		currentInstances[item.InstanceID] = true
 	}
 
-	// Single pass through events (newest-first order)
+	// Single pass through events (newest-first order), keyed by instanceID
 	type eventInfo struct {
-		value, itemDesc, itemGroupDesc, instanceID string
+		productID, value, itemDesc, itemGroupDesc string
 	}
-	createdProducts := make(map[string]bool)
+	createdInstances := make(map[string]bool)
 	lastSent := make(map[string]eventInfo)
 
 	for _, event := range billingService.Status.Events {
 		if event.Type == string(BillingEventTypeCreated) &&
 			event.State != string(BillingEventStateSuperseded) {
-			createdProducts[event.ProductID] = true
+			createdInstances[event.InstanceID] = true
 		}
 
-		// Capture from first (most recent) sent created/scaled event
-		if _, seen := lastSent[event.ProductID]; !seen &&
+		// Capture from first (most recent) sent created/scaled event per instanceID
+		if _, seen := lastSent[event.InstanceID]; !seen &&
 			event.State == string(BillingEventStateSent) &&
 			(event.Type == string(BillingEventTypeCreated) || event.Type == string(BillingEventTypeScaled)) {
-			lastSent[event.ProductID] = eventInfo{
+			lastSent[event.InstanceID] = eventInfo{
+				productID:     event.ProductID,
 				value:         event.Value,
 				itemDesc:      event.ItemDescription,
 				itemGroupDesc: event.ItemGroupDescription,
-				instanceID:    event.InstanceID,
 			}
 		}
 	}
 
-	for productID := range createdProducts {
-		if currentProducts[productID] || hasEvent(billingService, BillingEventTypeDeleted, productID) {
+	for instanceID := range createdInstances {
+		if currentInstances[instanceID] || hasEventByInstanceID(billingService, BillingEventTypeDeleted, instanceID) {
 			continue
 		}
 
-		info, ok := lastSent[productID]
+		info, ok := lastSent[instanceID]
 		if !ok {
 			// Never sent to Odoo — nothing to delete
-			b.log.Info("Skipping delete event for product never sent to Odoo",
-				"productID", productID,
+			b.log.Info("Skipping delete event for instance never sent to Odoo",
+				"instanceID", instanceID,
 				"billingService", billingService.Name)
 			continue
 		}
 		delEvent := vshnv1.BillingEventStatus{
 			Type:                 string(BillingEventTypeDeleted),
-			ProductID:            productID,
-			InstanceID:           info.instanceID,
+			ProductID:            info.productID,
+			InstanceID:           instanceID,
 			Value:                info.value,
 			ItemDescription:      info.itemDesc,
 			ItemGroupDescription: info.itemGroupDesc,

--- a/pkg/controller/billing/remove_test.go
+++ b/pkg/controller/billing/remove_test.go
@@ -19,8 +19,9 @@ func TestHandleRemovedItems(t *testing.T) {
 	tests := []struct {
 		name                 string
 		billingService       *vshnv1.BillingService
-		expectDeleteEvents   []string // productIDs that should have delete events
-		expectNoDeleteEvents []string // productIDs that should not have delete events
+		expectDeleteEvents   []string          // instanceIDs that should have delete events
+		expectNoDeleteEvents []string          // instanceIDs that should not have delete events
+		expectedDeleteValues map[string]string // instanceID → expected delete event Value
 	}{
 		{
 			name: "creates delete event for removed item",
@@ -60,8 +61,8 @@ func TestHandleRemovedItems(t *testing.T) {
 					},
 				},
 			},
-			expectDeleteEvents:   []string{"prod-456"},
-			expectNoDeleteEvents: []string{"prod-123"},
+			expectDeleteEvents:   []string{"inst-456"},
+			expectNoDeleteEvents: []string{"inst-123"},
 		},
 		{
 			name: "does not create delete event when no items removed",
@@ -103,7 +104,7 @@ func TestHandleRemovedItems(t *testing.T) {
 				},
 			},
 			expectDeleteEvents:   []string{},
-			expectNoDeleteEvents: []string{"prod-123", "prod-456"},
+			expectNoDeleteEvents: []string{"inst-123", "inst-456"},
 		},
 		{
 			name: "creates delete events for multiple removed items",
@@ -152,8 +153,8 @@ func TestHandleRemovedItems(t *testing.T) {
 					},
 				},
 			},
-			expectDeleteEvents:   []string{"prod-456", "prod-789"},
-			expectNoDeleteEvents: []string{"prod-123"},
+			expectDeleteEvents:   []string{"inst-456", "inst-789"},
+			expectNoDeleteEvents: []string{"inst-123"},
 		},
 		{
 			name: "does not create duplicate delete event",
@@ -201,7 +202,7 @@ func TestHandleRemovedItems(t *testing.T) {
 				},
 			},
 			expectDeleteEvents:   []string{},
-			expectNoDeleteEvents: []string{"prod-123"},
+			expectNoDeleteEvents: []string{"inst-123"},
 		},
 		{
 			name: "ignores superseded created events",
@@ -242,7 +243,7 @@ func TestHandleRemovedItems(t *testing.T) {
 				},
 			},
 			expectDeleteEvents:   []string{},
-			expectNoDeleteEvents: []string{"prod-123", "prod-456"},
+			expectNoDeleteEvents: []string{"inst-123", "inst-456"},
 		},
 		{
 			name: "uses last sent value for delete event",
@@ -280,7 +281,59 @@ func TestHandleRemovedItems(t *testing.T) {
 					},
 				},
 			},
-			expectDeleteEvents: []string{"prod-123"},
+			expectDeleteEvents:   []string{"inst-123"},
+			expectedDeleteValues: map[string]string{"inst-123": "5"},
+		},
+		{
+			name: "creates delete event for instance with only scaled event (create was pruned)",
+			billingService: &vshnv1.BillingService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-service",
+					Namespace: "test-ns",
+				},
+				Spec: vshnv1.BillingServiceSpec{
+					Odoo: vshnv1.OdooSpec{
+						ServiceID: "test-instance",
+						Items:     []vshnv1.ItemSpec{},
+					},
+				},
+				Status: vshnv1.BillingServiceStatus{
+					Events: []vshnv1.BillingEventStatus{
+						// create event pruned; only scale event remains in status
+						{Type: string(BillingEventTypeScaled), ProductID: "prod-123", InstanceID: "inst-123", Value: "5", State: string(BillingEventStateSent)},
+					},
+				},
+			},
+			expectDeleteEvents:   []string{"inst-123"},
+			expectedDeleteValues: map[string]string{"inst-123": "5"},
+		},
+		{
+			name: "does not create delete event for pending-only create (never sent to Odoo)",
+			billingService: &vshnv1.BillingService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-service",
+					Namespace: "test-ns",
+				},
+				Spec: vshnv1.BillingServiceSpec{
+					Odoo: vshnv1.OdooSpec{
+						ServiceID: "test-instance",
+						Items:     []vshnv1.ItemSpec{},
+					},
+				},
+				Status: vshnv1.BillingServiceStatus{
+					Events: []vshnv1.BillingEventStatus{
+						{
+							Type:       string(BillingEventTypeCreated),
+							ProductID:  "prod-123",
+							InstanceID: "inst-123",
+							Value:      "2",
+							State:      string(BillingEventStatePending),
+						},
+					},
+				},
+			},
+			expectDeleteEvents:   []string{},
+			expectNoDeleteEvents: []string{"inst-123"},
 		},
 	}
 
@@ -302,37 +355,32 @@ func TestHandleRemovedItems(t *testing.T) {
 			err := handler.handleRemovedItems(context.Background(), tt.billingService)
 			require.NoError(t, err)
 
-			// Check for expected delete events
-			for _, productID := range tt.expectDeleteEvents {
+			// Check for expected delete events (keyed by instanceID)
+			for _, instanceID := range tt.expectDeleteEvents {
 				found := false
 				for _, event := range tt.billingService.Status.Events {
-					if event.Type == string(BillingEventTypeDeleted) && event.ProductID == productID {
+					if event.Type == string(BillingEventTypeDeleted) && event.InstanceID == instanceID {
 						found = true
 						assert.Equal(t, string(BillingEventStatePending), event.State)
-
-						// Special check for "uses last sent value for delete event" test
-						if tt.name == "uses last sent value for delete event" {
-							assert.Equal(t, "5", event.Value, "should use last sent scaled value")
-							assert.Equal(t, "Instance Item", event.ItemDescription, "should use last sent item description")
-							assert.Equal(t, "Instance Group", event.ItemGroupDescription, "should use last sent item group description")
+						if want, ok := tt.expectedDeleteValues[instanceID]; ok {
+							assert.Equal(t, want, event.Value, "delete value mismatch for instanceID %s", instanceID)
 						}
 						break
 					}
 				}
-				assert.True(t, found, "expected delete event for product %s", productID)
+				assert.True(t, found, "expected delete event for instanceID %s", instanceID)
 			}
 
-			// Check that no delete events exist for products that should not be deleted
-			for _, productID := range tt.expectNoDeleteEvents {
+			// Check that no delete events exist for instances that should not be deleted
+			for _, instanceID := range tt.expectNoDeleteEvents {
 				for _, event := range tt.billingService.Status.Events {
-					if event.Type == string(BillingEventTypeDeleted) && event.ProductID == productID {
-						t.Errorf("unexpected delete event for product %s", productID)
+					if event.Type == string(BillingEventTypeDeleted) && event.InstanceID == instanceID {
+						t.Errorf("unexpected delete event for instanceID %s", instanceID)
 					}
 				}
 			}
 
-			expectedEventCount := initialEventCount + len(tt.expectDeleteEvents)
-			assert.Equal(t, expectedEventCount, len(tt.billingService.Status.Events))
+			assert.Equal(t, initialEventCount+len(tt.expectDeleteEvents), len(tt.billingService.Status.Events))
 		})
 	}
 }

--- a/pkg/controller/billing/remove_test.go
+++ b/pkg/controller/billing/remove_test.go
@@ -33,7 +33,7 @@ func TestHandleRemovedItems(t *testing.T) {
 					Odoo: vshnv1.OdooSpec{
 						ServiceID: "test-instance",
 						Items: []vshnv1.ItemSpec{
-							{ProductID: "prod-123", Value: "2", ItemDescription: "Instance Item", ItemGroupDescription: "Instance Group"},
+							{ProductID: "prod-123", InstanceID: "inst-123", Value: "2", ItemDescription: "Instance Item", ItemGroupDescription: "Instance Group"},
 						},
 					},
 				},
@@ -42,6 +42,7 @@ func TestHandleRemovedItems(t *testing.T) {
 						{
 							Type:                 string(BillingEventTypeCreated),
 							ProductID:            "prod-123",
+							InstanceID:           "inst-123",
 							Value:                "2",
 							ItemDescription:      "Instance Item",
 							ItemGroupDescription: "Instance Group",
@@ -50,6 +51,7 @@ func TestHandleRemovedItems(t *testing.T) {
 						{
 							Type:                 string(BillingEventTypeCreated),
 							ProductID:            "prod-456",
+							InstanceID:           "inst-456",
 							Value:                "50Gi",
 							ItemDescription:      "Storage Item",
 							ItemGroupDescription: "Storage Group",
@@ -72,8 +74,8 @@ func TestHandleRemovedItems(t *testing.T) {
 					Odoo: vshnv1.OdooSpec{
 						ServiceID: "test-instance",
 						Items: []vshnv1.ItemSpec{
-							{ProductID: "prod-123", Value: "2", ItemDescription: "Instance Item", ItemGroupDescription: "Instance Group"},
-							{ProductID: "prod-456", Value: "50Gi", ItemDescription: "Storage Item", ItemGroupDescription: "Storage Group"},
+							{ProductID: "prod-123", InstanceID: "inst-123", Value: "2", ItemDescription: "Instance Item", ItemGroupDescription: "Instance Group"},
+							{ProductID: "prod-456", InstanceID: "inst-456", Value: "50Gi", ItemDescription: "Storage Item", ItemGroupDescription: "Storage Group"},
 						},
 					},
 				},
@@ -82,6 +84,7 @@ func TestHandleRemovedItems(t *testing.T) {
 						{
 							Type:                 string(BillingEventTypeCreated),
 							ProductID:            "prod-123",
+							InstanceID:           "inst-123",
 							Value:                "2",
 							ItemDescription:      "Instance Item",
 							ItemGroupDescription: "Instance Group",
@@ -90,6 +93,7 @@ func TestHandleRemovedItems(t *testing.T) {
 						{
 							Type:                 string(BillingEventTypeCreated),
 							ProductID:            "prod-456",
+							InstanceID:           "inst-456",
 							Value:                "50Gi",
 							ItemDescription:      "Storage Item",
 							ItemGroupDescription: "Storage Group",
@@ -112,7 +116,7 @@ func TestHandleRemovedItems(t *testing.T) {
 					Odoo: vshnv1.OdooSpec{
 						ServiceID: "test-instance",
 						Items: []vshnv1.ItemSpec{
-							{ProductID: "prod-123", Value: "2", ItemDescription: "Instance Item", ItemGroupDescription: "Instance Group"},
+							{ProductID: "prod-123", InstanceID: "inst-123", Value: "2", ItemDescription: "Instance Item", ItemGroupDescription: "Instance Group"},
 						},
 					},
 				},
@@ -121,6 +125,7 @@ func TestHandleRemovedItems(t *testing.T) {
 						{
 							Type:                 string(BillingEventTypeCreated),
 							ProductID:            "prod-123",
+							InstanceID:           "inst-123",
 							Value:                "2",
 							ItemDescription:      "Instance Item",
 							ItemGroupDescription: "Instance Group",
@@ -129,6 +134,7 @@ func TestHandleRemovedItems(t *testing.T) {
 						{
 							Type:                 string(BillingEventTypeCreated),
 							ProductID:            "prod-456",
+							InstanceID:           "inst-456",
 							Value:                "50Gi",
 							ItemDescription:      "Storage Item",
 							ItemGroupDescription: "Storage Group",
@@ -137,6 +143,7 @@ func TestHandleRemovedItems(t *testing.T) {
 						{
 							Type:                 string(BillingEventTypeCreated),
 							ProductID:            "prod-789",
+							InstanceID:           "inst-789",
 							Value:                "enabled",
 							ItemDescription:      "Boolean Item",
 							ItemGroupDescription: "Boolean Group",
@@ -159,21 +166,23 @@ func TestHandleRemovedItems(t *testing.T) {
 					Odoo: vshnv1.OdooSpec{
 						ServiceID: "test-instance",
 						Items: []vshnv1.ItemSpec{
-							{ProductID: "prod-123", Value: "2", ItemDescription: "Instance Item", ItemGroupDescription: "Instance Group"},
+							{ProductID: "prod-123", InstanceID: "inst-123", Value: "2", ItemDescription: "Instance Item", ItemGroupDescription: "Instance Group"},
 						},
 					},
 				},
 				Status: vshnv1.BillingServiceStatus{
 					Events: []vshnv1.BillingEventStatus{
 						{
-							Type:      string(BillingEventTypeDeleted),
-							ProductID: "prod-456",
-							Value:     "50Gi",
-							State:     string(BillingEventStatePending),
+							Type:       string(BillingEventTypeDeleted),
+							ProductID:  "prod-456",
+							InstanceID: "inst-456",
+							Value:      "50Gi",
+							State:      string(BillingEventStatePending),
 						},
 						{
 							Type:                 string(BillingEventTypeCreated),
 							ProductID:            "prod-123",
+							InstanceID:           "inst-123",
 							Value:                "2",
 							ItemDescription:      "Instance Item",
 							ItemGroupDescription: "Instance Group",
@@ -182,6 +191,7 @@ func TestHandleRemovedItems(t *testing.T) {
 						{
 							Type:                 string(BillingEventTypeCreated),
 							ProductID:            "prod-456",
+							InstanceID:           "inst-456",
 							Value:                "50Gi",
 							ItemDescription:      "Storage Item",
 							ItemGroupDescription: "Storage Group",
@@ -204,7 +214,7 @@ func TestHandleRemovedItems(t *testing.T) {
 					Odoo: vshnv1.OdooSpec{
 						ServiceID: "test-instance",
 						Items: []vshnv1.ItemSpec{
-							{ProductID: "prod-123", Value: "2", ItemDescription: "Instance Item", ItemGroupDescription: "Instance Group"},
+							{ProductID: "prod-123", InstanceID: "inst-123", Value: "2", ItemDescription: "Instance Item", ItemGroupDescription: "Instance Group"},
 						},
 					},
 				},
@@ -213,6 +223,7 @@ func TestHandleRemovedItems(t *testing.T) {
 						{
 							Type:                 string(BillingEventTypeCreated),
 							ProductID:            "prod-123",
+							InstanceID:           "inst-123",
 							Value:                "2",
 							ItemDescription:      "Instance Item",
 							ItemGroupDescription: "Instance Group",
@@ -221,6 +232,7 @@ func TestHandleRemovedItems(t *testing.T) {
 						{
 							Type:                 string(BillingEventTypeCreated),
 							ProductID:            "prod-456",
+							InstanceID:           "inst-456",
 							Value:                "50Gi",
 							ItemDescription:      "Storage Item",
 							ItemGroupDescription: "Storage Group",
@@ -250,6 +262,7 @@ func TestHandleRemovedItems(t *testing.T) {
 						{
 							Type:                 string(BillingEventTypeScaled),
 							ProductID:            "prod-123",
+							InstanceID:           "inst-123",
 							Value:                "5",
 							ItemDescription:      "Instance Item",
 							ItemGroupDescription: "Instance Group",
@@ -258,6 +271,7 @@ func TestHandleRemovedItems(t *testing.T) {
 						{
 							Type:                 string(BillingEventTypeCreated),
 							ProductID:            "prod-123",
+							InstanceID:           "inst-123",
 							Value:                "2",
 							ItemDescription:      "Instance Item",
 							ItemGroupDescription: "Instance Group",
@@ -343,6 +357,7 @@ func TestHandleRemovedItems_EmptySpec(t *testing.T) {
 				{
 					Type:                 string(BillingEventTypeCreated),
 					ProductID:            "prod-123",
+					InstanceID:           "inst-123",
 					Value:                "2",
 					ItemDescription:      "Instance Item",
 					ItemGroupDescription: "Instance Group",
@@ -351,6 +366,7 @@ func TestHandleRemovedItems_EmptySpec(t *testing.T) {
 				{
 					Type:                 string(BillingEventTypeCreated),
 					ProductID:            "prod-456",
+					InstanceID:           "inst-456",
 					Value:                "50Gi",
 					ItemDescription:      "Storage Item",
 					ItemGroupDescription: "Storage Group",
@@ -359,6 +375,7 @@ func TestHandleRemovedItems_EmptySpec(t *testing.T) {
 				{
 					Type:                 string(BillingEventTypeCreated),
 					ProductID:            "prod-789",
+					InstanceID:           "inst-789",
 					Value:                "enabled",
 					ItemDescription:      "Boolean Item",
 					ItemGroupDescription: "Boolean Group",

--- a/pkg/controller/billing/scale.go
+++ b/pkg/controller/billing/scale.go
@@ -9,11 +9,11 @@ import (
 
 // handleItemScaling enqueues a scaled event if the value changed from the last sent value.
 func (b *BillingHandler) handleItemScaling(ctx context.Context, billingService *vshnv1.BillingService, item vshnv1.ItemSpec) error {
-	lastValue, ok := lastSentValueForProduct(billingService, item.ProductID)
+	lastValue, ok := lastSentValueForInstanceID(billingService, item.InstanceID)
 	if !ok || lastValue == item.Value {
 		return nil
 	}
-	if hasEventWithValue(billingService, BillingEventTypeScaled, item.ProductID, item.Value) {
+	if hasEventWithValueByInstanceID(billingService, BillingEventTypeScaled, item.InstanceID, item.Value) {
 		return nil // already queued
 	}
 

--- a/pkg/controller/billing/scale_test.go
+++ b/pkg/controller/billing/scale_test.go
@@ -34,23 +34,25 @@ func TestHandleItemScaling(t *testing.T) {
 					Odoo: vshnv1.OdooSpec{
 						ServiceID: "test-instance",
 						Items: []vshnv1.ItemSpec{
-							{ProductID: "prod-123", Value: "3", ItemDescription: "Test Item", ItemGroupDescription: "Test Group"},
+							{ProductID: "prod-123", InstanceID: "inst-123", Value: "3", ItemDescription: "Test Item", ItemGroupDescription: "Test Group"},
 						},
 					},
 				},
 				Status: vshnv1.BillingServiceStatus{
 					Events: []vshnv1.BillingEventStatus{
 						{
-							Type:      string(BillingEventTypeCreated),
-							ProductID: "prod-123",
-							Value:     "1",
-							State:     string(BillingEventStateSent),
+							Type:       string(BillingEventTypeCreated),
+							ProductID:  "prod-123",
+							InstanceID: "inst-123",
+							Value:      "1",
+							State:      string(BillingEventStateSent),
 						},
 					},
 				},
 			},
 			item: vshnv1.ItemSpec{
 				ProductID:            "prod-123",
+				InstanceID:           "inst-123",
 				Value:                "3",
 				ItemDescription:      "Test Item",
 				ItemGroupDescription: "Test Group",
@@ -69,23 +71,25 @@ func TestHandleItemScaling(t *testing.T) {
 					Odoo: vshnv1.OdooSpec{
 						ServiceID: "test-instance",
 						Items: []vshnv1.ItemSpec{
-							{ProductID: "prod-123", Value: "2", ItemDescription: "Test Item", ItemGroupDescription: "Test Group"},
+							{ProductID: "prod-123", InstanceID: "inst-123", Value: "2", ItemDescription: "Test Item", ItemGroupDescription: "Test Group"},
 						},
 					},
 				},
 				Status: vshnv1.BillingServiceStatus{
 					Events: []vshnv1.BillingEventStatus{
 						{
-							Type:      string(BillingEventTypeCreated),
-							ProductID: "prod-123",
-							Value:     "2",
-							State:     string(BillingEventStateSent),
+							Type:       string(BillingEventTypeCreated),
+							ProductID:  "prod-123",
+							InstanceID: "inst-123",
+							Value:      "2",
+							State:      string(BillingEventStateSent),
 						},
 					},
 				},
 			},
 			item: vshnv1.ItemSpec{
 				ProductID:            "prod-123",
+				InstanceID:           "inst-123",
 				Value:                "2",
 				ItemDescription:      "Test Item",
 				ItemGroupDescription: "Test Group",
@@ -103,23 +107,25 @@ func TestHandleItemScaling(t *testing.T) {
 					Odoo: vshnv1.OdooSpec{
 						ServiceID: "test-instance",
 						Items: []vshnv1.ItemSpec{
-							{ProductID: "prod-123", Value: "3", ItemDescription: "Test Item", ItemGroupDescription: "Test Group"},
+							{ProductID: "prod-123", InstanceID: "inst-123", Value: "3", ItemDescription: "Test Item", ItemGroupDescription: "Test Group"},
 						},
 					},
 				},
 				Status: vshnv1.BillingServiceStatus{
 					Events: []vshnv1.BillingEventStatus{
 						{
-							Type:      string(BillingEventTypeCreated),
-							ProductID: "prod-123",
-							Value:     "1",
-							State:     string(BillingEventStatePending),
+							Type:       string(BillingEventTypeCreated),
+							ProductID:  "prod-123",
+							InstanceID: "inst-123",
+							Value:      "1",
+							State:      string(BillingEventStatePending),
 						},
 					},
 				},
 			},
 			item: vshnv1.ItemSpec{
 				ProductID:            "prod-123",
+				InstanceID:           "inst-123",
 				Value:                "3",
 				ItemDescription:      "Test Item",
 				ItemGroupDescription: "Test Group",
@@ -137,29 +143,32 @@ func TestHandleItemScaling(t *testing.T) {
 					Odoo: vshnv1.OdooSpec{
 						ServiceID: "test-instance",
 						Items: []vshnv1.ItemSpec{
-							{ProductID: "prod-123", Value: "3", ItemDescription: "Test Item", ItemGroupDescription: "Test Group"},
+							{ProductID: "prod-123", InstanceID: "inst-123", Value: "3", ItemDescription: "Test Item", ItemGroupDescription: "Test Group"},
 						},
 					},
 				},
 				Status: vshnv1.BillingServiceStatus{
 					Events: []vshnv1.BillingEventStatus{
 						{
-							Type:      string(BillingEventTypeScaled),
-							ProductID: "prod-123",
-							Value:     "3",
-							State:     string(BillingEventStatePending),
+							Type:       string(BillingEventTypeScaled),
+							ProductID:  "prod-123",
+							InstanceID: "inst-123",
+							Value:      "3",
+							State:      string(BillingEventStatePending),
 						},
 						{
-							Type:      string(BillingEventTypeCreated),
-							ProductID: "prod-123",
-							Value:     "1",
-							State:     string(BillingEventStateSent),
+							Type:       string(BillingEventTypeCreated),
+							ProductID:  "prod-123",
+							InstanceID: "inst-123",
+							Value:      "1",
+							State:      string(BillingEventStateSent),
 						},
 					},
 				},
 			},
 			item: vshnv1.ItemSpec{
 				ProductID:            "prod-123",
+				InstanceID:           "inst-123",
 				Value:                "3",
 				ItemDescription:      "Test Item",
 				ItemGroupDescription: "Test Group",
@@ -177,23 +186,25 @@ func TestHandleItemScaling(t *testing.T) {
 					Odoo: vshnv1.OdooSpec{
 						ServiceID: "test-instance",
 						Items: []vshnv1.ItemSpec{
-							{ProductID: "prod-storage", Value: "100Gi", ItemDescription: "Storage Item", ItemGroupDescription: "Storage Group"},
+							{ProductID: "prod-storage", InstanceID: "inst-storage", Value: "100Gi", ItemDescription: "Storage Item", ItemGroupDescription: "Storage Group"},
 						},
 					},
 				},
 				Status: vshnv1.BillingServiceStatus{
 					Events: []vshnv1.BillingEventStatus{
 						{
-							Type:      string(BillingEventTypeCreated),
-							ProductID: "prod-storage",
-							Value:     "50Gi",
-							State:     string(BillingEventStateSent),
+							Type:       string(BillingEventTypeCreated),
+							ProductID:  "prod-storage",
+							InstanceID: "inst-storage",
+							Value:      "50Gi",
+							State:      string(BillingEventStateSent),
 						},
 					},
 				},
 			},
 			item: vshnv1.ItemSpec{
 				ProductID:            "prod-storage",
+				InstanceID:           "inst-storage",
 				Value:                "100Gi",
 				ItemDescription:      "Storage Item",
 				ItemGroupDescription: "Storage Group",
@@ -252,31 +263,34 @@ func TestHandleItemScaling_MultipleItems(t *testing.T) {
 			Odoo: vshnv1.OdooSpec{
 				ServiceID: "test-instance",
 				Items: []vshnv1.ItemSpec{
-					{ProductID: "prod-compute", Value: "4", ItemDescription: "Compute Item", ItemGroupDescription: "Compute Group"},
-					{ProductID: "prod-storage", Value: "100Gi", ItemDescription: "Storage Item", ItemGroupDescription: "Storage Group"},
-					{ProductID: "prod-backup", Value: "enabled", ItemDescription: "Backup Item", ItemGroupDescription: "Backup Group"},
+					{ProductID: "prod-compute", InstanceID: "inst-compute", Value: "4", ItemDescription: "Compute Item", ItemGroupDescription: "Compute Group"},
+					{ProductID: "prod-storage", InstanceID: "inst-storage", Value: "100Gi", ItemDescription: "Storage Item", ItemGroupDescription: "Storage Group"},
+					{ProductID: "prod-backup", InstanceID: "inst-backup", Value: "enabled", ItemDescription: "Backup Item", ItemGroupDescription: "Backup Group"},
 				},
 			},
 		},
 		Status: vshnv1.BillingServiceStatus{
 			Events: []vshnv1.BillingEventStatus{
 				{
-					Type:      string(BillingEventTypeCreated),
-					ProductID: "prod-compute",
-					Value:     "2",
-					State:     string(BillingEventStateSent),
+					Type:       string(BillingEventTypeCreated),
+					ProductID:  "prod-compute",
+					InstanceID: "inst-compute",
+					Value:      "2",
+					State:      string(BillingEventStateSent),
 				},
 				{
-					Type:      string(BillingEventTypeCreated),
-					ProductID: "prod-storage",
-					Value:     "50Gi",
-					State:     string(BillingEventStateSent),
+					Type:       string(BillingEventTypeCreated),
+					ProductID:  "prod-storage",
+					InstanceID: "inst-storage",
+					Value:      "50Gi",
+					State:      string(BillingEventStateSent),
 				},
 				{
-					Type:      string(BillingEventTypeCreated),
-					ProductID: "prod-backup",
-					Value:     "enabled",
-					State:     string(BillingEventStateSent),
+					Type:       string(BillingEventTypeCreated),
+					ProductID:  "prod-backup",
+					InstanceID: "inst-backup",
+					Value:      "enabled",
+					State:      string(BillingEventStateSent),
 				},
 			},
 		},


### PR DESCRIPTION
  ## Summary

  - Replace productID-keyed event lookups with instanceID across all billing handlers (`create`, `delete`, `remove`, `scale`) — fixes silent skipping of second items sharing the same productID on Servala
  - Retry `persistEventSent` on transient k8s API errors (Conflict, ServerTimeout, etc.) — prevents re-delivery of already-sent events when status update fails
  - Block finalizer removal while there is an undelivered event backlog
  - Remove deprecated productID-keyed helpers from `events.go`

## Checklist

- [x] Update tests.
- [ ] Link this PR to related issues.
- [ ] Merge with `/merge` comment.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->


Component PR: https://github.com/vshn/component-appcat/pull/1149