### PR TITLE
Adjust runtime to properly support provider-kubernetes SSA

### DIFF
--- a/config/controller/webhooks.yaml
+++ b/config/controller/webhooks.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:

--- a/pkg/comp-functions/functions/vshnkeycloak/deploy.go
+++ b/pkg/comp-functions/functions/vshnkeycloak/deploy.go
@@ -422,7 +422,7 @@ func addStsObserver(comp *vshnv1.VSHNKeycloak, svc *runtime.ServiceRuntime) erro
 			Namespace: comp.GetInstanceNamespace(),
 		},
 	}
-	return svc.SetDesiredKubeObject(sts, comp.GetName()+"-sts-observer", runtime.KubeOptionObserve, runtime.KubeOptionAllowDeletion)
+	return svc.SetDesiredKubeObject(sts, comp.GetName()+"-sts-observer", runtime.KubeOptionObserve, runtime.KubeOptionObserveMinimalManifest, runtime.KubeOptionAllowDeletion)
 }
 
 func buildConfigApplyJob(comp *vshnv1.VSHNKeycloak, adminSecret, jobName string) *batchv1.Job {

--- a/pkg/comp-functions/runtime/function_mgr.go
+++ b/pkg/comp-functions/runtime/function_mgr.go
@@ -723,9 +723,43 @@ func (s *ServiceRuntime) putIntoObject(o client.Object, kon, resourceName string
 		ko.Spec.References = refs
 	}
 
-	ko.Spec.ForProvider.Manifest = runtime.RawExtension{Object: o}
+	rawBytes, err := json.Marshal(o)
+	if err != nil {
+		return nil, fmt.Errorf("cannot marshal manifest: %w", err)
+	}
+	var manifestMap map[string]any
+
+	if err := json.Unmarshal(rawBytes, &manifestMap); err != nil {
+		return nil, fmt.Errorf("cannot unmarshal manifest: %w", err)
+	}
+	pruneNilFields(manifestMap)
+
+	ko.Spec.ForProvider.Manifest = runtime.RawExtension{Object: &unstructured.Unstructured{Object: manifestMap}}
 
 	return ko, nil
+}
+
+// pruneNilFields recursively removes nil values from obj.
+// provider-kubernetes uses server-side apply, which sends
+// null fields as-is; some CRs reject null values that
+// client-side apply previously dropped silently.
+func pruneNilFields(obj map[string]any) {
+	for k, v := range obj {
+		if v == nil {
+			delete(obj, k)
+			continue
+		}
+		switch val := v.(type) {
+		case []any:
+			for _, item := range val {
+				if m, ok := item.(map[string]any); ok {
+					pruneNilFields(m)
+				}
+			}
+		case map[string]any:
+			pruneNilFields(val)
+		}
+	}
 }
 
 // GetObservedComposite returns the observed composite and unmarshals it into the given object.

--- a/pkg/comp-functions/runtime/function_mgr.go
+++ b/pkg/comp-functions/runtime/function_mgr.go
@@ -501,7 +501,7 @@ func (s *ServiceRuntime) SetDesiredKubeObjectWithName(obj client.Object, objectN
 	return s.SetDesiredComposedResourceWithName(kobj, resourceName)
 }
 
-// KubeOptionLabeler adds the given labels to the kube object.
+// KubeOptionAddLabels adds the given labels to the kube object.
 func KubeOptionAddLabels(labels map[string]string) KubeObjectOption {
 	return func(obj *xkube.Object) {
 		current := obj.GetLabels()
@@ -569,6 +569,19 @@ func KubeOptionSetOwnerReferenceFromKubeObject(res client.Object, ownerRef metav
 func KubeOptionObserve(obj *xkube.Object) {
 	obj.Spec.ManagementPolicies = nil
 	obj.Spec.ManagementPolicies = append(obj.Spec.ManagementPolicies, xpv1.ManagementActionObserve)
+}
+
+// KubeOptionObserveMinimalManifest removes the spec from the inner manifest, keeping only
+// the fields needed to identify the object (apiVersion, kind, metadata).
+// Use this for observer objects whose types contain non-omitempty fields (e.g. StatefulSet.spec.serviceName)
+// that would otherwise be sent via server-side apply and fail immutability validation.
+func KubeOptionObserveMinimalManifest(obj *xkube.Object) {
+	if obj.Spec.ForProvider.Manifest.Object == nil {
+		return
+	}
+	if u, ok := obj.Spec.ForProvider.Manifest.Object.(*unstructured.Unstructured); ok {
+		delete(u.Object, "spec")
+	}
 }
 
 // KubeOptionProtectedBy protects the given kube objects from deletion as long

--- a/pkg/comp-functions/runtime/function_mgr.go
+++ b/pkg/comp-functions/runtime/function_mgr.go
@@ -502,7 +502,7 @@ func (s *ServiceRuntime) SetDesiredKubeObjectWithName(obj client.Object, objectN
 	return s.SetDesiredComposedResourceWithName(kobj, resourceName)
 }
 
-// KubeOptionLabeler adds the given labels to the kube object.
+// KubeOptionAddLabels adds the given labels to the kube object.
 func KubeOptionAddLabels(labels map[string]string) KubeObjectOption {
 	return func(obj *xkube.Object) {
 		current := obj.GetLabels()
@@ -566,10 +566,18 @@ func KubeOptionSetOwnerReferenceFromKubeObject(res client.Object, ownerRef metav
 	}
 }
 
-// KubeOptionObserve sets the object to only observe.
+// KubeOptionObserve sets the object to only observe and strips the spec from the inner
+// manifest, keeping only the fields needed to identify the object (apiVersion, kind, metadata).
+// Stripping spec avoids server-side apply failures from non-omitempty fields (e.g. StatefulSet.spec.serviceName).
 func KubeOptionObserve(obj *xkube.Object) {
 	obj.Spec.ManagementPolicies = nil
 	obj.Spec.ManagementPolicies = append(obj.Spec.ManagementPolicies, xpv1.ManagementActionObserve)
+	if obj.Spec.ForProvider.Manifest.Object == nil {
+		return
+	}
+	if u, ok := obj.Spec.ForProvider.Manifest.Object.(*unstructured.Unstructured); ok {
+		delete(u.Object, "spec")
+	}
 }
 
 // KubeOptionProtectedBy protects the given kube objects from deletion as long

--- a/pkg/comp-functions/runtime/function_mgr.go
+++ b/pkg/comp-functions/runtime/function_mgr.go
@@ -719,9 +719,43 @@ func (s *ServiceRuntime) putIntoObject(o client.Object, kon, resourceName string
 		ko.Spec.References = refs
 	}
 
-	ko.Spec.ForProvider.Manifest = runtime.RawExtension{Object: o}
+	rawBytes, err := json.Marshal(o)
+	if err != nil {
+		return nil, fmt.Errorf("cannot marshal manifest: %w", err)
+	}
+	var manifestMap map[string]any
+
+	if err := json.Unmarshal(rawBytes, &manifestMap); err != nil {
+		return nil, fmt.Errorf("cannot unmarshal manifest: %w", err)
+	}
+	pruneNilFields(manifestMap)
+
+	ko.Spec.ForProvider.Manifest = runtime.RawExtension{Object: &unstructured.Unstructured{Object: manifestMap}}
 
 	return ko, nil
+}
+
+// pruneNilFields recursively removes nil values from obj.
+// provider-kubernetes uses server-side apply, which sends
+// null fields as-is; some CRs reject null values that
+// client-side apply previously dropped silently.
+func pruneNilFields(obj map[string]any) {
+	for k, v := range obj {
+		if v == nil {
+			delete(obj, k)
+			continue
+		}
+		switch val := v.(type) {
+		case []any:
+			for _, item := range val {
+				if m, ok := item.(map[string]any); ok {
+					pruneNilFields(m)
+				}
+			}
+		case map[string]any:
+			pruneNilFields(val)
+		}
+	}
 }
 
 // GetObservedComposite returns the observed composite and unmarshals it into the given object.

--- a/pkg/comp-functions/runtime/function_mgr_test.go
+++ b/pkg/comp-functions/runtime/function_mgr_test.go
@@ -1,6 +1,7 @@
 package runtime
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -253,6 +254,110 @@ func TestServiceRuntime_IsResourceReady(t *testing.T) {
 	}
 }
 
+func TestPruneNilFields(t *testing.T) {
+	tests := []struct {
+		name  string
+		input map[string]any
+		want  map[string]any
+	}{
+		{
+			name:  "GivenNilValue_ThenRemoved",
+			input: map[string]any{"key": nil},
+			want:  map[string]any{},
+		},
+		{
+			name:  "GivenEmptyString_ThenKept",
+			input: map[string]any{"key": ""},
+			want:  map[string]any{"key": ""},
+		},
+		{
+			name:  "GivenNonEmptyString_ThenKept",
+			input: map[string]any{"key": "value"},
+			want:  map[string]any{"key": "value"},
+		},
+		{
+			name:  "GivenEmptySlice_ThenKept",
+			input: map[string]any{"key": []any{}},
+			want:  map[string]any{"key": []any{}},
+		},
+		{
+			name:  "GivenEmptyMap_ThenKept",
+			input: map[string]any{"key": map[string]any{}},
+			want:  map[string]any{"key": map[string]any{}},
+		},
+		{
+			name: "GivenNestedNilValue_ThenRemovedRecursively",
+			input: map[string]any{
+				"outer": map[string]any{
+					"nil":  nil,
+					"kept": "value",
+				},
+			},
+			want: map[string]any{
+				"outer": map[string]any{
+					"kept": "value",
+				},
+			},
+		},
+		{
+			name: "GivenSliceWithMapItems_ThenNilsInItemsPruned",
+			input: map[string]any{
+				"items": []any{
+					map[string]any{"name": "foo", "nil": nil},
+				},
+			},
+			want: map[string]any{
+				"items": []any{
+					map[string]any{"name": "foo"},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pruneNilFields(tt.input)
+			assert.Equal(t, tt.want, tt.input)
+		})
+	}
+}
+
+func TestSetDesiredKubeObject_PrunesNilFieldsFromManifest(t *testing.T) {
+	fakeComp := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "mycomp",
+		},
+	}
+	s := getTestRuntime(t, nil, fakeComp)
+
+	obj := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cm",
+			Namespace: "default",
+			Annotations: map[string]string{
+				"some-key": "value",
+			},
+		},
+	}
+
+	err := s.SetDesiredKubeObject(obj, "test-cm")
+	assert.NoError(t, err)
+
+	kobj := &xkube.Object{}
+	err = s.GetDesiredComposedResourceByName(kobj, "test-cm")
+	assert.NoError(t, err)
+
+	manifestJSON := kobj.Spec.ForProvider.Manifest.Raw
+	var manifestMap map[string]any
+	err = json.Unmarshal(manifestJSON, &manifestMap)
+	assert.NoError(t, err)
+
+	metadata := manifestMap["metadata"].(map[string]any)
+	metadata["nullField"] = nil
+	pruneNilFields(manifestMap)
+	assert.NotContains(t, metadata, "nullField", "nil field should be pruned")
+	assert.Equal(t, "value", metadata["annotations"].(map[string]any)["some-key"], "non-nil fields should be kept")
+}
+
 func getTestRuntime(t *testing.T, initialObjects []client.Object, comp client.Object) *ServiceRuntime {
 	req := &xfnproto.RunFunctionRequest{
 		Observed: &xfnproto.State{
@@ -277,5 +382,6 @@ func getTestRuntime(t *testing.T, initialObjects []client.Object, comp client.Ob
 		req:               req,
 		desiredResources:  map[resource.Name]*resource.DesiredComposed{},
 		observedComposite: &composite.Unstructured{Unstructured: compRes.Unstructured},
+		kubeOptionTracker: map[string][]KubeObjectOption{},
 	}
 }


### PR DESCRIPTION
## Summary

* This PR adjust the runtime as follows:
  * Remove empty fields from objects before putting them into the desired state
  * Adjust sts-observer object to not create it with the unnecessary `spec` fields

## Checklist

- [x] Update tests.
- [ ] Link this PR to related issues.
- [ ] Merge with `/merge` comment.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->


Component PR: https://github.com/vshn/component-appcat/pull/1168