### PR TITLE
Fix pinImageTag leaking into the nested service

### DIFF
--- a/pkg/comp-functions/functions/common/postgresql.go
+++ b/pkg/comp-functions/functions/common/postgresql.go
@@ -117,9 +117,17 @@ func (a *PostgreSQLDependencyBuilder) CreateDependency() (string, error) {
 		}
 	}
 
+	// Inherit only the maintenance window. Other fields are parent-specific and must not
+	// leak (e.g. PinImageTag would pin the PG image to the parent's tag). Copy explicitly
+	// so future struct fields don't leak either.
+	parentMaintenance := a.comp.GetFullMaintenanceSchedule()
+
 	params := &vshnv1.VSHNPostgreSQLParameters{
-		Size:        a.comp.GetSize(),
-		Maintenance: a.comp.GetFullMaintenanceSchedule(),
+		Size: a.comp.GetSize(),
+		Maintenance: vshnv1.VSHNDBaaSMaintenanceScheduleSpec{
+			DayOfWeek: parentMaintenance.DayOfWeek,
+			TimeOfDay: parentMaintenance.TimeOfDay,
+		},
 		Backup: vshnv1.VSHNPostgreSQLBackup{
 			Retention:          retention,
 			DeletionProtection: ptr.To(true),


### PR DESCRIPTION
## Summary

Nested services align their maintenance window with the parent (offset slightly). To do that we copied the parent's entire maintenance config into the nested PostgreSQL, which also carried pinImageTag. With a CNPG nested instance this pins the Postgres image to the parent's tag (e.g. a Keycloak version), producing an invalid image. 

This is fixed by only inheriting the window fields (dayOfWeek/timeOfDay), not the whole struct.

## Checklist

- [x] Update tests.
- [ ] Link this PR to related issues.
- [ ] Merge with `/merge` comment.

Component PR: https://github.com/vshn/component-appcat/pull/1202