### PR TITLE
Move SSH XListenerSet to instance namespace and filter webhook scope

### DIFF
--- a/config/controller/webhooks.yaml
+++ b/config/controller/webhooks.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:

--- a/pkg/comp-functions/functions/vshnforgejo/ssh.go
+++ b/pkg/comp-functions/functions/vshnforgejo/ssh.go
@@ -102,6 +102,9 @@ func createXListenerSet(svc *runtime.ServiceRuntime, name, namespace, gatewayNam
 	xls.SetKind("XListenerSet")
 	xls.SetName(name)
 	xls.SetNamespace(namespace)
+	xls.SetLabels(map[string]string{
+		"appcat.vshn.io/sshgateway": "true",
+	})
 
 	err := unstructured.SetNestedMap(xls.Object, map[string]any{
 		"group":     "gateway.networking.k8s.io",

--- a/pkg/comp-functions/functions/vshnforgejo/ssh.go
+++ b/pkg/comp-functions/functions/vshnforgejo/ssh.go
@@ -59,12 +59,12 @@ func ConfigureSSHAccess(ctx context.Context, comp *vshnv1.VSHNForgejo, svc *runt
 		effectiveGatewayNamespace = observed.gatewayNamespace
 	}
 
-	err = createXListenerSet(svc, resourceBaseName, effectiveGatewayNamespace, effectiveGatewayName, comp.GetInstanceNamespace(), observed.port)
+	err = createXListenerSet(svc, resourceBaseName, comp.GetInstanceNamespace(), effectiveGatewayName, effectiveGatewayNamespace, observed.port)
 	if err != nil {
 		return runtime.NewWarningResult(fmt.Sprintf("cannot create XListenerSet: %s", err))
 	}
 
-	err = createTCPRoute(svc, comp, resourceBaseName, effectiveGatewayNamespace)
+	err = createTCPRoute(svc, comp, resourceBaseName)
 	if err != nil {
 		return runtime.NewWarningResult(fmt.Sprintf("cannot create TCPRoute: %s", err))
 	}
@@ -94,22 +94,22 @@ func ConfigureSSHAccess(ctx context.Context, comp *vshnv1.VSHNForgejo, svc *runt
 	return nil
 }
 
-func createXListenerSet(svc *runtime.ServiceRuntime, name, namespace, gatewayName, instanceNamespace string, port int32) error {
+func createXListenerSet(svc *runtime.ServiceRuntime, name, instanceNamespace, gatewayName, gatewayNamespace string, port int32) error {
 	xls := &unstructured.Unstructured{
 		Object: map[string]any{},
 	}
 	xls.SetAPIVersion("gateway.networking.x-k8s.io/v1alpha1")
 	xls.SetKind("XListenerSet")
 	xls.SetName(name)
-	xls.SetNamespace(namespace)
+	xls.SetNamespace(instanceNamespace)
 	xls.SetLabels(map[string]string{
-		"appcat.vshn.io/sshgateway": "true",
+		runtime.SSHGatewayLabel: "true",
 	})
 
 	err := unstructured.SetNestedMap(xls.Object, map[string]any{
 		"group":     "gateway.networking.k8s.io",
 		"kind":      "Gateway",
-		"namespace": namespace,
+		"namespace": gatewayNamespace,
 		"name":      gatewayName,
 	}, "spec", "parentRef")
 
@@ -123,16 +123,9 @@ func createXListenerSet(svc *runtime.ServiceRuntime, name, namespace, gatewayNam
 		"protocol": "TCP",
 	}
 
-	err = unstructured.SetNestedField(listener, "Selector", "allowedRoutes", "namespaces", "from")
+	err = unstructured.SetNestedField(listener, "Same", "allowedRoutes", "namespaces", "from")
 	if err != nil {
 		return fmt.Errorf("setting allowedRoutes.namespaces.from: %w", err)
-	}
-
-	err = unstructured.SetNestedMap(listener, map[string]any{
-		"kubernetes.io/metadata.name": instanceNamespace,
-	}, "allowedRoutes", "namespaces", "selector", "matchLabels")
-	if err != nil {
-		return fmt.Errorf("setting allowedRoutes.namespaces.selector: %w", err)
 	}
 
 	err = unstructured.SetNestedSlice(listener, []any{
@@ -155,7 +148,7 @@ func createXListenerSet(svc *runtime.ServiceRuntime, name, namespace, gatewayNam
 	return svc.SetDesiredKubeObject(xls, name)
 }
 
-func createTCPRoute(svc *runtime.ServiceRuntime, comp *vshnv1.VSHNForgejo, name, gatewayNamespace string) error {
+func createTCPRoute(svc *runtime.ServiceRuntime, comp *vshnv1.VSHNForgejo, name string) error {
 	instanceNs := comp.GetInstanceNamespace()
 
 	// The Forgejo Helm chart creates a service named <fullname>-ssh for the SSH port.
@@ -169,11 +162,11 @@ func createTCPRoute(svc *runtime.ServiceRuntime, comp *vshnv1.VSHNForgejo, name,
 	tcpRoute.SetName(name)
 	tcpRoute.SetNamespace(instanceNs)
 
+	// XListenerSet is in the same namespace, no cross-namespace ref needed.
 	err := unstructured.SetNestedSlice(tcpRoute.Object, []any{
 		map[string]any{
 			"group":       "gateway.networking.x-k8s.io",
 			"kind":        "XListenerSet",
-			"namespace":   gatewayNamespace,
 			"name":        name,
 			"sectionName": sshListenerName,
 		},

--- a/pkg/comp-functions/functions/vshnforgejo/ssh_test.go
+++ b/pkg/comp-functions/functions/vshnforgejo/ssh_test.go
@@ -47,6 +47,7 @@ func TestSSH(t *testing.T) {
 		require.NoError(t, svc.GetDesiredKubeObject(xls, resourceBaseName))
 		assert.Equal(t, resourceBaseName, xls.GetName())
 		assert.Equal(t, "gateway-system", xls.GetNamespace())
+		assert.Equal(t, "true", xls.GetLabels()["appcat.vshn.io/sshgateway"])
 
 		parentName, _, _ := unstructured.NestedString(xls.Object, "spec", "parentRef", "name")
 		parentNs, _, _ := unstructured.NestedString(xls.Object, "spec", "parentRef", "namespace")

--- a/pkg/comp-functions/functions/vshnforgejo/ssh_test.go
+++ b/pkg/comp-functions/functions/vshnforgejo/ssh_test.go
@@ -46,8 +46,8 @@ func TestSSH(t *testing.T) {
 		xls.SetKind("XListenerSet")
 		require.NoError(t, svc.GetDesiredKubeObject(xls, resourceBaseName))
 		assert.Equal(t, resourceBaseName, xls.GetName())
-		assert.Equal(t, "gateway-system", xls.GetNamespace())
-		assert.Equal(t, "true", xls.GetLabels()["appcat.vshn.io/sshgateway"])
+		assert.Equal(t, instanceNs, xls.GetNamespace())
+		assert.Equal(t, "true", xls.GetLabels()[runtime.SSHGatewayLabel])
 
 		parentName, _, _ := unstructured.NestedString(xls.Object, "spec", "parentRef", "name")
 		parentNs, _, _ := unstructured.NestedString(xls.Object, "spec", "parentRef", "namespace")
@@ -62,11 +62,9 @@ func TestSSH(t *testing.T) {
 		assert.Equal(t, "TCP", l0["protocol"])
 		assert.Equal(t, int64(0), l0["port"]) // 0 on first create, webhook assigns
 
-		// Verify allowedRoutes scoped to instance namespace
+		// Verify allowedRoutes scoped to same namespace (XLS and TCPRoute co-located)
 		fromMode, _, _ := unstructured.NestedString(l0, "allowedRoutes", "namespaces", "from")
-		assert.Equal(t, "Selector", fromMode)
-		selectorLabel, _, _ := unstructured.NestedString(l0, "allowedRoutes", "namespaces", "selector", "matchLabels", "kubernetes.io/metadata.name")
-		assert.Equal(t, instanceNs, selectorLabel)
+		assert.Equal(t, "Same", fromMode)
 
 		// Verify TCPRoute
 		tcpRoute := &unstructured.Unstructured{}
@@ -82,6 +80,7 @@ func TestSSH(t *testing.T) {
 		assert.Equal(t, "XListenerSet", pRef["kind"])
 		assert.Equal(t, resourceBaseName, pRef["name"])
 		assert.Equal(t, "ssh", pRef["sectionName"])
+		assert.Nil(t, pRef["namespace"], "parentRef must have no namespace (same-ns)")
 
 		rules, _, _ := unstructured.NestedSlice(tcpRoute.Object, "spec", "rules")
 		require.Len(t, rules, 1)

--- a/pkg/comp-functions/runtime/function_mgr.go
+++ b/pkg/comp-functions/runtime/function_mgr.go
@@ -60,6 +60,7 @@ const (
 	WebhookAllowDeletionLabel         = "appcat.vshn.io/webhook-allowdeletion"
 	IgnoreConnectionDetailsAnnotation = "appcat.vshn.io/ignore-connection-details"
 	LastReconcileAnnotation           = "appcat.vshn.io/reconciled-on"
+	SSHGatewayLabel                   = "appcat.vshn.io/sshgateway"
 
 	ResourceReady   ResourceReadiness = ResourceReadiness(resource.ReadyTrue)
 	ResourceUnReady ResourceReadiness = ResourceReadiness(resource.ReadyFalse)

--- a/pkg/controller/webhooks/sshgateway/allocator.go
+++ b/pkg/controller/webhooks/sshgateway/allocator.go
@@ -3,6 +3,7 @@ package sshgateway
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/vshn/appcat/v4/pkg/common/utils"
@@ -107,6 +108,7 @@ func (a *PortAllocator) AllocatePort(ctx context.Context, usedPorts map[int32]bo
 
 // tryReclaimStaleLease checks if the holder XListenerSet of an existing Lease
 // still exists. If the holder is gone/empty, the Lease is deleted.
+// The holder identity is expected in "namespace/name" format.
 func (a *PortAllocator) tryReclaimStaleLease(ctx context.Context, name, namespace string) bool {
 	existing := &coordinationv1.Lease{}
 	if err := a.client.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, existing); err != nil {
@@ -118,10 +120,12 @@ func (a *PortAllocator) tryReclaimStaleLease(ctx context.Context, name, namespac
 		return a.client.Delete(ctx, existing, client.Preconditions{UID: &uid}) == nil
 	}
 
+	holderNs, holderName, _ := strings.Cut(*existing.Spec.HolderIdentity, "/")
+
 	holder := &unstructured.Unstructured{}
 	holder.SetGroupVersionKind(xListenerSetSingleGVK)
 
-	err := a.client.Get(ctx, client.ObjectKey{Namespace: namespace, Name: *existing.Spec.HolderIdentity}, holder)
+	err := a.client.Get(ctx, client.ObjectKey{Namespace: holderNs, Name: holderName}, holder)
 	if err == nil {
 		return false
 	}

--- a/pkg/controller/webhooks/sshgateway/allocator_test.go
+++ b/pkg/controller/webhooks/sshgateway/allocator_test.go
@@ -168,7 +168,7 @@ func newTestClient(t *testing.T, objects ...client.Object) client.Client {
 }
 
 func TestTryReclaimStaleLease_HolderGone(t *testing.T) {
-	holderName := "gone-xls"
+	holder := "vshn-forgejo-test/gone-xls"
 	oldTime := metav1.NewMicroTime(time.Now().Add(-5 * time.Minute))
 	lease := &coordinationv1.Lease{
 		ObjectMeta: metav1.ObjectMeta{
@@ -176,7 +176,7 @@ func TestTryReclaimStaleLease_HolderGone(t *testing.T) {
 			Namespace: "test-ns",
 		},
 		Spec: coordinationv1.LeaseSpec{
-			HolderIdentity: &holderName,
+			HolderIdentity: &holder,
 			AcquireTime:    &oldTime,
 		},
 	}
@@ -192,18 +192,18 @@ func TestTryReclaimStaleLease_HolderGone(t *testing.T) {
 }
 
 func TestTryReclaimStaleLease_HolderExists(t *testing.T) {
-	holderName := "existing-xls"
+	holder := "vshn-forgejo-test/existing-xls"
 	lease := &coordinationv1.Lease{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("ssh-port-%d", 10000),
 			Namespace: "test-ns",
 		},
 		Spec: coordinationv1.LeaseSpec{
-			HolderIdentity: &holderName,
+			HolderIdentity: &holder,
 		},
 	}
 
-	xls := newXListenerSet("existing-xls", "test-ns", 10000)
+	xls := newXListenerSet("existing-xls", "vshn-forgejo-test", 10000)
 	c := newTestClient(t, lease, xls)
 	alloc := newTestAllocatorWithClient(t, c)
 
@@ -231,7 +231,7 @@ func TestTryReclaimStaleLease_NoHolderIdentity(t *testing.T) {
 }
 
 func TestTryReclaimStaleLease_HolderGoneButRecent(t *testing.T) {
-	holderName := "pending-xls"
+	holder := "vshn-forgejo-test/pending-xls"
 	now := metav1.NewMicroTime(time.Now())
 	lease := &coordinationv1.Lease{
 		ObjectMeta: metav1.ObjectMeta{
@@ -239,7 +239,7 @@ func TestTryReclaimStaleLease_HolderGoneButRecent(t *testing.T) {
 			Namespace: "test-ns",
 		},
 		Spec: coordinationv1.LeaseSpec{
-			HolderIdentity: &holderName,
+			HolderIdentity: &holder,
 			AcquireTime:    &now,
 		},
 	}

--- a/pkg/controller/webhooks/sshgateway/handler.go
+++ b/pkg/controller/webhooks/sshgateway/handler.go
@@ -126,7 +126,8 @@ func (h *XListenerSetHandler) Handle(ctx context.Context, req admission.Request)
 		if port == 0 {
 			listenerName, _ := listenerMap["name"].(string)
 
-			newPort, err := h.allocator.AllocatePort(ctx, usedPorts, h.leaseNS, name)
+			holder := namespace + "/" + name
+			newPort, err := h.allocator.AllocatePort(ctx, usedPorts, h.leaseNS, holder)
 			if err != nil {
 				h.log.Error(err, "Failed to allocate port", "listener", listenerName)
 				return admission.Errored(http.StatusInternalServerError, fmt.Errorf("allocating port for listener %q: %w", listenerName, err))

--- a/test/functions/vshnforgejo/02_ssh_with_port.yaml
+++ b/test/functions/vshnforgejo/02_ssh_with_port.yaml
@@ -74,7 +74,7 @@ observed:
               kind: XListenerSet
               metadata:
                 name: forgejo-unit-test-ssh
-                namespace: gateway-system
+                namespace: vshn-forgejo-unit-test
               spec:
                 parentRef:
                   group: gateway.networking.k8s.io

--- a/test/functions/vshnforgejo/02_ssh_with_port_sharded.yaml
+++ b/test/functions/vshnforgejo/02_ssh_with_port_sharded.yaml
@@ -74,7 +74,7 @@ observed:
               kind: XListenerSet
               metadata:
                 name: forgejo-unit-test-ssh
-                namespace: gateway-system
+                namespace: vshn-forgejo-unit-test
               spec:
                 parentRef:
                   group: gateway.networking.k8s.io


### PR DESCRIPTION
## Summary

* Add `appcat.vshn.io/sshgateway: true` label to `XListenerSets` created by Forgejo SSH composition function
* Allows the mutating webhook to scope its matching to only Forgejo SSH `XListenerSet`s, avoiding unintended mutations on other `XListenerSet` resources
* Move create of SSH `XListenerSet` to instance namespace

## Checklist

- [x] Update tests.
- [ ] Link this PR to related issues.
- [ ] Merge with `/merge` comment.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->


Component PR: https://github.com/vshn/component-appcat/pull/1153