### PR TITLE
Allow deletion of HTTPRoute cert Object on FQDN change

### DIFF
--- a/pkg/comp-functions/functions/common/httproute.go
+++ b/pkg/comp-functions/functions/common/httproute.go
@@ -321,8 +321,9 @@ func GenerateCertificates(comp InfoGetter, svc *runtime.ServiceRuntime, cfg HTTP
 
 // CreateCertificates applies generated Certificates using svc.SetDesiredKubeObject().
 func CreateCertificates(svc *runtime.ServiceRuntime, certs []*cmv1.Certificate, opts ...runtime.KubeObjectOption) error {
+	certOpts := append([]runtime.KubeObjectOption{runtime.KubeOptionAllowDeletion}, opts...)
 	for _, c := range certs {
-		if err := svc.SetDesiredKubeObject(c, c.Name, opts...); err != nil {
+		if err := svc.SetDesiredKubeObject(c, c.Name, certOpts...); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
## Summary

* When changing FQDN in the claim, reconciliation got stuck because the cert Object name depends on the FQDN and the AppCat deletion-protection webhook blocked garbage collection of the old one.


## Checklist

- [ ] Update tests.
- [ ] Link this PR to related issues.
- [x] Merge with `/merge` comment.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->


Component PR: https://github.com/vshn/component-appcat/pull/1192