### PR TITLE
Rework guaranteed availability webhook

### DIFF
--- a/apis/vshn/v1/vshn_nextcloud.go
+++ b/apis/vshn/v1/vshn_nextcloud.go
@@ -94,7 +94,7 @@ type VSHNNextcloudParameters struct {
 
 	// +kubebuilder:default=1
 	// +kubebuilder:validation:Minimum=0
-	// +kubebuilder:validation:Maximum=3
+	// +kubebuilder:validation:Maximum=1
 
 	// Instances configures the number of Nextcloud instances for the cluster.
 	// Each instance contains one Nextcloud server.

--- a/config/controller/webhooks.yaml
+++ b/config/controller/webhooks.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:

--- a/crds/vshn.appcat.vshn.io_vshnnextclouds.yaml
+++ b/crds/vshn.appcat.vshn.io_vshnnextclouds.yaml
@@ -151,7 +151,7 @@ spec:
                       description: |-
                         Instances configures the number of Nextcloud instances for the cluster.
                         Each instance contains one Nextcloud server.
-                      maximum: 3
+                      maximum: 1
                       minimum: 0
                       type: integer
                     maintenance:

--- a/crds/vshn.appcat.vshn.io_xvshnnextclouds.yaml
+++ b/crds/vshn.appcat.vshn.io_xvshnnextclouds.yaml
@@ -199,7 +199,7 @@ spec:
                     description: |-
                       Instances configures the number of Nextcloud instances for the cluster.
                       Each instance contains one Nextcloud server.
-                    maximum: 3
+                    maximum: 1
                     minimum: 0
                     type: integer
                   maintenance:

--- a/pkg/controller/webhooks/default_handler.go
+++ b/pkg/controller/webhooks/default_handler.go
@@ -145,6 +145,8 @@ func (r *DefaultWebhookHandler) ValidateCreate(ctx context.Context, obj runtime.
 		allErrs.Add(err)
 	}
 
+	allErrs.Add(r.checkGuaranteedAvailability(comp)...)
+
 	warn := checkManualVersionManagementWarnings(comp.GetFullMaintenanceSchedule())
 	return warn, allErrs.Get()
 }
@@ -189,6 +191,8 @@ func (r *DefaultWebhookHandler) ValidateUpdate(ctx context.Context, oldObj, newO
 			})
 		}
 	}
+
+	allErrs.Add(r.checkGuaranteedAvailability(comp)...)
 
 	warn := checkManualVersionManagementWarnings(comp.GetFullMaintenanceSchedule())
 	return warn, allErrs.Get()
@@ -615,6 +619,19 @@ func (r *DefaultWebhookHandler) getEffectiveDiskSize(ctx context.Context, comp c
 
 	// No disk size configured
 	return "", nil
+}
+
+func (r *DefaultWebhookHandler) checkGuaranteedAvailability(comp common.Composite) field.ErrorList {
+	allErrs := field.ErrorList{}
+	if comp.GetSLA() == string(vshnv1.Guaranteed) && comp.GetInstances() > 0 && comp.GetInstances() < 2 {
+		name := strings.TrimPrefix(r.gk.Kind, "VSHN")
+		allErrs = append(allErrs, field.Invalid(
+			field.NewPath("spec", "parameters", "instances"),
+			comp.GetInstances(),
+			fmt.Sprintf("%s instances with service level Guaranteed Availability must have at least 2 replicas. Please set spec.parameters.instances to 2 or more. Additional costs will apply, please refer to: https://products.vshn.ch/appcat/pricing.html", name),
+		))
+	}
+	return allErrs
 }
 
 // checkManualVersionManagementWarnings returns warnings if manual version management flags are enabled

--- a/pkg/controller/webhooks/default_handler.go
+++ b/pkg/controller/webhooks/default_handler.go
@@ -628,7 +628,7 @@ func (r *DefaultWebhookHandler) checkGuaranteedAvailability(comp common.Composit
 		allErrs = append(allErrs, field.Invalid(
 			field.NewPath("spec", "parameters", "instances"),
 			comp.GetInstances(),
-			fmt.Sprintf("%s instances with service level Guaranteed Availability must have at least 2 replicas. Please set spec.parameters.instances to 2 or more. Additional costs will apply, please refer to: https://products.vshn.ch/appcat/pricing.html", name),
+			fmt.Sprintf("%s instances with service level Guaranteed Availability must have more than 1 replicas. Please set spec.parameters.instances to accordingly, depending on your service. Additional costs will apply, please refer to: https://products.vshn.ch/appcat/pricing.html", name),
 		))
 	}
 	return allErrs

--- a/pkg/controller/webhooks/default_handler_test.go
+++ b/pkg/controller/webhooks/default_handler_test.go
@@ -130,6 +130,27 @@ func TestSetupWebhookHandlerWithManager_ValidateCreate(t *testing.T) {
 	keycloakInvalid.Spec.Parameters.Size.Disk = "foo"
 	_, err = handler.ValidateCreate(ctx, keycloakInvalid)
 	assert.Error(t, err)
+
+	// Guaranteed availability: 1 instance with guaranteed SLA must fail
+	keycloakInvalid = keycloakOrig.DeepCopy()
+	keycloakInvalid.Spec.Parameters.Instances = 1
+	keycloakInvalid.Spec.Parameters.Service.ServiceLevel = vshnv1.Guaranteed
+	_, err = handler.ValidateCreate(ctx, keycloakInvalid)
+	assert.Error(t, err)
+
+	// Guaranteed availability: 2 instances with guaranteed SLA must pass
+	keycloakValid := keycloakOrig.DeepCopy()
+	keycloakValid.Spec.Parameters.Instances = 2
+	keycloakValid.Spec.Parameters.Service.ServiceLevel = vshnv1.Guaranteed
+	_, err = handler.ValidateCreate(ctx, keycloakValid)
+	assert.NoError(t, err)
+
+	// Guaranteed availability: 0 instances (suspended) with guaranteed SLA must pass
+	keycloakValid = keycloakOrig.DeepCopy()
+	keycloakValid.Spec.Parameters.Instances = 0
+	keycloakValid.Spec.Parameters.Service.ServiceLevel = vshnv1.Guaranteed
+	_, err = handler.ValidateCreate(ctx, keycloakValid)
+	assert.NoError(t, err)
 }
 
 func TestSetupWebhookHandlerWithManager_ValidateDelete(t *testing.T) {

--- a/pkg/controller/webhooks/postgresql.go
+++ b/pkg/controller/webhooks/postgresql.go
@@ -172,7 +172,7 @@ func (p *PostgreSQLWebhookHandler) validatePostgreSQL(ctx context.Context, newOb
 	}
 
 	// Validate guaranteed availability
-	allErrs.Add(p.checkGuaranteedAvailability(newPg)...)
+	allErrs.Add(p.DefaultWebhookHandler.checkGuaranteedAvailability(newPg)...)
 
 	// Validate name length
 	if err := p.validateResourceNameLength(newPg.GetName()); err != nil {
@@ -320,20 +320,6 @@ func parseResource(childPath *field.Path, value, errMessage string) (resource.Qu
 		return quantity, field.Invalid(childPath, value, errMessage)
 	}
 	return quantity, nil
-}
-
-func (p *PostgreSQLWebhookHandler) checkGuaranteedAvailability(pg *vshnv1.VSHNPostgreSQL) field.ErrorList {
-	allErrs := field.ErrorList{}
-	// Allow instances=0 (suspended) regardless of service level
-	// Only enforce guaranteed availability (>=2 instances) when service is running (instances > 0)
-	if pg.Spec.Parameters.Service.ServiceLevel == "guaranteed" && pg.Spec.Parameters.Instances > 0 && pg.Spec.Parameters.Instances < 2 {
-		allErrs = append(allErrs, field.Invalid(
-			field.NewPath("spec.parameters.instances"),
-			pg.Spec.Parameters.Instances,
-			"PostgreSQL instances with service level Guaranteed Availability must have at least 2 replicas. Please set .spec.parameters.instances: [2,3]. Additional costs will apply, please refer to: https://products.vshn.ch/appcat/pricing.html",
-		))
-	}
-	return allErrs
 }
 
 func validateVacuumRepack(vacuum, repack bool) *field.Error {


### PR DESCRIPTION
## Summary

* This PR reworks the guaranteed availability webhook to support all services
* It also restricts Nextcloud to 1 replica, since we currently don't support HA for nextcloud yet

## Checklist

- [x] Update tests.
- [ ] Link this PR to related issues.
- [ ] Merge with `/merge` comment.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->


Component PR: https://github.com/vshn/component-appcat/pull/1162