### PR TITLE
Fix probe path when relativePath is overwritten

### DIFF
--- a/config/controller/cluster-role.yaml
+++ b/config/controller/cluster-role.yaml
@@ -33,6 +33,7 @@ rules:
   - apiextensions.crossplane.io
   resources:
   - compositeresourcedefinitions
+  - compositionrevisions
   verbs:
   - get
   - list

--- a/pkg/comp-functions/functions/vshnkeycloak/deploy.go
+++ b/pkg/comp-functions/functions/vshnkeycloak/deploy.go
@@ -1084,8 +1084,23 @@ func buildKeycloakCommand(comp *vshnv1.VSHNKeycloak, svc *runtime.ServiceRuntime
 		"--spi-events-listener-jboss-logging-success-level=info",
 		"--spi-events-listener-jboss-logging-error-level=warn",
 	}
-	if comp.Spec.Parameters.Service.CustomizationImage.Image == "" && svc.Config.Data["keycloak_images_optimized"] == "true" {
-		cmd = append(cmd, "--optimized")
+	wantOptimized := comp.Spec.Parameters.Service.CustomizationImage.Image == "" && svc.Config.Data["keycloak_images_optimized"] == "true"
+
+	if wantOptimized {
+		// http-relative-path is a Keycloak build-time option. With --optimized, Keycloak uses the
+		// image's pre-baked build (relative-path "/") and skips the startup build, so a non-root
+		// relativePath would be silently ignored and Keycloak crash-loops (the setup waits for the
+		// health endpoint under the new path, which is never served). Fall back to a runtime build
+		// (plain start) for non-root relativePath, which rebuilds and honours the value.
+		if strings.TrimSuffix(comp.Spec.Parameters.Service.RelativePath, "/") == "" {
+			cmd = append(cmd, "--optimized")
+		} else {
+			svc.Log.Info("Disabling --optimized: a non-root service.relativePath requires a runtime Keycloak build", "relativePath", comp.Spec.Parameters.Service.RelativePath)
+			svc.AddResult(runtime.NewWarningResult(
+				"keycloak: --optimized disabled because service.relativePath is not '/'; falling back to a " +
+					"runtime build (slower startup). http-relative-path is a build-time option and is " +
+					"incompatible with optimized prebuilt images."))
+		}
 	}
 	return cmd
 }

--- a/pkg/comp-functions/functions/vshnkeycloak/deploy.go
+++ b/pkg/comp-functions/functions/vshnkeycloak/deploy.go
@@ -774,6 +774,8 @@ func newValues(ctx context.Context, svc *runtime.ServiceRuntime, comp *vshnv1.VS
 		return nil, err
 	}
 
+	probeBasePath := strings.TrimSuffix(comp.Spec.Parameters.Service.RelativePath, "/")
+
 	values = map[string]any{
 		"replicas":          comp.Spec.Parameters.Instances,
 		"extraEnv":          extraEnv,
@@ -824,9 +826,10 @@ func newValues(ctx context.Context, svc *runtime.ServiceRuntime, comp *vshnv1.VS
 			},
 		},
 		// Workaround until https://github.com/codecentric/helm-charts/pull/784 is merged
-		"livenessProbe":  "{\"httpGet\": {\"path\": \"/health/live\", \"port\": \"http-internal\", \"scheme\": \"HTTPS\"}, \"initialDelaySeconds\": 0, \"timeoutSeconds\": 5}",
-		"readinessProbe": "{\"httpGet\": {\"path\": \"/health/ready\", \"port\": \"http-internal\", \"scheme\": \"HTTPS\"}, \"initialDelaySeconds\": 10, \"timeoutSeconds\": 1}",
-		"startupProbe":   "{\"httpGet\": {\"path\": \"/health\", \"port\": \"http-internal\", \"scheme\": \"HTTPS\"}, \"initialDelaySeconds\": 15, \"timeoutSeconds\": 1, \"failureThreshold\": 60, \"periodSeconds\": 5}",
+		// Health endpoints are served under KC_HTTP_RELATIVE_PATH, so probes must include it.
+		"livenessProbe":  fmt.Sprintf("{\"httpGet\": {\"path\": \"%s/health/live\", \"port\": \"http-internal\", \"scheme\": \"HTTPS\"}, \"initialDelaySeconds\": 0, \"timeoutSeconds\": 5}", probeBasePath),
+		"readinessProbe": fmt.Sprintf("{\"httpGet\": {\"path\": \"%s/health/ready\", \"port\": \"http-internal\", \"scheme\": \"HTTPS\"}, \"initialDelaySeconds\": 10, \"timeoutSeconds\": 1}", probeBasePath),
+		"startupProbe":   fmt.Sprintf("{\"httpGet\": {\"path\": \"%s/health\", \"port\": \"http-internal\", \"scheme\": \"HTTPS\"}, \"initialDelaySeconds\": 15, \"timeoutSeconds\": 1, \"failureThreshold\": 60, \"periodSeconds\": 5}", probeBasePath),
 		"http": map[string]any{
 			"relativePath": comp.Spec.Parameters.Service.RelativePath,
 		},

--- a/pkg/comp-functions/functions/vshnkeycloak/deploy_test.go
+++ b/pkg/comp-functions/functions/vshnkeycloak/deploy_test.go
@@ -332,6 +332,61 @@ func Test_dbcheckerImage(t *testing.T) {
 	})
 }
 
+func Test_probeRelativePath(t *testing.T) {
+	tests := map[string]struct {
+		relativePath string
+		wantLiveness string
+		wantReady    string
+		wantStartup  string
+	}{
+		"default root path": {
+			relativePath: "/",
+			wantLiveness: "/health/live",
+			wantReady:    "/health/ready",
+			wantStartup:  "/health",
+		},
+		"custom relative path": {
+			relativePath: "/auth",
+			wantLiveness: "/auth/health/live",
+			wantReady:    "/auth/health/ready",
+			wantStartup:  "/auth/health",
+		},
+		"custom relative path with trailing slash": {
+			relativePath: "/auth/",
+			wantLiveness: "/auth/health/live",
+			wantReady:    "/auth/health/ready",
+			wantStartup:  "/auth/health",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			svc := commontest.LoadRuntimeFromFile(t, "vshnkeycloak/01_default.yaml")
+			comp := &vshnv1.VSHNKeycloak{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "mycloak",
+					Namespace: "default",
+				},
+				Spec: vshnv1.VSHNKeycloakSpec{
+					Parameters: vshnv1.VSHNKeycloakParameters{
+						Service: vshnv1.VSHNKeycloakServiceSpec{
+							Version:      "26",
+							RelativePath: tc.relativePath,
+						},
+					},
+				},
+			}
+
+			values, err := newValues(context.TODO(), svc, comp, "mysecret", "mypgsecret")
+			assert.NoError(t, err)
+
+			assert.Contains(t, values["livenessProbe"], "\"path\": \""+tc.wantLiveness+"\"")
+			assert.Contains(t, values["readinessProbe"], "\"path\": \""+tc.wantReady+"\"")
+			assert.Contains(t, values["startupProbe"], "\"path\": \""+tc.wantStartup+"\"")
+		})
+	}
+}
+
 func Test_configOrEnvChanged(t *testing.T) {
 	configHash1 := "0bee89b07a248e27c83fc3d5951213c1"
 	configHash2 := "b6273b589df2dfdbd8fe35b1011e3183"

--- a/pkg/comp-functions/functions/vshnkeycloak/deploy_test.go
+++ b/pkg/comp-functions/functions/vshnkeycloak/deploy_test.go
@@ -3,6 +3,7 @@ package vshnkeycloak
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -383,6 +384,89 @@ func Test_probeRelativePath(t *testing.T) {
 			assert.Contains(t, values["livenessProbe"], "\"path\": \""+tc.wantLiveness+"\"")
 			assert.Contains(t, values["readinessProbe"], "\"path\": \""+tc.wantReady+"\"")
 			assert.Contains(t, values["startupProbe"], "\"path\": \""+tc.wantStartup+"\"")
+		})
+	}
+}
+
+func Test_buildKeycloakCommand(t *testing.T) {
+	tests := map[string]struct {
+		optimized          string
+		relativePath       string
+		customizationImage string
+		wantOptimized      bool
+		wantWarning        bool
+	}{
+		"optimized on, root path": {
+			optimized:     "true",
+			relativePath:  "/",
+			wantOptimized: true,
+		},
+		"optimized on, empty path defaults to root": {
+			optimized:     "true",
+			relativePath:  "",
+			wantOptimized: true,
+		},
+		"optimized on, non-root path falls back with warning": {
+			optimized:     "true",
+			relativePath:  "/auth",
+			wantOptimized: false,
+			wantWarning:   true,
+		},
+		"optimized on, non-root path with trailing slash falls back with warning": {
+			optimized:     "true",
+			relativePath:  "/auth/",
+			wantOptimized: false,
+			wantWarning:   true,
+		},
+		"optimized off, non-root path: no flag, no warning": {
+			optimized:     "false",
+			relativePath:  "/auth",
+			wantOptimized: false,
+			wantWarning:   false,
+		},
+		"optimized on but customizationImage set: not eligible, no warning": {
+			optimized:          "true",
+			relativePath:       "/",
+			customizationImage: "my-registry/custom:1",
+			wantOptimized:      false,
+			wantWarning:        false,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			svc := commontest.LoadRuntimeFromFile(t, "vshnkeycloak/01_default.yaml")
+			svc.Config.Data["keycloak_images_optimized"] = tc.optimized
+			comp := &vshnv1.VSHNKeycloak{
+				ObjectMeta: metav1.ObjectMeta{Name: "mycloak", Namespace: "default"},
+				Spec: vshnv1.VSHNKeycloakSpec{
+					Parameters: vshnv1.VSHNKeycloakParameters{
+						Service: vshnv1.VSHNKeycloakServiceSpec{
+							Version:            "26",
+							RelativePath:       tc.relativePath,
+							CustomizationImage: vshnv1.VSHNKeycloakCustomizationImage{Image: tc.customizationImage},
+						},
+					},
+				},
+			}
+
+			cmd := buildKeycloakCommand(comp, svc)
+
+			if tc.wantOptimized {
+				assert.Contains(t, cmd, "--optimized")
+			} else {
+				assert.NotContains(t, cmd, "--optimized")
+			}
+
+			resp, err := svc.GetResponse()
+			assert.NoError(t, err)
+			hasWarning := false
+			for _, r := range resp.GetResults() {
+				if strings.Contains(r.GetMessage(), "--optimized disabled") {
+					hasWarning = true
+				}
+			}
+			assert.Equal(t, tc.wantWarning, hasWarning)
 		})
 	}
 }

--- a/pkg/controller/webhooks/keycloak.go
+++ b/pkg/controller/webhooks/keycloak.go
@@ -267,9 +267,7 @@ func (h *KeycloakWebhookHandler) optimizedImagesEnabled(ctx context.Context) boo
 		if err := json.Unmarshal(step.Input.Raw, input); err != nil {
 			continue
 		}
-		if input.Data[keycloakImagesOptimizedInput] == "true" {
-			return true
-		}
+		return input.Data[keycloakImagesOptimizedInput] == "true"
 	}
 	return false
 }

--- a/pkg/controller/webhooks/keycloak.go
+++ b/pkg/controller/webhooks/keycloak.go
@@ -2,14 +2,18 @@ package webhooks
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 
+	apixv1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
 	vshnv1 "github.com/vshn/appcat/v4/apis/vshn/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
@@ -18,6 +22,7 @@ import (
 
 //+kubebuilder:rbac:groups=vshn.appcat.vshn.io,resources=xvshnkeycloaks,verbs=get;list;watch;patch;update
 //+kubebuilder:rbac:groups=vshn.appcat.vshn.io,resources=xvshnkeycloaks/status,verbs=get;list;watch;patch;update
+//+kubebuilder:rbac:groups=apiextensions.crossplane.io,resources=compositionrevisions,verbs=get;list;watch
 
 var (
 	keycloakGK = schema.GroupKind{Group: "vshn.appcat.vshn.io", Kind: "VSHNKeycloak"}
@@ -84,7 +89,9 @@ func (n *KeycloakWebhookHandler) ValidateCreate(ctx context.Context, obj runtime
 		allErrs.Add(err)
 	}
 
-	return append(defaultWarnings, append(isDeprecatedFieldInUse(keycloak), warnPinImageTagIgnoredForCustomImage(keycloak)...)...), allErrs.Get()
+	warnings := append(isDeprecatedFieldInUse(keycloak), warnPinImageTagIgnoredForCustomImage(keycloak)...)
+	warnings = append(warnings, n.warnRelativePathDisablesOptimized(ctx, keycloak)...)
+	return append(defaultWarnings, warnings...), allErrs.Get()
 }
 
 // ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type
@@ -127,7 +134,9 @@ func (p *KeycloakWebhookHandler) ValidateUpdate(ctx context.Context, oldObj, new
 		}
 	}
 
-	return append(defaultWarnings, append(isDeprecatedFieldInUse(newKeycloak), warnPinImageTagIgnoredForCustomImage(newKeycloak)...)...), allErrs.Get()
+	warnings := append(isDeprecatedFieldInUse(newKeycloak), warnPinImageTagIgnoredForCustomImage(newKeycloak)...)
+	warnings = append(warnings, p.warnRelativePathDisablesOptimized(ctx, newKeycloak)...)
+	return append(defaultWarnings, warnings...), allErrs.Get()
 }
 
 func validateCustomImageMutualExclusion(keycloak *vshnv1.VSHNKeycloak) *field.Error {
@@ -203,6 +212,66 @@ func warnPinImageTagIgnoredForCustomImage(keycloak *vshnv1.VSHNKeycloak) admissi
 		)}
 	}
 	return nil
+}
+
+const (
+	keycloakImagesOptimizedInput = "keycloak_images_optimized"
+	keycloakServiceIDLabel       = "metadata.appcat.vshn.io/serviceID"
+	keycloakServiceID            = "vshn-keycloak"
+)
+
+// warnRelativePathDisablesOptimized warns when a non-root relativePath is combined with optimized
+// Keycloak images. http-relative-path is a Keycloak build-time option, so for such instances the
+// composition omits --optimized and Keycloak rebuilds at startup (slower). It checks the latest
+// composition revision and only warns when keycloak_images_optimized is actually "true".
+func (h *KeycloakWebhookHandler) warnRelativePathDisablesOptimized(ctx context.Context, keycloak *vshnv1.VSHNKeycloak) admission.Warnings {
+	if strings.TrimSuffix(keycloak.Spec.Parameters.Service.RelativePath, "/") == "" {
+		return nil
+	}
+	if !h.optimizedImagesEnabled(ctx) {
+		return nil
+	}
+	return admission.Warnings{fmt.Sprintf(
+		"%s is not '/': optimized Keycloak images are enabled, so --optimized is omitted for this instance "+
+			"and Keycloak performs a slower runtime build at startup (http-relative-path is a build-time option)",
+		field.NewPath("spec", "parameters", "service", "relativePath").String(),
+	)}
+}
+
+// optimizedImagesEnabled reports whether the latest Keycloak composition revision sets the function
+// input keycloak_images_optimized to "true". The latest revision is what Crossplane binds to new
+// instances by default, so it reflects what an instance will actually run. Returns false on any
+// error so the webhook never blocks admission.
+func (h *KeycloakWebhookHandler) optimizedImagesEnabled(ctx context.Context) bool {
+	list := &apixv1.CompositionRevisionList{}
+	if err := h.client.List(ctx, list, client.MatchingLabels{keycloakServiceIDLabel: keycloakServiceID}); err != nil {
+		return false
+	}
+
+	var latest *apixv1.CompositionRevision
+	for i := range list.Items {
+		r := &list.Items[i]
+		if latest == nil || r.Spec.Revision > latest.Spec.Revision {
+			latest = r
+		}
+	}
+	if latest == nil {
+		return false
+	}
+
+	for _, step := range latest.Spec.Pipeline {
+		if step.Input == nil {
+			continue
+		}
+		input := &corev1.ConfigMap{}
+		if err := json.Unmarshal(step.Input.Raw, input); err != nil {
+			continue
+		}
+		if input.Data[keycloakImagesOptimizedInput] == "true" {
+			return true
+		}
+	}
+	return false
 }
 
 func isDeprecatedFieldInUse(comp *vshnv1.VSHNKeycloak) admission.Warnings {

--- a/pkg/controller/webhooks/keycloak_test.go
+++ b/pkg/controller/webhooks/keycloak_test.go
@@ -2,14 +2,20 @@ package webhooks
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"testing"
 
+	apixv1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	vshnv1 "github.com/vshn/appcat/v4/apis/vshn/v1"
 	"github.com/vshn/appcat/v4/pkg"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -172,6 +178,71 @@ func TestWarnPinImageTagIgnoredForCustomImage(t *testing.T) {
 		},
 	}
 	assert.Empty(t, warnPinImageTagIgnoredForCustomImage(keycloakImageOnly))
+}
+
+func TestWarnRelativePathDisablesOptimized(t *testing.T) {
+	// revision builds a Keycloak CompositionRevision labelled with the serviceID (so the webhook's
+	// List finds it) and carrying the given keycloak_images_optimized value in its function input.
+	revision := func(t *testing.T, name string, revNum int64, optimized string) *apixv1.CompositionRevision {
+		raw, err := json.Marshal(&corev1.ConfigMap{
+			TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "ConfigMap"},
+			Data:     map[string]string{"keycloak_images_optimized": optimized},
+		})
+		require.NoError(t, err)
+		return &apixv1.CompositionRevision{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   name,
+				Labels: map[string]string{keycloakServiceIDLabel: keycloakServiceID},
+			},
+			Spec: apixv1.CompositionRevisionSpec{
+				Revision: revNum,
+				Pipeline: []apixv1.PipelineStep{
+					{Step: "keycloak-func", Input: &runtime.RawExtension{Raw: raw}},
+				},
+			},
+		}
+	}
+
+	handlerWith := func(objs ...client.Object) KeycloakWebhookHandler {
+		return KeycloakWebhookHandler{DefaultWebhookHandler: DefaultWebhookHandler{
+			client: fake.NewClientBuilder().WithScheme(pkg.SetupScheme()).WithObjects(objs...).Build(),
+			log:    logr.Discard(),
+		}}
+	}
+
+	claim := func(relativePath string) *vshnv1.VSHNKeycloak {
+		return &vshnv1.VSHNKeycloak{
+			Spec: vshnv1.VSHNKeycloakSpec{
+				Parameters: vshnv1.VSHNKeycloakParameters{
+					Service: vshnv1.VSHNKeycloakServiceSpec{RelativePath: relativePath},
+				},
+			},
+		}
+	}
+
+	ctx := context.TODO()
+
+	t.Log("latest revision optimized=true + non-root relativePath: expect warning")
+	h := handlerWith(revision(t, "rev-1", 1, "false"), revision(t, "rev-2", 2, "true"))
+	warnings := h.warnRelativePathDisablesOptimized(ctx, claim("/auth"))
+	assert.Len(t, warnings, 1)
+	assert.Contains(t, warnings[0], "relativePath")
+	assert.Contains(t, warnings[0], "--optimized is omitted")
+
+	t.Log("trailing slash is also non-root: expect warning")
+	assert.Len(t, h.warnRelativePathDisablesOptimized(ctx, claim("/auth/")), 1)
+
+	t.Log("latest revision optimized=false: expect no warning (older revision is true)")
+	h = handlerWith(revision(t, "rev-1", 1, "true"), revision(t, "rev-2", 2, "false"))
+	assert.Empty(t, h.warnRelativePathDisablesOptimized(ctx, claim("/auth")))
+
+	t.Log("root relativePath: expect no warning (no revision lookup)")
+	h = handlerWith(revision(t, "rev-1", 1, "true"))
+	assert.Empty(t, h.warnRelativePathDisablesOptimized(ctx, claim("/")))
+
+	t.Log("no revisions present: expect no warning, no error")
+	h = handlerWith()
+	assert.Empty(t, h.warnRelativePathDisablesOptimized(ctx, claim("/auth")))
 }
 
 func TestKeycloakWebhookHandler_ValidatePostgreSQLEncryptionChanges(t *testing.T) {


### PR DESCRIPTION
## Summary

Keycloak health probes (liveness/readiness/startup) hardcoded paths to `/health/live`, `/health/ready`, and `/health`. When a custom `service.relativePath` is set (e.g. `/auth`), Keycloak serves its health endpoints under `KC_HTTP_RELATIVE_PATH`, so the probes pointed at the wrong path and failed leaving pods unready.

While testing I also found that a non-root `relativePath` is mutually exclusive with `keycloak_images_optimized`. KC_HTTP_RELATIVE_PATH is a build-time option, so under `--optimized` the path is ignored and the pod crash-loops. We now drop `--optimized` for such instances and a webhook warns about the combination.

## Checklist

- [x] Update tests.
- [ ] Link this PR to related issues.
- [ ] Merge with `/merge` comment.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->


Component PR: https://github.com/vshn/component-appcat/pull/1217