### PR TITLE
Make luks key secret object name deterministic

### DIFF
--- a/pkg/comp-functions/functions/vshnpostgrescnpg/encrypted_pvc.go
+++ b/pkg/comp-functions/functions/vshnpostgrescnpg/encrypted_pvc.go
@@ -104,8 +104,13 @@ func writeLuksSecret(svc *runtime.ServiceRuntime, log logr.Logger, comp *vshnv1.
 			},
 		}
 
+		// CNPG always names its cluster "postgresql", so luksKeyName collides across
+		// composites on the cluster-scoped Object CR. Prefix with the composite name to
+		// keep it unique. resourceName stays luksKeyName so the existing key is read back
+		// and preserved (no rotation), and the inner Secret keeps its CSI-referenced name.
+		objectName := comp.GetName() + "-" + luksKeyName
 		// Allow deletion is required for scaling
-		err = svc.SetDesiredKubeObject(secret, luksKeyName, runtime.KubeOptionAllowDeletion)
+		err = svc.SetDesiredKubeObjectWithName(secret, objectName, luksKeyName, runtime.KubeOptionAllowDeletion)
 		if err != nil {
 			return runtime.NewFatalResult(fmt.Errorf("cannot add luks secret object: %w", err))
 		}

--- a/pkg/comp-functions/functions/vshnpostgrescnpg/encrypted_pvc_test.go
+++ b/pkg/comp-functions/functions/vshnpostgrescnpg/encrypted_pvc_test.go
@@ -86,9 +86,15 @@ func TestGivenEncrypedPvcThenExpectOutput(t *testing.T) {
 			kubeObject := &xkube.Object{}
 			assert.NoError(t, svc.GetDesiredComposedResourceByName(kubeObject, v))
 
+			// The Object CR name must be composite-prefixed so it doesn't collide with
+			// other composites' identically-named CNPG instances, while the inner Secret
+			// keeps the bare, CSI-referenced name.
+			assert.Equal(t, comp.GetName()+"-"+v, kubeObject.GetName())
+
 			s := &v1.Secret{}
 			assert.NoError(t, yaml.Unmarshal(kubeObject.Spec.ForProvider.Manifest.Raw, s))
 			assert.NotEmpty(t, s.Data["luksKey"])
+			assert.Equal(t, v, s.GetName())
 		}
 	})
 


### PR DESCRIPTION
## Summary

The provider Kubernetes object creating the Luks secret for CNPG encryption was not deterministic, thus it collided when more than one instance was created.

I've checked existing clusters and there are currently no instances that use this feature, so this won't break anything.

## Checklist

- [x] Update tests.
- [ ] Link this PR to related issues.
- [ ] Merge with `/merge` comment.


Component PR: https://github.com/vshn/component-appcat/pull/1204