### PR TITLE
Fix the topologyKey for CNPG Cluster

### DIFF
--- a/pkg/comp-functions/functions/vshnpostgrescnpg/deploy.go
+++ b/pkg/comp-functions/functions/vshnpostgrescnpg/deploy.go
@@ -278,6 +278,9 @@ func createCnpgHelmValues(ctx context.Context, svc *runtime.ServiceRuntime, comp
 				"serverCASecret":  certificateSecretName,
 				"serverTLSSecret": certificateSecretName,
 			},
+			"affinity": map[string]any{
+				"topologyKey": "kubernetes.io/hostname",
+			},
 			// The following will be overwritten by setResources() later
 			"storage": map[string]any{},
 			"resources": map[string]any{


### PR DESCRIPTION
## Summary

The chart defaults to `topology.kubernetes.io/zone` which doesn't do much in our setups. We should consider `kubernetes.io/hostname` instead

## Checklist

- [ ] Update tests.
- [ ] Link this PR to related issues.
- [ ] Merge with `/merge` comment.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->


Component PR: https://github.com/vshn/component-appcat/pull/1185