### PR TITLE
Add Generalied TCPRoute handler

### DIFF
--- a/cmd/controller.go
+++ b/cmd/controller.go
@@ -14,7 +14,7 @@ import (
 	"github.com/vshn/appcat/v4/pkg/controller/events"
 	"github.com/vshn/appcat/v4/pkg/controller/garagebucket"
 	"github.com/vshn/appcat/v4/pkg/controller/webhooks"
-	"github.com/vshn/appcat/v4/pkg/controller/webhooks/sshgateway"
+	"github.com/vshn/appcat/v4/pkg/controller/webhooks/tcpgateway"
 	"github.com/vshn/appcat/v4/pkg/odoo"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/dynamic"
@@ -169,7 +169,7 @@ func (c *controller) executeController(cmd *cobra.Command, _ []string) error {
 	if c.sshGateways != "" && c.sshGatewayNamespace != "" {
 		gatewayNames := strings.Split(c.sshGateways, ",")
 
-		err = sshgateway.SetupXListenerSetWebhookWithManager(mgr, c.sshPortRangeStart, c.sshPortRangeEnd, c.sshGatewayCapacity, c.sshGatewayNamespace, gatewayNames)
+		err = tcpgateway.SetupXListenerSetWebhookWithManager(mgr, c.sshPortRangeStart, c.sshPortRangeEnd, c.sshGatewayCapacity, c.sshGatewayNamespace, gatewayNames)
 		if err != nil {
 			return err
 		}

--- a/pkg/comp-functions/functions/common/tcproute/tcproute.go
+++ b/pkg/comp-functions/functions/common/tcproute/tcproute.go
@@ -1,0 +1,289 @@
+package tcproute
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+
+	xfnproto "github.com/crossplane/function-sdk-go/proto/v1"
+	"github.com/vshn/appcat/v4/pkg/comp-functions/runtime"
+	corev1 "k8s.io/api/core/v1"
+	netv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+const (
+	defaultGatewayNamespaceConfigKey = "sshGatewayNamespace"
+	defaultGatewaysConfigKey         = "sshGateways"
+)
+
+// AddTCPRoute creates the Gateway API resources needed for TCP routing:
+// an XListenerSet, a TCPRoute, and a NetworkPolicy.
+func AddTCPRoute(svc *runtime.ServiceRuntime, cfg TCPRouteConfig) (*xfnproto.Result, ObservedState) {
+	cfg.applyDefaults()
+
+	gatewayNamespace := svc.Config.Data[cfg.GatewayNamespaceConfigKey]
+	tcpGatewayName := defaultGatewayName(svc, cfg.GatewaysConfigKey)
+
+	if gatewayNamespace == "" || tcpGatewayName == "" {
+		return runtime.NewWarningResult(fmt.Sprintf("TCPRoute requested but %s or %s is not configured", cfg.GatewayNamespaceConfigKey, cfg.GatewaysConfigKey)), ObservedState{}
+	}
+
+	svc.Log.Info("Configuring TCPRoute", "resource", cfg.ResourceName)
+
+	observed := ObserveXListenerSet(svc, cfg.ResourceName)
+
+	effectiveGatewayName := tcpGatewayName
+	effectiveGatewayNamespace := gatewayNamespace
+
+	if observed.GatewayName != "" {
+		effectiveGatewayName = observed.GatewayName
+		effectiveGatewayNamespace = observed.GatewayNamespace
+	}
+
+	err := createXListenerSet(svc, cfg, effectiveGatewayNamespace, effectiveGatewayName, observed.Port)
+	if err != nil {
+		return runtime.NewWarningResult(fmt.Sprintf("cannot create XListenerSet: %s", err)), observed
+	}
+
+	err = createTCPRoute(svc, cfg)
+	if err != nil {
+		return runtime.NewWarningResult(fmt.Sprintf("cannot create TCPRoute: %s", err)), observed
+	}
+
+	err = createGatewayNetworkPolicy(svc, cfg, effectiveGatewayNamespace)
+	if err != nil {
+		return runtime.NewWarningResult(fmt.Sprintf("cannot create gateway NetworkPolicy: %s", err)), observed
+	}
+
+	observed.Domain = lookupDomain(svc, cfg.GatewaysConfigKey, effectiveGatewayName)
+
+	return nil, observed
+}
+
+func createXListenerSet(svc *runtime.ServiceRuntime, cfg TCPRouteConfig, gatewayNamespace, gatewayName string, port int32) error {
+	xls := &unstructured.Unstructured{
+		Object: map[string]any{},
+	}
+	xls.SetAPIVersion("gateway.networking.x-k8s.io/v1alpha1")
+	xls.SetKind("XListenerSet")
+	xls.SetName(cfg.ResourceName)
+	xls.SetNamespace(cfg.InstanceNamespace)
+
+	err := unstructured.SetNestedMap(xls.Object, map[string]any{
+		"group":     "gateway.networking.k8s.io",
+		"kind":      "Gateway",
+		"namespace": gatewayNamespace,
+		"name":      gatewayName,
+	}, "spec", "parentRef")
+	if err != nil {
+		return fmt.Errorf("setting parentRef: %w", err)
+	}
+
+	listener := map[string]any{
+		"name":     cfg.ListenerName,
+		"port":     int64(port),
+		"protocol": "TCP",
+	}
+
+	err = unstructured.SetNestedField(listener, "Same", "allowedRoutes", "namespaces", "from")
+	if err != nil {
+		return fmt.Errorf("setting allowedRoutes.namespaces.from: %w", err)
+	}
+
+	err = unstructured.SetNestedSlice(listener, []any{
+		map[string]any{
+			"group": "gateway.networking.k8s.io",
+			"kind":  "TCPRoute",
+		},
+	}, "allowedRoutes", "kinds")
+	if err != nil {
+		return fmt.Errorf("setting allowedRoutes.kinds: %w", err)
+	}
+
+	err = unstructured.SetNestedSlice(xls.Object, []any{listener}, "spec", "listeners")
+	if err != nil {
+		return fmt.Errorf("setting listeners: %w", err)
+	}
+
+	return svc.SetDesiredKubeObject(xls, cfg.ResourceName)
+}
+
+func createTCPRoute(svc *runtime.ServiceRuntime, cfg TCPRouteConfig) error {
+	tcpRoute := &unstructured.Unstructured{
+		Object: map[string]any{},
+	}
+	tcpRoute.SetAPIVersion("gateway.networking.k8s.io/v1alpha2")
+	tcpRoute.SetKind("TCPRoute")
+	tcpRoute.SetName(cfg.ResourceName)
+	tcpRoute.SetNamespace(cfg.InstanceNamespace)
+
+	err := unstructured.SetNestedSlice(tcpRoute.Object, []any{
+		map[string]any{
+			"group":       "gateway.networking.x-k8s.io",
+			"kind":        "XListenerSet",
+			"name":        cfg.ResourceName,
+			"sectionName": cfg.ListenerName,
+		},
+	}, "spec", "parentRefs")
+	if err != nil {
+		return fmt.Errorf("setting parentRefs: %w", err)
+	}
+
+	err = unstructured.SetNestedSlice(tcpRoute.Object, []any{
+		map[string]any{
+			"backendRefs": []any{
+				map[string]any{
+					"group":     "",
+					"kind":      "Service",
+					"name":      cfg.BackendServiceName,
+					"namespace": cfg.InstanceNamespace,
+					"port":      int64(cfg.BackendServicePort),
+				},
+			},
+		},
+	}, "spec", "rules")
+	if err != nil {
+		return fmt.Errorf("setting rules: %w", err)
+	}
+
+	return svc.SetDesiredKubeObject(tcpRoute, cfg.ResourceName+"-tcproute")
+}
+
+func createGatewayNetworkPolicy(svc *runtime.ServiceRuntime, cfg TCPRouteConfig, gatewayNamespace string) error {
+	protocol := corev1.ProtocolTCP
+	port := intstr.FromInt(int(cfg.PodListenPort))
+
+	netPol := &netv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cfg.ResourceName,
+			Namespace: cfg.InstanceNamespace,
+		},
+		Spec: netv1.NetworkPolicySpec{
+			PolicyTypes: []netv1.PolicyType{"Ingress"},
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: cfg.PodSelectorLabels,
+			},
+			Ingress: []netv1.NetworkPolicyIngressRule{
+				{
+					From: []netv1.NetworkPolicyPeer{
+						{
+							NamespaceSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									"kubernetes.io/metadata.name": gatewayNamespace,
+								},
+							},
+						},
+					},
+					Ports: []netv1.NetworkPolicyPort{
+						{
+							Protocol: &protocol,
+							Port:     &port,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	return svc.SetDesiredKubeObject(netPol, cfg.ResourceName+"-netpol")
+}
+
+func ObserveXListenerSet(svc *runtime.ServiceRuntime, name string) ObservedState {
+	observed := &unstructured.Unstructured{
+		Object: map[string]any{},
+	}
+	observed.SetAPIVersion("gateway.networking.x-k8s.io/v1alpha1")
+	observed.SetKind("XListenerSet")
+
+	err := svc.GetObservedKubeObject(observed, name)
+	if err != nil {
+		svc.Log.Info("XListenerSet not yet observed, skipping readback")
+		return ObservedState{}
+	}
+
+	state := ObservedState{}
+
+	gwName, _, _ := unstructured.NestedString(observed.Object, "spec", "parentRef", "name")
+	gwNs, _, _ := unstructured.NestedString(observed.Object, "spec", "parentRef", "namespace")
+	state.GatewayName = gwName
+	state.GatewayNamespace = gwNs
+
+	listeners, found, err := unstructured.NestedSlice(observed.Object, "spec", "listeners")
+	if err != nil || !found || len(listeners) == 0 {
+		svc.Log.Info("No listeners found in observed XListenerSet")
+		return state
+	}
+
+	listenerMap, ok := listeners[0].(map[string]any)
+	if !ok {
+		return state
+	}
+
+	state.Port = toInt(listenerMap["port"])
+
+	if state.Port == 0 {
+		return state
+	}
+
+	svc.Log.Info("Observed allocated port", "port", state.Port, "gateway", state.GatewayName)
+
+	return state
+}
+
+// lookupDomain resolves the domain for a given gateway name from the
+// gateways config value.
+func lookupDomain(svc *runtime.ServiceRuntime, configKey, gatewayName string) string {
+	raw := svc.Config.Data[configKey]
+	if raw == "" {
+		return ""
+	}
+
+	mapping := map[string]string{}
+	if err := json.Unmarshal([]byte(raw), &mapping); err != nil {
+		svc.Log.Error(err, "failed to parse gateways config", "key", configKey)
+		svc.AddResult(runtime.NewFatalResult(fmt.Errorf("failed to parse gateways: %w", err)))
+		return ""
+	}
+
+	return mapping[gatewayName]
+}
+
+func defaultGatewayName(svc *runtime.ServiceRuntime, configKey string) string {
+	raw, ok := svc.Config.Data[configKey]
+	if !ok || raw == "" {
+		return ""
+	}
+
+	mapping := map[string]string{}
+	if err := json.Unmarshal([]byte(raw), &mapping); err != nil {
+		svc.Log.Error(err, "failed to parse gateways config", "key", configKey)
+		return ""
+	}
+
+	names := make([]string, 0, len(mapping))
+	for name := range mapping {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	if len(names) == 0 {
+		return ""
+	}
+	return names[0]
+}
+
+func toInt(v any) int32 {
+	switch p := v.(type) {
+	case int64:
+		return int32(p)
+	case float64:
+		return int32(p)
+	case int:
+		return int32(p)
+	default:
+		return 0
+	}
+}

--- a/pkg/comp-functions/functions/common/tcproute/tcproute_test.go
+++ b/pkg/comp-functions/functions/common/tcproute/tcproute_test.go
@@ -1,0 +1,170 @@
+package tcproute
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vshn/appcat/v4/pkg/comp-functions/functions/commontest"
+	"github.com/vshn/appcat/v4/pkg/comp-functions/runtime"
+	netv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func testConfig() TCPRouteConfig {
+	return TCPRouteConfig{
+		ResourceName:       "my-service-tcp",
+		ListenerName:       "tcp",
+		BackendServiceName: "my-backend-svc",
+		BackendServicePort: 3306,
+		PodListenPort:      3306,
+		PodSelectorLabels: map[string]string{
+			"app.kubernetes.io/name":     "myapp",
+			"app.kubernetes.io/instance": "my-service",
+		},
+		InstanceNamespace: "vshn-myapp-test",
+	}
+}
+
+func TestAddTCPRoute(t *testing.T) {
+	t.Run("AllResourcesCreated", func(t *testing.T) {
+		svc := commontest.LoadRuntimeFromFile(t, "tcproute/01_basic.yaml")
+		cfg := testConfig()
+
+		result, state := AddTCPRoute(svc, cfg)
+		assert.Nil(t, result)
+		assert.Equal(t, int32(0), state.Port, "port should be 0 when no observed XListenerSet")
+
+		// Verify XListenerSet
+		xls := &unstructured.Unstructured{}
+		xls.SetAPIVersion("gateway.networking.x-k8s.io/v1alpha1")
+		xls.SetKind("XListenerSet")
+		require.NoError(t, svc.GetDesiredKubeObject(xls, cfg.ResourceName))
+		assert.Equal(t, cfg.ResourceName, xls.GetName())
+		assert.Equal(t, cfg.InstanceNamespace, xls.GetNamespace())
+
+		parentName, _, _ := unstructured.NestedString(xls.Object, "spec", "parentRef", "name")
+		parentNs, _, _ := unstructured.NestedString(xls.Object, "spec", "parentRef", "namespace")
+		assert.Equal(t, "tcp-gateway", parentName)
+		assert.Equal(t, "gateway-system", parentNs)
+
+		listeners, found, _ := unstructured.NestedSlice(xls.Object, "spec", "listeners")
+		require.True(t, found)
+		require.Len(t, listeners, 1)
+		l0 := listeners[0].(map[string]any)
+		assert.Equal(t, "tcp", l0["name"])
+		assert.Equal(t, "TCP", l0["protocol"])
+		assert.Equal(t, int64(0), l0["port"])
+
+		// Verify allowedRoutes scoped to same namespace (XLS and TCPRoute co-located)
+		fromMode, _, _ := unstructured.NestedString(l0, "allowedRoutes", "namespaces", "from")
+		assert.Equal(t, "Same", fromMode)
+
+		// Verify TCPRoute
+		tcpRoute := &unstructured.Unstructured{}
+		tcpRoute.SetAPIVersion("gateway.networking.k8s.io/v1alpha2")
+		tcpRoute.SetKind("TCPRoute")
+		require.NoError(t, svc.GetDesiredKubeObject(tcpRoute, cfg.ResourceName+"-tcproute"))
+		assert.Equal(t, cfg.ResourceName, tcpRoute.GetName())
+		assert.Equal(t, cfg.InstanceNamespace, tcpRoute.GetNamespace())
+
+		parentRefs, _, _ := unstructured.NestedSlice(tcpRoute.Object, "spec", "parentRefs")
+		require.Len(t, parentRefs, 1)
+		pRef := parentRefs[0].(map[string]any)
+		assert.Equal(t, "XListenerSet", pRef["kind"])
+		assert.Equal(t, cfg.ResourceName, pRef["name"])
+		assert.Equal(t, "tcp", pRef["sectionName"])
+		assert.Nil(t, pRef["namespace"], "parentRef must have no namespace (same-ns)")
+
+		rules, _, _ := unstructured.NestedSlice(tcpRoute.Object, "spec", "rules")
+		require.Len(t, rules, 1)
+		backendRefs := rules[0].(map[string]any)["backendRefs"].([]any)
+		require.Len(t, backendRefs, 1)
+		backend := backendRefs[0].(map[string]any)
+		assert.Equal(t, "Service", backend["kind"])
+		assert.Equal(t, cfg.BackendServiceName, backend["name"])
+		assert.Equal(t, cfg.InstanceNamespace, backend["namespace"])
+		assert.Equal(t, int64(cfg.BackendServicePort), backend["port"])
+
+		// Verify NetworkPolicy
+		netPol := &netv1.NetworkPolicy{}
+		require.NoError(t, svc.GetDesiredKubeObject(netPol, cfg.ResourceName+"-netpol"))
+		assert.Equal(t, cfg.ResourceName, netPol.Name)
+		assert.Equal(t, cfg.InstanceNamespace, netPol.Namespace)
+		assert.Equal(t, "myapp", netPol.Spec.PodSelector.MatchLabels["app.kubernetes.io/name"])
+		assert.Equal(t, "my-service", netPol.Spec.PodSelector.MatchLabels["app.kubernetes.io/instance"])
+		require.Len(t, netPol.Spec.Ingress, 1)
+		require.Len(t, netPol.Spec.Ingress[0].From, 1)
+		assert.Equal(t, "gateway-system", netPol.Spec.Ingress[0].From[0].NamespaceSelector.MatchLabels["kubernetes.io/metadata.name"])
+		require.Len(t, netPol.Spec.Ingress[0].Ports, 1)
+		assert.Equal(t, int32(cfg.PodListenPort), netPol.Spec.Ingress[0].Ports[0].Port.IntVal)
+	})
+
+	t.Run("GatewayConfigMissing_WarningResult", func(t *testing.T) {
+		svc := commontest.LoadRuntimeFromFile(t, "tcproute/01_basic.yaml")
+		cfg := testConfig()
+
+		delete(svc.Config.Data, "sshGatewayNamespace")
+		delete(svc.Config.Data, "sshGateways")
+
+		result, _ := AddTCPRoute(svc, cfg)
+		require.NotNil(t, result)
+		assert.Contains(t, result.Message, "is not configured")
+	})
+
+	t.Run("AllocatedPortPreserved", func(t *testing.T) {
+		svc := commontest.LoadRuntimeFromFile(t, "tcproute/02_with_port.yaml")
+		cfg := testConfig()
+
+		result, state := AddTCPRoute(svc, cfg)
+		assert.Nil(t, result)
+
+		// Verify port preserved from observed state
+		assert.Equal(t, int32(10005), state.Port)
+		assert.Equal(t, "tcp.example.com", state.Domain)
+
+		// Verify XListenerSet has the allocated port
+		xls := &unstructured.Unstructured{}
+		xls.SetAPIVersion("gateway.networking.x-k8s.io/v1alpha1")
+		xls.SetKind("XListenerSet")
+		require.NoError(t, svc.GetDesiredKubeObject(xls, cfg.ResourceName))
+		listeners, _, _ := unstructured.NestedSlice(xls.Object, "spec", "listeners")
+		require.Len(t, listeners, 1)
+		l0 := listeners[0].(map[string]any)
+		assert.Equal(t, int64(10005), l0["port"])
+	})
+
+	t.Run("AllocatedGatewayPreserved", func(t *testing.T) {
+		svc := commontest.LoadRuntimeFromFile(t, "tcproute/03_sharded.yaml")
+		cfg := testConfig()
+
+		result, state := AddTCPRoute(svc, cfg)
+		assert.Nil(t, result)
+
+		// Verify gateway preserved from observed state
+		assert.Equal(t, int32(10005), state.Port)
+		assert.Equal(t, "tcp2.example.com", state.Domain)
+
+		// Verify XListenerSet uses observed gateway
+		xls := &unstructured.Unstructured{}
+		xls.SetAPIVersion("gateway.networking.x-k8s.io/v1alpha1")
+		xls.SetKind("XListenerSet")
+		require.NoError(t, svc.GetDesiredKubeObject(xls, cfg.ResourceName))
+
+		parentName, _, _ := unstructured.NestedString(xls.Object, "spec", "parentRef", "name")
+		parentNs, _, _ := unstructured.NestedString(xls.Object, "spec", "parentRef", "namespace")
+		assert.Equal(t, "tcp-gateway-2", parentName)
+		assert.Equal(t, "gateway-system", parentNs)
+	})
+
+	t.Run("NoResources_WhenNotCalled", func(t *testing.T) {
+		svc := commontest.LoadRuntimeFromFile(t, "tcproute/01_basic.yaml")
+		cfg := testConfig()
+
+		// Verify no resources exist before calling AddTCPRoute
+		xls := &unstructured.Unstructured{}
+		xls.SetAPIVersion("gateway.networking.x-k8s.io/v1alpha1")
+		xls.SetKind("XListenerSet")
+		assert.ErrorIs(t, svc.GetDesiredKubeObject(xls, cfg.ResourceName), runtime.ErrNotFound)
+	})
+}

--- a/pkg/comp-functions/functions/common/tcproute/types.go
+++ b/pkg/comp-functions/functions/common/tcproute/types.go
@@ -1,0 +1,37 @@
+package tcproute
+
+type TCPRouteConfig struct {
+	// Name prefix for all created resources (e.g. "mycomp-ssh")
+	ResourceName string
+	// Listener name inside XListenerSet (e.g. "ssh", "mysql")
+	ListenerName string
+	// Target service name + port for the TCPRoute backend
+	BackendServiceName string
+	BackendServicePort int32
+	// Pod-level port for NetworkPolicy (the port pods actually listen on)
+	PodListenPort int32
+	// Pod selector labels for NetworkPolicy
+	PodSelectorLabels map[string]string
+	// Instance namespace where TCPRoute + NetworkPolicy are created
+	InstanceNamespace string
+	// Config key names (default: "sshGatewayNamespace", "sshGateways")
+	// Allow override so services can use different config keys if needed
+	GatewayNamespaceConfigKey string // default "sshGatewayNamespace"
+	GatewaysConfigKey         string // default "sshGateways"
+}
+
+func (c *TCPRouteConfig) applyDefaults() {
+	if c.GatewayNamespaceConfigKey == "" {
+		c.GatewayNamespaceConfigKey = defaultGatewayNamespaceConfigKey
+	}
+	if c.GatewaysConfigKey == "" {
+		c.GatewaysConfigKey = defaultGatewaysConfigKey
+	}
+}
+
+type ObservedState struct {
+	Port             int32
+	GatewayName      string
+	GatewayNamespace string
+	Domain           string // looked up from config
+}

--- a/pkg/comp-functions/functions/vshnforgejo/ssh.go
+++ b/pkg/comp-functions/functions/vshnforgejo/ssh.go
@@ -4,20 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"sort"
 	"strconv"
 
 	xfnproto "github.com/crossplane/function-sdk-go/proto/v1"
 	xhelmv1 "github.com/vshn/appcat/v4/apis/helm/release/v1beta1"
 	vshnv1 "github.com/vshn/appcat/v4/apis/vshn/v1"
-	"github.com/vshn/appcat/v4/pkg/common/utils"
 	"github.com/vshn/appcat/v4/pkg/comp-functions/functions/common"
+	"github.com/vshn/appcat/v4/pkg/comp-functions/functions/common/tcproute"
 	"github.com/vshn/appcat/v4/pkg/comp-functions/runtime"
-	corev1 "k8s.io/api/core/v1"
-	netv1 "k8s.io/api/networking/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 const (
@@ -38,207 +32,41 @@ func ConfigureSSHAccess(ctx context.Context, comp *vshnv1.VSHNForgejo, svc *runt
 		return nil
 	}
 
-	gatewayNamespace := svc.Config.Data["sshGatewayNamespace"]
-	tcpGatewayName := defaultGatewayName(svc)
-
-	if gatewayNamespace == "" || tcpGatewayName == "" {
-		return runtime.NewWarningResult("SSH is enabled but sshGatewayNamespace or sshGateways is not configured")
+	cfg := tcproute.TCPRouteConfig{
+		ResourceName:       comp.GetName() + "-ssh",
+		ListenerName:       sshListenerName,
+		BackendServiceName: helmFullname(comp) + "-ssh",
+		BackendServicePort: sshServicePort,
+		PodListenPort:      sshPodListenPort,
+		PodSelectorLabels: map[string]string{
+			"app.kubernetes.io/name":     comp.GetServiceName(),
+			"app.kubernetes.io/instance": comp.GetName(),
+		},
+		InstanceNamespace: comp.GetInstanceNamespace(),
 	}
 
-	svc.Log.Info("Configuring SSH access for Forgejo instance")
-
-	resourceBaseName := comp.GetName() + "-ssh"
-
-	observed := observeXListenerSet(svc, resourceBaseName)
-
-	effectiveGatewayName := tcpGatewayName
-	effectiveGatewayNamespace := gatewayNamespace
-
-	if observed.gatewayName != "" {
-		effectiveGatewayName = observed.gatewayName
-		effectiveGatewayNamespace = observed.gatewayNamespace
+	result, state := tcproute.AddTCPRoute(svc, cfg)
+	if result != nil {
+		return result
 	}
 
-	err = createXListenerSet(svc, resourceBaseName, comp.GetInstanceNamespace(), effectiveGatewayName, effectiveGatewayNamespace, observed.port)
-	if err != nil {
-		return runtime.NewWarningResult(fmt.Sprintf("cannot create XListenerSet: %s", err))
-	}
-
-	err = createTCPRoute(svc, comp, resourceBaseName)
-	if err != nil {
-		return runtime.NewWarningResult(fmt.Sprintf("cannot create TCPRoute: %s", err))
-	}
-
-	err = createGatewayNetworkPolicy(svc, comp, resourceBaseName, effectiveGatewayNamespace)
-	if err != nil {
-		return runtime.NewWarningResult(fmt.Sprintf("cannot create gateway NetworkPolicy: %s", err))
-	}
-
-	sshDomain := lookupSSHDomain(svc, effectiveGatewayName)
-
-	if observed.port > 0 {
-		comp.Status.SSHPort = observed.port
-		if err := svc.SetDesiredCompositeStatus(comp); err != nil {
-			svc.Log.Error(err, "cannot update SSHPort in status")
+	// Forgejo-specific: update connection details + Helm values
+	if state.Port > 0 {
+		comp.Status.SSHPort = state.Port
+		err := svc.SetDesiredCompositeStatus(comp)
+		if err != nil {
+			return runtime.NewFatalResult(fmt.Errorf("cannot update composite status: %w", err))
 		}
-		if sshDomain != "" {
-			svc.SetConnectionDetail("FORGEJO_SSH_HOST", []byte(sshDomain))
-		}
-		svc.SetConnectionDetail("FORGEJO_SSH_PORT", []byte(strconv.FormatInt(int64(observed.port), 10)))
 
-		if err := enableSSHInRelease(svc, comp, sshDomain, observed.port); err != nil {
-			return runtime.NewWarningResult(fmt.Sprintf("cannot enable SSH in release: %s", err))
+		svc.SetConnectionDetail("FORGEJO_SSH_HOST", []byte(state.Domain))
+		svc.SetConnectionDetail("FORGEJO_SSH_PORT", []byte(strconv.FormatInt(int64(state.Port), 10)))
+		err = enableSSHInRelease(svc, comp, state.Domain, state.Port)
+		if err != nil {
+			return runtime.NewFatalResult(fmt.Errorf("cannot update forgejo release: %w", err))
 		}
 	}
 
 	return nil
-}
-
-func createXListenerSet(svc *runtime.ServiceRuntime, name, instanceNamespace, gatewayName, gatewayNamespace string, port int32) error {
-	xls := &unstructured.Unstructured{
-		Object: map[string]any{},
-	}
-	xls.SetAPIVersion("gateway.networking.x-k8s.io/v1alpha1")
-	xls.SetKind("XListenerSet")
-	xls.SetName(name)
-	xls.SetNamespace(instanceNamespace)
-	xls.SetLabels(map[string]string{
-		runtime.SSHGatewayLabel: "true",
-	})
-
-	err := unstructured.SetNestedMap(xls.Object, map[string]any{
-		"group":     "gateway.networking.k8s.io",
-		"kind":      "Gateway",
-		"namespace": gatewayNamespace,
-		"name":      gatewayName,
-	}, "spec", "parentRef")
-
-	if err != nil {
-		return fmt.Errorf("setting parentRef: %w", err)
-	}
-
-	listener := map[string]any{
-		"name":     sshListenerName,
-		"port":     int64(port),
-		"protocol": "TCP",
-	}
-
-	err = unstructured.SetNestedField(listener, "Same", "allowedRoutes", "namespaces", "from")
-	if err != nil {
-		return fmt.Errorf("setting allowedRoutes.namespaces.from: %w", err)
-	}
-
-	err = unstructured.SetNestedSlice(listener, []any{
-		map[string]any{
-			"group": "gateway.networking.k8s.io",
-			"kind":  "TCPRoute",
-		},
-	}, "allowedRoutes", "kinds")
-
-	if err != nil {
-		return fmt.Errorf("setting allowedRoutes.kinds: %w", err)
-	}
-
-	err = unstructured.SetNestedSlice(xls.Object, []any{listener}, "spec", "listeners")
-
-	if err != nil {
-		return fmt.Errorf("setting listeners: %w", err)
-	}
-
-	return svc.SetDesiredKubeObject(xls, name)
-}
-
-func createTCPRoute(svc *runtime.ServiceRuntime, comp *vshnv1.VSHNForgejo, name string) error {
-	instanceNs := comp.GetInstanceNamespace()
-
-	// The Forgejo Helm chart creates a service named <fullname>-ssh for the SSH port.
-	sshServiceName := helmFullname(comp) + "-ssh"
-
-	tcpRoute := &unstructured.Unstructured{
-		Object: map[string]any{},
-	}
-	tcpRoute.SetAPIVersion("gateway.networking.k8s.io/v1alpha2")
-	tcpRoute.SetKind("TCPRoute")
-	tcpRoute.SetName(name)
-	tcpRoute.SetNamespace(instanceNs)
-
-	// XListenerSet is in the same namespace, no cross-namespace ref needed.
-	err := unstructured.SetNestedSlice(tcpRoute.Object, []any{
-		map[string]any{
-			"group":       "gateway.networking.x-k8s.io",
-			"kind":        "XListenerSet",
-			"name":        name,
-			"sectionName": sshListenerName,
-		},
-	}, "spec", "parentRefs")
-
-	if err != nil {
-		return fmt.Errorf("setting parentRefs: %w", err)
-	}
-
-	err = unstructured.SetNestedSlice(tcpRoute.Object, []any{
-		map[string]any{
-			"backendRefs": []any{
-				map[string]any{
-					"group":     "",
-					"kind":      "Service",
-					"name":      sshServiceName,
-					"namespace": instanceNs,
-					"port":      int64(sshServicePort),
-				},
-			},
-		},
-	}, "spec", "rules")
-
-	if err != nil {
-		return fmt.Errorf("setting rules: %w", err)
-	}
-
-	return svc.SetDesiredKubeObject(tcpRoute, name+"-tcproute")
-}
-
-func createGatewayNetworkPolicy(svc *runtime.ServiceRuntime, comp *vshnv1.VSHNForgejo, name, gatewayNamespace string) error {
-	instanceNs := comp.GetInstanceNamespace()
-
-	protocol := corev1.ProtocolTCP
-	port := intstr.FromInt(sshPodListenPort)
-
-	netPol := &netv1.NetworkPolicy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: instanceNs,
-		},
-		Spec: netv1.NetworkPolicySpec{
-			PolicyTypes: []netv1.PolicyType{"Ingress"},
-			PodSelector: metav1.LabelSelector{
-				MatchLabels: map[string]string{
-					"app.kubernetes.io/name":     comp.GetServiceName(),
-					"app.kubernetes.io/instance": comp.GetName(),
-				},
-			},
-			Ingress: []netv1.NetworkPolicyIngressRule{
-				{
-					From: []netv1.NetworkPolicyPeer{
-						{
-							NamespaceSelector: &metav1.LabelSelector{
-								MatchLabels: map[string]string{
-									"kubernetes.io/metadata.name": gatewayNamespace,
-								},
-							},
-						},
-					},
-					Ports: []netv1.NetworkPolicyPort{
-						{
-							Protocol: &protocol,
-							Port:     &port,
-						},
-					},
-				},
-			},
-		},
-	}
-
-	return svc.SetDesiredKubeObject(netPol, name+"-netpol")
 }
 
 // enableSSHInRelease modifies the Helm release values to enable SSH in Forgejo.
@@ -254,14 +82,27 @@ func enableSSHInRelease(svc *runtime.ServiceRuntime, comp *vshnv1.VSHNForgejo, s
 		return fmt.Errorf("getting release values: %w", err)
 	}
 
-	common.SetNestedObjectValue(values, []string{"gitea", "config", "server", "DISABLE_SSH"}, false)
-	common.SetNestedObjectValue(values, []string{"gitea", "config", "server", "START_SSH_SERVER"}, true)
+	err = common.SetNestedObjectValue(values, []string{"gitea", "config", "server", "DISABLE_SSH"}, false)
+	if err != nil {
+		return err
+	}
+
+	err = common.SetNestedObjectValue(values, []string{"gitea", "config", "server", "START_SSH_SERVER"}, true)
+	if err != nil {
+		return err
+	}
 
 	if sshDomain != "" {
-		common.SetNestedObjectValue(values, []string{"gitea", "config", "server", "SSH_DOMAIN"}, sshDomain)
+		err := common.SetNestedObjectValue(values, []string{"gitea", "config", "server", "SSH_DOMAIN"}, sshDomain)
+		if err != nil {
+			return err
+		}
 	}
 	if allocatedPort > 0 {
-		common.SetNestedObjectValue(values, []string{"gitea", "config", "server", "SSH_PORT"}, int(allocatedPort))
+		err := common.SetNestedObjectValue(values, []string{"gitea", "config", "server", "SSH_PORT"}, int(allocatedPort))
+		if err != nil {
+			return err
+		}
 	}
 
 	byteValues, err := json.Marshal(values)
@@ -271,95 +112,4 @@ func enableSSHInRelease(svc *runtime.ServiceRuntime, comp *vshnv1.VSHNForgejo, s
 	release.Spec.ForProvider.Values.Raw = byteValues
 
 	return svc.SetDesiredComposedResourceWithName(release, comp.GetName())
-}
-
-// lookupSSHDomain resolves the SSH domain for a given gateway name from the
-// sshGateways config value.
-func lookupSSHDomain(svc *runtime.ServiceRuntime, gatewayName string) string {
-	raw := svc.Config.Data["sshGateways"]
-	if raw == "" {
-		return ""
-	}
-
-	mapping := map[string]string{}
-	if err := json.Unmarshal([]byte(raw), &mapping); err != nil {
-		svc.Log.Error(err, "failed to parse sshGateways")
-		return ""
-	}
-
-	return mapping[gatewayName]
-}
-
-// observedXListenerSetState holds the observed state of an XListenerSet,
-// including the webhook-assigned port and gateway.
-type observedXListenerSetState struct {
-	port             int32
-	gatewayName      string
-	gatewayNamespace string
-}
-
-func observeXListenerSet(svc *runtime.ServiceRuntime, name string) observedXListenerSetState {
-	observed := &unstructured.Unstructured{
-		Object: map[string]any{},
-	}
-	observed.SetAPIVersion("gateway.networking.x-k8s.io/v1alpha1")
-	observed.SetKind("XListenerSet")
-
-	err := svc.GetObservedKubeObject(observed, name)
-	if err != nil {
-		svc.Log.Info("XListenerSet not yet observed, skipping readback")
-		return observedXListenerSetState{}
-	}
-
-	state := observedXListenerSetState{}
-
-	gwName, _, _ := unstructured.NestedString(observed.Object, "spec", "parentRef", "name")
-	gwNs, _, _ := unstructured.NestedString(observed.Object, "spec", "parentRef", "namespace")
-	state.gatewayName = gwName
-	state.gatewayNamespace = gwNs
-
-	listeners, found, err := unstructured.NestedSlice(observed.Object, "spec", "listeners")
-	if err != nil || !found || len(listeners) == 0 {
-		svc.Log.Info("No listeners found in observed XListenerSet")
-		return state
-	}
-
-	listenerMap, ok := listeners[0].(map[string]any)
-	if !ok {
-		return state
-	}
-
-	state.port = utils.ToInt32(listenerMap["port"])
-
-	if state.port == 0 {
-		return state
-	}
-
-	svc.Log.Info("Observed allocated SSH port", "port", state.port, "gateway", state.gatewayName)
-
-	return state
-}
-
-func defaultGatewayName(svc *runtime.ServiceRuntime) string {
-	raw, ok := svc.Config.Data["sshGateways"]
-	if !ok || raw == "" {
-		return ""
-	}
-
-	mapping := map[string]string{}
-	if err := json.Unmarshal([]byte(raw), &mapping); err != nil {
-		svc.Log.Error(err, "failed to parse sshGateways")
-		return ""
-	}
-
-	names := make([]string, 0, len(mapping))
-	for name := range mapping {
-		names = append(names, name)
-	}
-	sort.Strings(names)
-
-	if len(names) == 0 {
-		return ""
-	}
-	return names[0]
 }

--- a/pkg/comp-functions/functions/vshnforgejo/ssh_test.go
+++ b/pkg/comp-functions/functions/vshnforgejo/ssh_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/vshn/appcat/v4/pkg/comp-functions/functions/common"
 	"github.com/vshn/appcat/v4/pkg/comp-functions/functions/commontest"
 	"github.com/vshn/appcat/v4/pkg/comp-functions/runtime"
-	netv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -31,90 +30,6 @@ func TestSSH(t *testing.T) {
 		assert.ErrorIs(t, svc.GetDesiredKubeObject(xls, comp.GetName()+"-ssh"), runtime.ErrNotFound)
 	})
 
-	t.Run("SSHEnabled_AllResourcesCreated", func(t *testing.T) {
-		svc, comp := bootstrapSSHTestFromFixture(t, "vshnforgejo/02_ssh.yaml")
-
-		result := ConfigureSSHAccess(context.TODO(), comp, svc)
-		assert.Nil(t, result)
-
-		resourceBaseName := comp.GetName() + "-ssh"
-		instanceNs := comp.GetInstanceNamespace()
-
-		// Verify XListenerSet
-		xls := &unstructured.Unstructured{}
-		xls.SetAPIVersion("gateway.networking.x-k8s.io/v1alpha1")
-		xls.SetKind("XListenerSet")
-		require.NoError(t, svc.GetDesiredKubeObject(xls, resourceBaseName))
-		assert.Equal(t, resourceBaseName, xls.GetName())
-		assert.Equal(t, instanceNs, xls.GetNamespace())
-		assert.Equal(t, "true", xls.GetLabels()[runtime.SSHGatewayLabel])
-
-		parentName, _, _ := unstructured.NestedString(xls.Object, "spec", "parentRef", "name")
-		parentNs, _, _ := unstructured.NestedString(xls.Object, "spec", "parentRef", "namespace")
-		assert.Equal(t, "tcp-gateway", parentName)
-		assert.Equal(t, "gateway-system", parentNs)
-
-		listeners, found, _ := unstructured.NestedSlice(xls.Object, "spec", "listeners")
-		require.True(t, found)
-		require.Len(t, listeners, 1)
-		l0 := listeners[0].(map[string]any)
-		assert.Equal(t, "ssh", l0["name"])
-		assert.Equal(t, "TCP", l0["protocol"])
-		assert.Equal(t, int64(0), l0["port"]) // 0 on first create, webhook assigns
-
-		// Verify allowedRoutes scoped to same namespace (XLS and TCPRoute co-located)
-		fromMode, _, _ := unstructured.NestedString(l0, "allowedRoutes", "namespaces", "from")
-		assert.Equal(t, "Same", fromMode)
-
-		// Verify TCPRoute
-		tcpRoute := &unstructured.Unstructured{}
-		tcpRoute.SetAPIVersion("gateway.networking.k8s.io/v1alpha2")
-		tcpRoute.SetKind("TCPRoute")
-		require.NoError(t, svc.GetDesiredKubeObject(tcpRoute, resourceBaseName+"-tcproute"))
-		assert.Equal(t, resourceBaseName, tcpRoute.GetName())
-		assert.Equal(t, instanceNs, tcpRoute.GetNamespace())
-
-		parentRefs, _, _ := unstructured.NestedSlice(tcpRoute.Object, "spec", "parentRefs")
-		require.Len(t, parentRefs, 1)
-		pRef := parentRefs[0].(map[string]any)
-		assert.Equal(t, "XListenerSet", pRef["kind"])
-		assert.Equal(t, resourceBaseName, pRef["name"])
-		assert.Equal(t, "ssh", pRef["sectionName"])
-		assert.Nil(t, pRef["namespace"], "parentRef must have no namespace (same-ns)")
-
-		rules, _, _ := unstructured.NestedSlice(tcpRoute.Object, "spec", "rules")
-		require.Len(t, rules, 1)
-		backendRefs := rules[0].(map[string]any)["backendRefs"].([]any)
-		require.Len(t, backendRefs, 1)
-		backend := backendRefs[0].(map[string]any)
-		assert.Equal(t, "Service", backend["kind"])
-		assert.Equal(t, resourceBaseName, backend["name"]) // <comp-name>-ssh
-		assert.Equal(t, instanceNs, backend["namespace"])
-		assert.Equal(t, int64(22), backend["port"])
-
-		// Verify Helm release does not have SSH enabled yet
-		release := &xhelmv1.Release{}
-		require.NoError(t, svc.GetDesiredComposedResourceByName(release, comp.GetName()))
-		values := getReleaseValues(t, *release)
-		serverConfig := values["gitea"].(map[string]any)["config"].(map[string]any)["server"].(map[string]any)
-		assert.Equal(t, true, serverConfig["DISABLE_SSH"], "SSH should stay disabled until a port is allocated")
-		assert.Nil(t, serverConfig["START_SSH_SERVER"], "START_SSH_SERVER should not be set until a port is allocated")
-
-		// Verify NetworkPolicy
-		netPol := &netv1.NetworkPolicy{}
-		require.NoError(t, svc.GetDesiredKubeObject(netPol, resourceBaseName+"-netpol"))
-		assert.Equal(t, resourceBaseName, netPol.Name)
-		assert.Equal(t, instanceNs, netPol.Namespace)
-		assert.Equal(t, "forgejo", netPol.Spec.PodSelector.MatchLabels["app.kubernetes.io/name"])
-		assert.Equal(t, comp.GetName(), netPol.Spec.PodSelector.MatchLabels["app.kubernetes.io/instance"], "NetworkPolicy should target Forgejo pods")
-		require.Len(t, netPol.Spec.Ingress, 1)
-		require.Len(t, netPol.Spec.Ingress[0].From, 1)
-		assert.Equal(t, "gateway-system", netPol.Spec.Ingress[0].From[0].NamespaceSelector.MatchLabels["kubernetes.io/metadata.name"])
-		require.Len(t, netPol.Spec.Ingress[0].Ports, 1)
-		assert.Equal(t, int32(2222), netPol.Spec.Ingress[0].Ports[0].Port.IntVal, "NetworkPolicy should allow traffic on the SSH pod listen port")
-
-	})
-
 	t.Run("SSHEnabled_GatewayConfigMissing_WarningResult", func(t *testing.T) {
 		svc, comp := bootstrapSSHTestFromFixture(t, "vshnforgejo/02_ssh.yaml")
 
@@ -124,24 +39,14 @@ func TestSSH(t *testing.T) {
 
 		result := ConfigureSSHAccess(context.TODO(), comp, svc)
 		require.NotNil(t, result)
-		assert.Contains(t, result.Message, "sshGatewayNamespace or sshGateways is not configured")
+		assert.Contains(t, result.Message, "is not configured")
 	})
 
-	t.Run("AllocatedPortPreserved_OnSubsequentReconcile", func(t *testing.T) {
+	t.Run("AllocatedPortPreserved_HelmAndConnectionDetails", func(t *testing.T) {
 		svc, comp := bootstrapSSHTestFromFixture(t, "vshnforgejo/02_ssh_with_port.yaml")
 
 		result := ConfigureSSHAccess(context.TODO(), comp, svc)
 		assert.Nil(t, result)
-
-		// Verify the desired XListenerSet preserves the allocated port
-		xls := &unstructured.Unstructured{}
-		xls.SetAPIVersion("gateway.networking.x-k8s.io/v1alpha1")
-		xls.SetKind("XListenerSet")
-		require.NoError(t, svc.GetDesiredKubeObject(xls, comp.GetName()+"-ssh"))
-		listeners, _, _ := unstructured.NestedSlice(xls.Object, "spec", "listeners")
-		require.Len(t, listeners, 1)
-		l0 := listeners[0].(map[string]any)
-		assert.Equal(t, int64(10005), l0["port"])
 
 		// Verify Helm release has SSH settings
 		release := &xhelmv1.Release{}
@@ -160,29 +65,12 @@ func TestSSH(t *testing.T) {
 		assert.Equal(t, "10005", string(cd["FORGEJO_SSH_PORT"]))
 	})
 
-	t.Run("AllocatedGatewayPreserved_OnSubsequentReconcile", func(t *testing.T) {
+	t.Run("AllocatedGatewayPreserved_ConnectionDetails", func(t *testing.T) {
 		// Observed XListenerSet has gateway tcp-gateway-2 (different from config's tcp-gateway)
 		svc, comp := bootstrapSSHTestFromFixture(t, "vshnforgejo/02_ssh_with_port_sharded.yaml")
 
 		result := ConfigureSSHAccess(context.TODO(), comp, svc)
 		assert.Nil(t, result)
-
-		// Verify the desired XListenerSet preserves the observed gateway
-		xls := &unstructured.Unstructured{}
-		xls.SetAPIVersion("gateway.networking.x-k8s.io/v1alpha1")
-		xls.SetKind("XListenerSet")
-		require.NoError(t, svc.GetDesiredKubeObject(xls, comp.GetName()+"-ssh"))
-
-		parentName, _, _ := unstructured.NestedString(xls.Object, "spec", "parentRef", "name")
-		parentNs, _, _ := unstructured.NestedString(xls.Object, "spec", "parentRef", "namespace")
-		assert.Equal(t, "tcp-gateway-2", parentName, "gateway name should be preserved from observed state")
-		assert.Equal(t, "gateway-system", parentNs)
-
-		// Port should still be preserved
-		listeners, _, _ := unstructured.NestedSlice(xls.Object, "spec", "listeners")
-		require.Len(t, listeners, 1)
-		l0 := listeners[0].(map[string]any)
-		assert.Equal(t, int64(10005), l0["port"])
 
 		// Verify connection details use the sharded gateway's domain
 		cd := svc.GetConnectionDetails()

--- a/pkg/comp-functions/runtime/function_mgr.go
+++ b/pkg/comp-functions/runtime/function_mgr.go
@@ -60,7 +60,7 @@ const (
 	WebhookAllowDeletionLabel         = "appcat.vshn.io/webhook-allowdeletion"
 	IgnoreConnectionDetailsAnnotation = "appcat.vshn.io/ignore-connection-details"
 	LastReconcileAnnotation           = "appcat.vshn.io/reconciled-on"
-	SSHGatewayLabel                   = "appcat.vshn.io/sshgateway"
+	TCPGatewayLabel                   = "appcat.vshn.io/tcpgateway"
 
 	ResourceReady   ResourceReadiness = ResourceReadiness(resource.ReadyTrue)
 	ResourceUnReady ResourceReadiness = ResourceReadiness(resource.ReadyFalse)
@@ -144,7 +144,6 @@ func init() {
 
 // RunFunction implements the crossplane composition function `FunctionRunnerServiceServer` interface.
 func (m Manager) RunFunction(ctx context.Context, req *fnv1.RunFunctionRequest) (*fnv1.RunFunctionResponse, error) {
-
 	if m.proxyMode {
 		return m.proxyFunction(ctx, req)
 	}
@@ -264,7 +263,6 @@ func (m *Manager) executeStep(ctx context.Context, obj client.Object, sr *Servic
 }
 
 func (m *Manager) proxyFunction(ctx context.Context, req *fnv1.RunFunctionRequest) (*fnv1.RunFunctionResponse, error) {
-
 	m.log.Info("Proxying request")
 
 	// errResp is only used to return a valid response in case of errors
@@ -321,7 +319,6 @@ func (m *Manager) proxyFunction(ctx context.Context, req *fnv1.RunFunctionReques
 
 // NewServiceRuntime returns a new runtime for a given service.
 func NewServiceRuntime(l logr.Logger, config corev1.ConfigMap, req *fnv1.RunFunctionRequest) (*ServiceRuntime, error) {
-
 	desiredResources, err := request.GetDesiredComposedResources(req)
 	if err != nil {
 		return &ServiceRuntime{}, err
@@ -366,7 +363,6 @@ func NewServiceRuntime(l logr.Logger, config corev1.ConfigMap, req *fnv1.RunFunc
 // If at any time s.SetRespones() was called, then this function will
 // return the set response.
 func (s *ServiceRuntime) GetResponse() (*fnv1.RunFunctionResponse, error) {
-
 	if s.resp != nil {
 		return s.resp, nil
 	}
@@ -422,7 +418,6 @@ func (s *ServiceRuntime) SetDesiredComposedResource(obj xpresource.Managed, opts
 // Usually needed for objects that where migrated from P+T compositions with a static name.
 // Additionally it injects the claim-name, claim-namespace and the composite name as a label.
 func (s *ServiceRuntime) SetDesiredComposedResourceWithName(obj xpresource.Managed, name string, opts ...ComposedResourceOption) error {
-
 	s.addOwnerReferenceAnnotation(obj, true)
 
 	escapeK8sNames(obj)
@@ -474,7 +469,6 @@ func ComposedOptionProtects(resName string) ComposedResourceOption {
 // SetDesiredKubeObject takes any `runtime.Object`, puts it into a provider-kubernetes Object and then
 // adds it to the desired composed resources. It takes options to manipulate the resulting kube object before applying.
 func (s *ServiceRuntime) SetDesiredKubeObject(obj client.Object, objectName string, opts ...KubeObjectOption) error {
-
 	kobj, err := s.putIntoObject(obj, objectName, objectName)
 	if err != nil {
 		return err
@@ -493,7 +487,6 @@ func (s *ServiceRuntime) SetDesiredKubeObject(obj client.Object, objectName stri
 // adds it to the desired composed resources with the specified resource name.
 // This should be used if manipulating objects that are declared in the P+T composition.
 func (s *ServiceRuntime) SetDesiredKubeObjectWithName(obj client.Object, objectName, resourceName string, opts ...KubeObjectOption) error {
-
 	kobj, err := s.putIntoObject(obj, objectName, resourceName)
 	if err != nil {
 		return err
@@ -1016,7 +1009,6 @@ func (s *ServiceRuntime) checkReadiness() error {
 	s.desiredResources = desired
 
 	return nil
-
 }
 
 // GetAllObserved returns a map of all observed resources.
@@ -1042,7 +1034,6 @@ func (s *ServiceRuntime) SetAllDesired(resources map[resource.Name]*resource.Des
 // The only differences from the observed composite will be either in metadata or the status.
 // As Crossplane 1.14 composition function forbid any changes other than those fields.
 func (s *ServiceRuntime) GetDesiredComposite(obj client.Object) error {
-
 	jsonBytes, err := s.desiredComposite.MarshalJSON()
 	if err != nil {
 		return err
@@ -1442,7 +1433,6 @@ func (s *ServiceRuntime) GetCrossplaneNamespace() string {
 // crossplane namespace and also deploy a copy of that to the instance namespace.
 // It will prefix the secret name with the composite name, to ensure that no secret names clash in the crossplane namespace.
 func (s *ServiceRuntime) deployConnectionDetailsToInstanceNS() error {
-
 	for i := range s.desiredResources {
 		cdRef := s.desiredResources[i].Resource.GetWriteConnectionSecretToReference()
 		if cdRef == nil {

--- a/pkg/controller/webhooks/tcpgateway/allocator.go
+++ b/pkg/controller/webhooks/tcpgateway/allocator.go
@@ -1,4 +1,4 @@
-package sshgateway
+package tcpgateway
 
 import (
 	"context"
@@ -76,9 +76,9 @@ func (a *PortAllocator) AllocatePort(ctx context.Context, usedPorts map[int32]bo
 
 		lease := &coordinationv1.Lease{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      fmt.Sprintf("ssh-port-%d", port),
+				Name:      fmt.Sprintf("tcp-port-%d", port),
 				Namespace: namespace,
-				Labels:    map[string]string{"app.kubernetes.io/managed-by": "sshgateway-port-allocator"},
+				Labels:    map[string]string{"app.kubernetes.io/managed-by": "tcpgateway-port-allocator"},
 			},
 			Spec: coordinationv1.LeaseSpec{
 				HolderIdentity: &holder,

--- a/pkg/controller/webhooks/tcpgateway/allocator_test.go
+++ b/pkg/controller/webhooks/tcpgateway/allocator_test.go
@@ -1,4 +1,4 @@
-package sshgateway
+package tcpgateway
 
 import (
 	"context"
@@ -172,7 +172,7 @@ func TestTryReclaimStaleLease_HolderGone(t *testing.T) {
 	oldTime := metav1.NewMicroTime(time.Now().Add(-5 * time.Minute))
 	lease := &coordinationv1.Lease{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("ssh-port-%d", 10000),
+			Name:      fmt.Sprintf("tcp-port-%d", 10000),
 			Namespace: "test-ns",
 		},
 		Spec: coordinationv1.LeaseSpec{
@@ -195,7 +195,7 @@ func TestTryReclaimStaleLease_HolderExists(t *testing.T) {
 	holder := "vshn-forgejo-test/existing-xls"
 	lease := &coordinationv1.Lease{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("ssh-port-%d", 10000),
+			Name:      fmt.Sprintf("tcp-port-%d", 10000),
 			Namespace: "test-ns",
 		},
 		Spec: coordinationv1.LeaseSpec{
@@ -214,7 +214,7 @@ func TestTryReclaimStaleLease_HolderExists(t *testing.T) {
 func TestTryReclaimStaleLease_NoHolderIdentity(t *testing.T) {
 	lease := &coordinationv1.Lease{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("ssh-port-%d", 10000),
+			Name:      fmt.Sprintf("tcp-port-%d", 10000),
 			Namespace: "test-ns",
 		},
 		Spec: coordinationv1.LeaseSpec{},
@@ -235,7 +235,7 @@ func TestTryReclaimStaleLease_HolderGoneButRecent(t *testing.T) {
 	now := metav1.NewMicroTime(time.Now())
 	lease := &coordinationv1.Lease{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("ssh-port-%d", 10000),
+			Name:      fmt.Sprintf("tcp-port-%d", 10000),
 			Namespace: "test-ns",
 		},
 		Spec: coordinationv1.LeaseSpec{

--- a/pkg/controller/webhooks/tcpgateway/handler.go
+++ b/pkg/controller/webhooks/tcpgateway/handler.go
@@ -1,4 +1,4 @@
-package sshgateway
+package tcpgateway
 
 import (
 	"context"
@@ -34,7 +34,7 @@ func SetupXListenerSetWebhookWithManager(mgr ctrl.Manager, portRangeStart, portR
 	allocator := NewPortAllocator(mgr.GetClient(), portRangeStart, portRangeEnd)
 	handler := &XListenerSetHandler{
 		allocator: allocator,
-		log:       mgr.GetLogger().WithName("webhook").WithName("xlistenerset-sshgateway"),
+		log:       mgr.GetLogger().WithName("webhook").WithName("xlistenerset-tcpgateway"),
 		leaseNS:   gatewayNS,
 	}
 

--- a/pkg/controller/webhooks/tcpgateway/handler_test.go
+++ b/pkg/controller/webhooks/tcpgateway/handler_test.go
@@ -1,4 +1,4 @@
-package sshgateway
+package tcpgateway
 
 import (
 	"context"

--- a/pkg/controller/webhooks/tcpgateway/sharding.go
+++ b/pkg/controller/webhooks/tcpgateway/sharding.go
@@ -1,4 +1,4 @@
-package sshgateway
+package tcpgateway
 
 import (
 	"fmt"

--- a/pkg/controller/webhooks/tcpgateway/sharding_test.go
+++ b/pkg/controller/webhooks/tcpgateway/sharding_test.go
@@ -1,4 +1,4 @@
-package sshgateway
+package tcpgateway
 
 import (
 	"context"

--- a/test/functions/tcproute/01_basic.yaml
+++ b/test/functions/tcproute/01_basic.yaml
@@ -1,0 +1,35 @@
+desired: {}
+input:
+  apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    annotations: {}
+    labels:
+      name: xfn-config
+    name: xfn-config
+  data:
+    defaultPlan: mini
+    controlNamespace: appcat-control
+    sshGatewayNamespace: gateway-system
+    sshGateways: '{"tcp-gateway":"tcp.example.com"}'
+    plans: |
+      {}
+observed:
+  composite:
+    resource:
+      apiVersion: vshn.appcat.vshn.io/v1
+      kind: XVSHNForgejo
+      metadata:
+        name: test-comp
+      spec:
+        parameters:
+          service:
+            ssh:
+              enabled: true
+            fqdn: []
+            majorVersion: "1.0.0"
+        claimRef:
+          apiVersion: vshn.appcat.vshn.io/v1
+          kind: VSHNForgejo
+          name: test
+          namespace: unit-test

--- a/test/functions/tcproute/02_with_port.yaml
+++ b/test/functions/tcproute/02_with_port.yaml
@@ -1,0 +1,66 @@
+desired: {}
+input:
+  apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    annotations: {}
+    labels:
+      name: xfn-config
+    name: xfn-config
+  data:
+    defaultPlan: mini
+    controlNamespace: appcat-control
+    sshGatewayNamespace: gateway-system
+    sshGateways: '{"tcp-gateway":"tcp.example.com"}'
+    plans: |
+      {}
+observed:
+  composite:
+    resource:
+      apiVersion: vshn.appcat.vshn.io/v1
+      kind: XVSHNForgejo
+      metadata:
+        name: test-comp
+      spec:
+        parameters:
+          service:
+            ssh:
+              enabled: true
+            fqdn: []
+            majorVersion: "1.0.0"
+        claimRef:
+          apiVersion: vshn.appcat.vshn.io/v1
+          kind: VSHNForgejo
+          name: test
+          namespace: unit-test
+  resources:
+    my-service-tcp:
+      resource:
+        apiVersion: kubernetes.crossplane.io/v1alpha2
+        kind: Object
+        metadata:
+          name: my-service-tcp
+        status:
+          atProvider:
+            manifest:
+              apiVersion: gateway.networking.x-k8s.io/v1alpha1
+              kind: XListenerSet
+              metadata:
+                name: my-service-tcp
+                namespace: gateway-system
+              spec:
+                parentRef:
+                  group: gateway.networking.k8s.io
+                  kind: Gateway
+                  namespace: gateway-system
+                  name: tcp-gateway
+                listeners:
+                  - name: tcp
+                    port: 10005
+                    protocol: TCP
+                    allowedRoutes:
+                      kinds:
+                        - kind: TCPRoute
+                          group: gateway.networking.k8s.io
+                      namespaces:
+                        from: All

--- a/test/functions/tcproute/03_sharded.yaml
+++ b/test/functions/tcproute/03_sharded.yaml
@@ -1,0 +1,66 @@
+desired: {}
+input:
+  apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    annotations: {}
+    labels:
+      name: xfn-config
+    name: xfn-config
+  data:
+    defaultPlan: mini
+    controlNamespace: appcat-control
+    sshGatewayNamespace: gateway-system
+    sshGateways: '{"tcp-gateway":"tcp.example.com","tcp-gateway-2":"tcp2.example.com"}'
+    plans: |
+      {}
+observed:
+  composite:
+    resource:
+      apiVersion: vshn.appcat.vshn.io/v1
+      kind: XVSHNForgejo
+      metadata:
+        name: test-comp
+      spec:
+        parameters:
+          service:
+            ssh:
+              enabled: true
+            fqdn: []
+            majorVersion: "1.0.0"
+        claimRef:
+          apiVersion: vshn.appcat.vshn.io/v1
+          kind: VSHNForgejo
+          name: test
+          namespace: unit-test
+  resources:
+    my-service-tcp:
+      resource:
+        apiVersion: kubernetes.crossplane.io/v1alpha2
+        kind: Object
+        metadata:
+          name: my-service-tcp
+        status:
+          atProvider:
+            manifest:
+              apiVersion: gateway.networking.x-k8s.io/v1alpha1
+              kind: XListenerSet
+              metadata:
+                name: my-service-tcp
+                namespace: gateway-system
+              spec:
+                parentRef:
+                  group: gateway.networking.k8s.io
+                  kind: Gateway
+                  namespace: gateway-system
+                  name: tcp-gateway-2
+                listeners:
+                  - name: tcp
+                    port: 10005
+                    protocol: TCP
+                    allowedRoutes:
+                      kinds:
+                        - kind: TCPRoute
+                          group: gateway.networking.k8s.io
+                      namespaces:
+                        from: All


### PR DESCRIPTION
## Summary

* This generalizes Forgejo's SSH TCPRoute handler so it can be used with other services as well
## Checklist

- [ ] Update tests.
- [ ] Link this PR to related issues.
- [ ] Merge with `/merge` comment.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
