### PR TITLE
Also pass admin credentials to apply job

### DIFF
--- a/pkg/comp-functions/functions/vshnkeycloak/deploy.go
+++ b/pkg/comp-functions/functions/vshnkeycloak/deploy.go
@@ -493,6 +493,21 @@ func buildConfigApplyJob(comp *vshnv1.VSHNKeycloak, adminSecret, jobName string)
 									},
 								},
 								{
+									Name:  "KEYCLOAK_MANAGED",
+									Value: "admin",
+								},
+								{
+									Name: "KEYCLOAK_MANAGED_PASSWORD",
+									ValueFrom: &corev1.EnvVarSource{
+										SecretKeyRef: &corev1.SecretKeySelector{
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: adminSecret,
+											},
+											Key: adminPWSecretField,
+										},
+									},
+								},
+								{
 									Name:  "KC_HTTP_RELATIVE_PATH",
 									Value: comp.Spec.Parameters.Service.RelativePath,
 								},


### PR DESCRIPTION
## Summary

The apply job applies ALL configuration again. Including the default one. The default one however will fallback to a default password if a specific env variable wasn't set. Those env vars were not set in the apply job, after the job ran it created the default user.

This fix adds the missing env vars to the job so it will not create the default user.

## Checklist

- [ ] Update tests.
- [ ] Link this PR to related issues.
- [ ] Merge with `/merge` comment.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->


Component PR: https://github.com/vshn/component-appcat/pull/1171