### PR TITLE
Return warning on error in enableSSHInRelease

### DIFF
--- a/pkg/comp-functions/functions/vshnforgejo/ssh.go
+++ b/pkg/comp-functions/functions/vshnforgejo/ssh.go
@@ -62,7 +62,7 @@ func ConfigureSSHAccess(ctx context.Context, comp *vshnv1.VSHNForgejo, svc *runt
 		svc.SetConnectionDetail("FORGEJO_SSH_PORT", []byte(strconv.FormatInt(int64(state.Port), 10)))
 		err = enableSSHInRelease(svc, comp, state.Domain, state.Port)
 		if err != nil {
-			return runtime.NewFatalResult(fmt.Errorf("cannot update forgejo release: %w", err))
+			return runtime.NewWarningResult(fmt.Sprintf("cannot update forgejo release: %s", err))
 		}
 	}
 


### PR DESCRIPTION
## Summary

On first instance create with SSH enabled, the Helm release does not exist yet so enableSSHInRelease returns an error. Returning Fatal blocked the composition from ever completing. Emit a warning instead so subsequent reconciles can wire up SSH once the release exists.

## Checklist

- [ ] Update tests.
- [ ] Link this PR to related issues.
- [ ] Merge with `/merge` comment.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->


Component PR: https://github.com/vshn/component-appcat/pull/1188