### PR TITLE
Add allowed namespaces to vshngarage

### DIFF
--- a/pkg/comp-functions/functions/vshngarage/deploy.go
+++ b/pkg/comp-functions/functions/vshngarage/deploy.go
@@ -21,25 +21,6 @@ const (
 	GarageHost = "GARAGE_URL"
 )
 
-// applyAllowedNamespaces decodes the comma-coupled JSON list provided through
-// the comp-function xfn-config (key: garageAllowedNamespaces) and injects it
-// into the vshngaragecluster chart values. Empty input leaves values
-// untouched so older component-appcat releases that don't ship the key keep
-// working — the chart simply skips the GarageReferenceGrant template.
-func applyAllowedNamespaces(values map[string]any, raw string) error {
-	if raw == "" {
-		return nil
-	}
-	var allowed []string
-	if err := json.Unmarshal([]byte(raw), &allowed); err != nil {
-		return fmt.Errorf("cannot parse garageAllowedNamespaces %q: %w", raw, err)
-	}
-	if len(allowed) > 0 {
-		values["allowedNamespaces"] = allowed
-	}
-	return nil
-}
-
 func DeployGarage(ctx context.Context, comp *vshnv1.VSHNGarage, svc *runtime.ServiceRuntime) *xfnproto.Result {
 	l := svc.Log
 
@@ -125,5 +106,24 @@ func DeployGarage(ctx context.Context, comp *vshnv1.VSHNGarage, svc *runtime.Ser
 		return runtime.NewWarningResult(fmt.Sprintf("cannot add observed connection details for garage: %s", err))
 	}
 
+	return nil
+}
+
+// applyAllowedNamespaces decodes the JSON array through
+// the comp-functions config key (`garageAllowedNamespaces`) and injects it
+// into the vshngaragecluster chart values.
+// An empty input leaves values untouched, for backwards compatibility.
+// the chart simply skips the GarageReferenceGrant template.
+func applyAllowedNamespaces(values map[string]any, raw string) error {
+	if raw == "" {
+		return nil
+	}
+	var allowed []string
+	if err := json.Unmarshal([]byte(raw), &allowed); err != nil {
+		return fmt.Errorf("cannot parse garageAllowedNamespaces %q: %w", raw, err)
+	}
+	if len(allowed) > 0 {
+		values["allowedNamespaces"] = allowed
+	}
 	return nil
 }

--- a/pkg/comp-functions/functions/vshngarage/deploy.go
+++ b/pkg/comp-functions/functions/vshngarage/deploy.go
@@ -2,6 +2,7 @@ package vshngarage
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -19,6 +20,25 @@ const (
 	// GarageHost is env variable in the connection secret
 	GarageHost = "GARAGE_URL"
 )
+
+// applyAllowedNamespaces decodes the comma-coupled JSON list provided through
+// the comp-function xfn-config (key: garageAllowedNamespaces) and injects it
+// into the vshngaragecluster chart values. Empty input leaves values
+// untouched so older component-appcat releases that don't ship the key keep
+// working — the chart simply skips the GarageReferenceGrant template.
+func applyAllowedNamespaces(values map[string]any, raw string) error {
+	if raw == "" {
+		return nil
+	}
+	var allowed []string
+	if err := json.Unmarshal([]byte(raw), &allowed); err != nil {
+		return fmt.Errorf("cannot parse garageAllowedNamespaces %q: %w", raw, err)
+	}
+	if len(allowed) > 0 {
+		values["allowedNamespaces"] = allowed
+	}
+	return nil
+}
 
 func DeployGarage(ctx context.Context, comp *vshnv1.VSHNGarage, svc *runtime.ServiceRuntime) *xfnproto.Result {
 	l := svc.Log
@@ -69,6 +89,10 @@ func DeployGarage(ctx context.Context, comp *vshnv1.VSHNGarage, svc *runtime.Ser
 		},
 		"storageDataSpace":     calcResources.Disk.String(),
 		"storageMetadataSpace": comp.Spec.Parameters.Service.MetadataStorage,
+	}
+
+	if err := applyAllowedNamespaces(values, svc.Config.Data["garageAllowedNamespaces"]); err != nil {
+		return runtime.NewFatalResult(err)
 	}
 
 	connectionDetails := []v1beta1.ConnectionDetail{

--- a/pkg/comp-functions/functions/vshngarage/deploy_test.go
+++ b/pkg/comp-functions/functions/vshngarage/deploy_test.go
@@ -1,0 +1,38 @@
+package vshngarage
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplyAllowedNamespaces(t *testing.T) {
+	t.Run("empty raw leaves values untouched", func(t *testing.T) {
+		values := map[string]any{"existing": "keep"}
+		require.NoError(t, applyAllowedNamespaces(values, ""))
+		_, present := values["allowedNamespaces"]
+		assert.False(t, present)
+		assert.Equal(t, "keep", values["existing"])
+	})
+
+	t.Run("populated list lands in values", func(t *testing.T) {
+		values := map[string]any{}
+		require.NoError(t, applyAllowedNamespaces(values, `["syn-appcat","team-a"]`))
+		assert.Equal(t, []string{"syn-appcat", "team-a"}, values["allowedNamespaces"])
+	})
+
+	t.Run("empty json array leaves values untouched", func(t *testing.T) {
+		values := map[string]any{}
+		require.NoError(t, applyAllowedNamespaces(values, `[]`))
+		_, present := values["allowedNamespaces"]
+		assert.False(t, present)
+	})
+
+	t.Run("malformed json fails", func(t *testing.T) {
+		values := map[string]any{}
+		err := applyAllowedNamespaces(values, `not-json`)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot parse garageAllowedNamespaces")
+	})
+}


### PR DESCRIPTION
## Summary

* This uses the GarageReferenceGrant to restrict where GarageKeys and GarageBuckets can be provisioned.
* `syn-appcat` is included by default so AppCat can provision the buckets as normal

## Checklist

- [x] Update tests.
- [ ] Link this PR to related issues.
- [ ] Merge with `/merge` comment.

Component PR: https://github.com/vshn/component-appcat/pull/1193