### PR TITLE
fix(mariadb): omit mariadb configuration on initial reconcile

### DIFF
--- a/pkg/comp-functions/functions/vshnmariadb/mariadb_deploy.go
+++ b/pkg/comp-functions/functions/vshnmariadb/mariadb_deploy.go
@@ -189,10 +189,12 @@ func newValues(ctx context.Context, svc *runtime.ServiceRuntime, comp *vshnv1.VS
 				"allowInsecureImages": true,
 			},
 		},
-		"existingSecret":       secretName,
-		"fullnameOverride":     comp.GetName(),
-		"replicaCount":         comp.GetInstances(),
-		"mariadbConfiguration": defaultVSHNSettings,
+		"existingSecret":   secretName,
+		"fullnameOverride": comp.GetName(),
+		"replicaCount":     comp.GetInstances(),
+		// Don't set mariadbConfiguration here: it would replace the chart defaults
+		// (pid_file, [galera]) and intermittently hang bootstrap. manageCustomDBSettings
+		// layers in the VSHN settings via !include once the release secret exists.
 		"resources": map[string]interface{}{
 			"requests": map[string]interface{}{
 				"memory": res.ReqMem.String(),

--- a/pkg/comp-functions/functions/vshnmariadb/mariadb_deploy_test.go
+++ b/pkg/comp-functions/functions/vshnmariadb/mariadb_deploy_test.go
@@ -141,10 +141,11 @@ func TestNewValues(t *testing.T) {
 	assert.True(t, ok)
 	assert.Equal(t, true, metrics["enabled"])
 
-	// Verify startup probe is disabled
-	startupProbe, ok := values["startupProbe"].(map[string]interface{})
-	assert.True(t, ok)
-	assert.Equal(t, false, startupProbe["enabled"])
+	// Phase 1 must NOT override mariadbConfiguration: doing so replaces the chart's
+	// defaults (pid_file + [galera] section) and intermittently hangs bootstrap.
+	// The chart default applies until manageCustomDBSettings layers in the VSHN include.
+	_, hasCfg := values["mariadbConfiguration"]
+	assert.False(t, hasCfg)
 
 	// Verify pod labels
 	podLabels, ok := values["podLabels"].(map[string]string)


### PR DESCRIPTION
## Summary

This fixes MariaDB instances getting stuck during fresh provisioning. The pod sits at 1/2 Running, then goes CrashLoopBackOff, recoverable only by deleting the PVC and pod.

Phase 1 of provisioning was shipping `mariadbConfiguration = defaultVSHNSettings` (a charset-only `[mysqld]` block), which completely overrides the Bitnami chart default and drops the `pid_file` setting and the `[galera]` section. With no `pid_file`, mysqld wrote its pid to the datadir default, but `is_mysql_running` only checks the configured pid file, so `setup.sh` hung in `wait_for_mysql` even though mysqld was up and pingable. It was intermittent because the correct config is only layered in during phase 2 (`manageCustomDBSettings`), which runs once the Helm release secret is observable. Whether a pod booted on the stripped config before phase 2 corrected it was a race.

The fix omits `mariadbConfiguration` in phase 1 so the chart's complete, valid default applies immediately. The VSHN utf8mb4 settings still get layered in via the existing include mechanism once the release secret exists.
## Checklist

- [x] Update tests.
- [ ] Link this PR to related issues.
- [ ] Merge with `/merge` comment.


Component PR: https://github.com/vshn/component-appcat/pull/1216