### PR TITLE
Fix gateway sharding to respect per-service gateway groups

### DIFF
--- a/pkg/comp-functions/functions/common/tcproute/tcproute.go
+++ b/pkg/comp-functions/functions/common/tcproute/tcproute.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"strings"
 
 	xfnproto "github.com/crossplane/function-sdk-go/proto/v1"
 	"github.com/vshn/appcat/v4/pkg/common/utils"
@@ -49,7 +50,9 @@ func AddTCPRoute(svc *runtime.ServiceRuntime, cfg TCPRouteConfig) (*xfnproto.Res
 		effectiveGatewayNamespace = observed.GatewayNamespace
 	}
 
-	err := createXListenerSet(svc, cfg, effectiveGatewayNamespace, effectiveGatewayName, observed.Port)
+	gwNames := allGatewayNames(svc, cfg.GatewaysConfigKey)
+
+	err := createXListenerSet(svc, cfg, effectiveGatewayNamespace, effectiveGatewayName, observed.Port, gwNames)
 	if err != nil {
 		return runtime.NewWarningResult(fmt.Sprintf("cannot create XListenerSet: %s", err)), observed
 	}
@@ -69,7 +72,7 @@ func AddTCPRoute(svc *runtime.ServiceRuntime, cfg TCPRouteConfig) (*xfnproto.Res
 	return nil, observed
 }
 
-func createXListenerSet(svc *runtime.ServiceRuntime, cfg TCPRouteConfig, gatewayNamespace, gatewayName string, port int32) error {
+func createXListenerSet(svc *runtime.ServiceRuntime, cfg TCPRouteConfig, gatewayNamespace, gatewayName string, port int32, allowedGateways []string) error {
 	xls := &unstructured.Unstructured{
 		Object: map[string]any{},
 	}
@@ -80,6 +83,12 @@ func createXListenerSet(svc *runtime.ServiceRuntime, cfg TCPRouteConfig, gateway
 	xls.SetLabels(map[string]string{
 		runtime.TCPGatewayLabel: "true",
 	})
+	if len(allowedGateways) > 0 {
+		sort.Strings(allowedGateways)
+		xls.SetAnnotations(map[string]string{
+			runtime.TCPGatewayAllowedAnnotation: strings.Join(allowedGateways, ","),
+		})
+	}
 
 	err := unstructured.SetNestedMap(xls.Object, map[string]any{
 		"group":     "gateway.networking.k8s.io",
@@ -242,36 +251,43 @@ func observeXListenerSet(svc *runtime.ServiceRuntime, name string) ObservedState
 	return state
 }
 
+// getRawGateways parses the JSON gateway config into a name->domain map.
+func getRawGateways(svc *runtime.ServiceRuntime, configKey string) map[string]string {
+	raw, ok := svc.Config.Data[configKey]
+	if !ok || raw == "" {
+		return nil
+	}
+
+	mapping := map[string]string{}
+	if err := json.Unmarshal([]byte(raw), &mapping); err != nil {
+		svc.Log.Error(err, "failed to parse gateways config", "key", configKey)
+		return nil
+	}
+
+	return mapping
+}
+
 // lookupDomain resolves the domain for a given gateway name from the
 // gateways config value.
 func lookupDomain(svc *runtime.ServiceRuntime, configKey, gatewayName string) string {
-	raw := svc.Config.Data[configKey]
-	if raw == "" {
+	mapping := getRawGateways(svc, configKey)
+	if mapping == nil {
 		return ""
 	}
-
-	mapping := map[string]string{}
-	if err := json.Unmarshal([]byte(raw), &mapping); err != nil {
-		svc.Log.Error(err, "failed to parse gateways config", "key", configKey)
-		svc.AddResult(runtime.NewFatalResult(fmt.Errorf("failed to parse gateways: %w", err)))
-		return ""
-	}
-
 	return mapping[gatewayName]
 }
 
+func allGatewayNames(svc *runtime.ServiceRuntime, configKey string) []string {
+	mapping := getRawGateways(svc, configKey)
+	names := make([]string, 0, len(mapping))
+	for name := range mapping {
+		names = append(names, name)
+	}
+	return names
+}
+
 func defaultGatewayName(svc *runtime.ServiceRuntime, configKey string) string {
-	raw, ok := svc.Config.Data[configKey]
-	if !ok || raw == "" {
-		return ""
-	}
-
-	mapping := map[string]string{}
-	if err := json.Unmarshal([]byte(raw), &mapping); err != nil {
-		svc.Log.Error(err, "failed to parse gateways config", "key", configKey)
-		return ""
-	}
-
+	mapping := getRawGateways(svc, configKey)
 	names := make([]string, 0, len(mapping))
 	for name := range mapping {
 		names = append(names, name)

--- a/pkg/comp-functions/functions/common/tcproute/tcproute_test.go
+++ b/pkg/comp-functions/functions/common/tcproute/tcproute_test.go
@@ -48,6 +48,10 @@ func TestAddTCPRoute(t *testing.T) {
 		assert.Equal(t, "tcp-gateway", parentName)
 		assert.Equal(t, "gateway-system", parentNs)
 
+		// Verify allowed-gateways annotation
+		ann := xls.GetAnnotations()
+		assert.Equal(t, "tcp-gateway", ann["appcat.vshn.io/allowed-gateways"])
+
 		listeners, found, _ := unstructured.NestedSlice(xls.Object, "spec", "listeners")
 		require.True(t, found)
 		require.Len(t, listeners, 1)
@@ -155,6 +159,10 @@ func TestAddTCPRoute(t *testing.T) {
 		parentNs, _, _ := unstructured.NestedString(xls.Object, "spec", "parentRef", "namespace")
 		assert.Equal(t, "tcp-gateway-2", parentName)
 		assert.Equal(t, "gateway-system", parentNs)
+
+		// Verify allowed-gateways annotation contains both gateways (sorted)
+		ann := xls.GetAnnotations()
+		assert.Equal(t, "tcp-gateway,tcp-gateway-2", ann["appcat.vshn.io/allowed-gateways"])
 	})
 
 	t.Run("NoResources_WhenNotCalled", func(t *testing.T) {

--- a/pkg/comp-functions/runtime/function_mgr.go
+++ b/pkg/comp-functions/runtime/function_mgr.go
@@ -60,6 +60,7 @@ const (
 	WebhookAllowDeletionLabel         = "appcat.vshn.io/webhook-allowdeletion"
 	IgnoreConnectionDetailsAnnotation = "appcat.vshn.io/ignore-connection-details"
 	LastReconcileAnnotation           = "appcat.vshn.io/reconciled-on"
+	TCPGatewayAllowedAnnotation       = "appcat.vshn.io/allowed-gateways"
 	TCPGatewayLabel                   = "appcat.vshn.io/tcpgateway"
 
 	ResourceReady   ResourceReadiness = ResourceReadiness(resource.ReadyTrue)

--- a/pkg/controller/webhooks/tcpgateway/handler.go
+++ b/pkg/controller/webhooks/tcpgateway/handler.go
@@ -5,9 +5,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/go-logr/logr"
 	"github.com/vshn/appcat/v4/pkg/common/utils"
+	"github.com/vshn/appcat/v4/pkg/comp-functions/runtime"
 	admissionv1 "k8s.io/api/admission/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -99,8 +101,10 @@ func (h *XListenerSetHandler) Handle(ctx context.Context, req admission.Request)
 			Name:      parentName,
 		}
 
+		allowedGateways := parseAllowedGateways(metadata, parentNs)
+
 		listeners, _ := spec["listeners"].([]any)
-		selected, changed, err := h.sharding.SelectGateway(currentRef, len(listeners), listenerCounts)
+		selected, changed, err := h.sharding.SelectGateway(currentRef, len(listeners), listenerCounts, allowedGateways)
 		if err != nil {
 			l.Info("All gateways full, denying admission", "error", err.Error())
 			return admission.Denied(fmt.Sprintf("cannot place XListenerSet: %s", err))
@@ -151,4 +155,23 @@ func (h *XListenerSetHandler) Handle(ctx context.Context, req admission.Request)
 	}
 
 	return admission.PatchResponseFromRaw(req.Object.Raw, patched)
+}
+
+// parseAllowedGateways reads the allowed-gateways annotation and returns
+// GatewayKey entries scoped to gatewayNS. Returns nil if annotation is absent.
+func parseAllowedGateways(metadata map[string]any, gatewayNS string) []GatewayKey {
+	annotations, _ := metadata["annotations"].(map[string]any)
+	raw, _ := annotations[runtime.TCPGatewayAllowedAnnotation].(string)
+	if raw == "" {
+		return nil
+	}
+
+	var keys []GatewayKey
+	for _, name := range strings.Split(raw, ",") {
+		name = strings.TrimSpace(name)
+		if name != "" {
+			keys = append(keys, GatewayKey{Namespace: gatewayNS, Name: name})
+		}
+	}
+	return keys
 }

--- a/pkg/controller/webhooks/tcpgateway/handler_test.go
+++ b/pkg/controller/webhooks/tcpgateway/handler_test.go
@@ -329,6 +329,65 @@ func TestHandle_AllGatewaysFull_Denied(t *testing.T) {
 	assert.Contains(t, resp.Result.Message, "all gateways are full")
 }
 
+func TestHandle_ShardingRespectsAllowedGateways(t *testing.T) {
+	// gw-1 full, gw-2 has room, gw-3 has room.
+	// XListenerSet annotation only allows gw-1 and gw-3.
+	// Should shard to gw-3, not gw-2.
+	existingXLS := []*unstructured.Unstructured{
+		newXListenerSetWithGateway("existing", "ns", "gw-1", "gw-ns", 10000, 10001, 10002, 10003, 10004, 10005, 10006, 10007, 10008, 10009),
+	}
+	gateways := []GatewayKey{
+		{Namespace: "gw-ns", Name: "gw-1"},
+		{Namespace: "gw-ns", Name: "gw-2"},
+		{Namespace: "gw-ns", Name: "gw-3"},
+	}
+
+	handler := newTestHandlerWithSharding(t, 10, existingXLS, gateways)
+
+	xls := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "gateway.networking.x-k8s.io/v1alpha1",
+			"kind":       "XListenerSet",
+			"metadata": map[string]any{
+				"name":      "new",
+				"namespace": "ns",
+				"annotations": map[string]any{
+					"appcat.vshn.io/allowed-gateways": "gw-1,gw-3",
+				},
+			},
+			"spec": map[string]any{
+				"parentRef": map[string]any{
+					"group":     "gateway.networking.k8s.io",
+					"kind":      "Gateway",
+					"namespace": "gw-ns",
+					"name":      "gw-1",
+				},
+				"listeners": []any{
+					map[string]any{
+						"name":     "listener",
+						"port":     float64(0),
+						"protocol": "TCP",
+					},
+				},
+			},
+		},
+	}
+
+	raw, err := json.Marshal(xls)
+	require.NoError(t, err)
+
+	resp := handler.Handle(context.Background(), makeAdmissionRequest(t, xls))
+	assert.True(t, resp.Allowed)
+	assert.NotEmpty(t, resp.Patches)
+
+	patched := applyPatches(t, raw, resp)
+
+	gwName, found, err := unstructured.NestedString(patched.Object, "spec", "parentRef", "name")
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, "gw-3", gwName, "should shard to gw-3 (allowed), not gw-2 (not allowed)")
+}
+
 func TestHandle_MultipleReplicas_UniquePorts(t *testing.T) {
 	// simulates shared etcd across replicas.
 	scheme := k8sruntime.NewScheme()

--- a/pkg/controller/webhooks/tcpgateway/sharding.go
+++ b/pkg/controller/webhooks/tcpgateway/sharding.go
@@ -24,15 +24,21 @@ func NewGatewaySharding(gateways []GatewayKey, capacity int) *GatewaySharding {
 // SelectGateway determines which gateway should host the new XListenerSet.
 // If the current gateway has room, it returns unchanged.
 // Otherwise it picks the gateway with the fewest listeners that still has capacity.
-// Returns an error if all gateways are full.
-func (gs *GatewaySharding) SelectGateway(currentRef GatewayKey, newListenerCount int, listenerCounts map[GatewayKey]int) (GatewayKey, bool, error) {
-	if slices.Contains(gs.gateways, currentRef) && listenerCounts[currentRef]+newListenerCount <= gs.capacity {
+// If allowedGateways is non-empty, only those gateways are considered as candidates.
+// Returns an error if all candidate gateways are full.
+func (gs *GatewaySharding) SelectGateway(currentRef GatewayKey, newListenerCount int, listenerCounts map[GatewayKey]int, allowedGateways []GatewayKey) (GatewayKey, bool, error) {
+	candidates := gs.gateways
+	if len(allowedGateways) > 0 {
+		candidates = gs.filterAllowed(allowedGateways)
+	}
+
+	if slices.Contains(candidates, currentRef) && listenerCounts[currentRef]+newListenerCount <= gs.capacity {
 		return currentRef, false, nil
 	}
 
 	best := GatewayKey{}
 	bestCount := gs.capacity + 1
-	for _, gw := range gs.gateways {
+	for _, gw := range candidates {
 		count := listenerCounts[gw]
 		if count+newListenerCount <= gs.capacity && count < bestCount {
 			best = gw
@@ -45,4 +51,15 @@ func (gs *GatewaySharding) SelectGateway(currentRef GatewayKey, newListenerCount
 	}
 
 	return best, true, nil
+}
+
+// filterAllowed returns gateways present in both gs.gateways and allowed.
+func (gs *GatewaySharding) filterAllowed(allowed []GatewayKey) []GatewayKey {
+	var result []GatewayKey
+	for _, gw := range gs.gateways {
+		if slices.Contains(allowed, gw) {
+			result = append(result, gw)
+		}
+	}
+	return result
 }

--- a/pkg/controller/webhooks/tcpgateway/sharding_test.go
+++ b/pkg/controller/webhooks/tcpgateway/sharding_test.go
@@ -55,7 +55,7 @@ func TestSelectGateway_UnderCapacity_NoReassignment(t *testing.T) {
 	current := GatewayKey{Namespace: "gw-ns", Name: "gw-1"}
 	counts := map[GatewayKey]int{current: 5}
 
-	selected, changed, err := gs.SelectGateway(current, 1, counts)
+	selected, changed, err := gs.SelectGateway(current, 1, counts, nil)
 	require.NoError(t, err)
 	assert.False(t, changed)
 	assert.Equal(t, current, selected)
@@ -70,7 +70,7 @@ func TestSelectGateway_AtCapacity_Reassign(t *testing.T) {
 	current := GatewayKey{Namespace: "gw-ns", Name: "gw-1"}
 	counts := map[GatewayKey]int{current: 10}
 
-	selected, changed, err := gs.SelectGateway(current, 1, counts)
+	selected, changed, err := gs.SelectGateway(current, 1, counts, nil)
 	require.NoError(t, err)
 	assert.True(t, changed)
 	assert.Equal(t, GatewayKey{Namespace: "gw-ns", Name: "gw-2"}, selected)
@@ -88,7 +88,7 @@ func TestSelectGateway_AllFull_Error(t *testing.T) {
 		{Namespace: "gw-ns", Name: "gw-2"}: 2,
 	}
 
-	_, _, err := gs.SelectGateway(current, 1, counts)
+	_, _, err := gs.SelectGateway(current, 1, counts, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "all gateways are full")
 }
@@ -109,7 +109,7 @@ func TestSelectGateway_MultipleListenersMustFit(t *testing.T) {
 		}: 2,
 	}
 
-	selected, changed, err := gs.SelectGateway(current, 3, counts)
+	selected, changed, err := gs.SelectGateway(current, 3, counts, nil)
 	require.NoError(t, err)
 	assert.True(t, changed)
 	assert.Equal(t, GatewayKey{Namespace: "gw-ns", Name: "gw-2"}, selected)
@@ -131,7 +131,7 @@ func TestSelectGateway_LeastListeners(t *testing.T) {
 		{Namespace: "gw-ns", Name: "gw-3"}: 1,
 	}
 
-	selected, changed, err := gs.SelectGateway(current, 1, counts)
+	selected, changed, err := gs.SelectGateway(current, 1, counts, nil)
 	require.NoError(t, err)
 	assert.True(t, changed)
 	assert.Equal(t, GatewayKey{Namespace: "gw-ns", Name: "gw-3"}, selected)
@@ -150,10 +150,62 @@ func TestSelectGateway_UnknownCurrentRef_Reassigns(t *testing.T) {
 		{Namespace: "gw-ns", Name: "gw-2"}: 5,
 	}
 
-	selected, changed, err := gs.SelectGateway(unknown, 1, counts)
+	selected, changed, err := gs.SelectGateway(unknown, 1, counts, nil)
 	require.NoError(t, err)
 	assert.True(t, changed, "should reassign away from unknown gateway")
 	assert.Equal(t, GatewayKey{Namespace: "gw-ns", Name: "gw-1"}, selected, "should pick least-loaded known gateway")
+}
+
+func TestSelectGateway_AllowedGateways_RestrictsScope(t *testing.T) {
+	// 3 gateways configured, but only gw-1 and gw-3 are allowed.
+	// gw-1 is full, gw-2 has room but isn't allowed, gw-3 has room.
+	gs := newTestSharding([]GatewayKey{
+		{Namespace: "gw-ns", Name: "gw-1"},
+		{Namespace: "gw-ns", Name: "gw-2"},
+		{Namespace: "gw-ns", Name: "gw-3"},
+	}, 5)
+
+	current := GatewayKey{Namespace: "gw-ns", Name: "gw-1"}
+	counts := map[GatewayKey]int{
+		{Namespace: "gw-ns", Name: "gw-1"}: 5, // full
+		{Namespace: "gw-ns", Name: "gw-2"}: 0, // empty but not allowed
+		{Namespace: "gw-ns", Name: "gw-3"}: 2,
+	}
+
+	allowed := []GatewayKey{
+		{Namespace: "gw-ns", Name: "gw-1"},
+		{Namespace: "gw-ns", Name: "gw-3"},
+	}
+
+	selected, changed, err := gs.SelectGateway(current, 1, counts, allowed)
+	require.NoError(t, err)
+	assert.True(t, changed)
+	assert.Equal(t, GatewayKey{Namespace: "gw-ns", Name: "gw-3"}, selected)
+}
+
+func TestSelectGateway_AllowedGateways_AllFull(t *testing.T) {
+	// Both allowed gateways full, gw-3 has room but isn't allowed.
+	gs := newTestSharding([]GatewayKey{
+		{Namespace: "gw-ns", Name: "gw-1"},
+		{Namespace: "gw-ns", Name: "gw-2"},
+		{Namespace: "gw-ns", Name: "gw-3"},
+	}, 2)
+
+	current := GatewayKey{Namespace: "gw-ns", Name: "gw-1"}
+	counts := map[GatewayKey]int{
+		{Namespace: "gw-ns", Name: "gw-1"}: 2,
+		{Namespace: "gw-ns", Name: "gw-2"}: 2,
+		{Namespace: "gw-ns", Name: "gw-3"}: 0,
+	}
+
+	allowed := []GatewayKey{
+		{Namespace: "gw-ns", Name: "gw-1"},
+		{Namespace: "gw-ns", Name: "gw-2"},
+	}
+
+	_, _, err := gs.SelectGateway(current, 1, counts, allowed)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "all gateways are full")
 }
 
 func TestCountListenersPerGateway(t *testing.T) {


### PR DESCRIPTION
## Summary

 * `XListenerSets` now has `appcat.vshn.io/allowed-gateways` annotation with valid target gateways
 * Webhook filters sharding candidates to only allowed gateways preventing cross-service overflow


## Checklist

- [ ] Update tests.
- [ ] Link this PR to related issues.
- [ ] Merge with `/merge` comment.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->


Component PR: https://github.com/vshn/component-appcat/pull/1166