### PR TITLE
Fix keycloak prober to work with relativePath

### DIFF
--- a/pkg/comp-functions/functions/vshnkeycloak/deploy.go
+++ b/pkg/comp-functions/functions/vshnkeycloak/deploy.go
@@ -1321,6 +1321,8 @@ func copyKeycloakCredentials(comp *vshnv1.VSHNKeycloak, svc *runtime.ServiceRunt
 
 func addServiceMonitor(comp *vshnv1.VSHNKeycloak, svc *runtime.ServiceRuntime) error {
 
+	basePath := strings.TrimSuffix(comp.Spec.Parameters.Service.RelativePath, "/")
+
 	serviceMonitor := prom.ServiceMonitor{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      comp.GetName() + "-service-monitor",
@@ -1337,7 +1339,7 @@ func addServiceMonitor(comp *vshnv1.VSHNKeycloak, svc *runtime.ServiceRuntime) e
 			Endpoints: []prom.Endpoint{
 				{
 					Port:     "http-internal",
-					Path:     "/metrics",
+					Path:     basePath + "/metrics",
 					Interval: "15s",
 					Scheme:   "https",
 					TLSConfig: &prom.TLSConfig{
@@ -1348,7 +1350,7 @@ func addServiceMonitor(comp *vshnv1.VSHNKeycloak, svc *runtime.ServiceRuntime) e
 				},
 				{
 					Port:     "http",
-					Path:     "/realms/master/metrics",
+					Path:     basePath + "/realms/master/metrics",
 					Interval: "15s",
 					Scheme:   "http",
 				},

--- a/pkg/comp-functions/functions/vshnkeycloak/deploy_test.go
+++ b/pkg/comp-functions/functions/vshnkeycloak/deploy_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	prom "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/stretchr/testify/assert"
 	xhelmv1 "github.com/vshn/appcat/v4/apis/helm/release/v1beta1"
 	xkube "github.com/vshn/appcat/v4/apis/kubernetes/v1alpha2"
@@ -384,6 +385,66 @@ func Test_probeRelativePath(t *testing.T) {
 			assert.Contains(t, values["livenessProbe"], "\"path\": \""+tc.wantLiveness+"\"")
 			assert.Contains(t, values["readinessProbe"], "\"path\": \""+tc.wantReady+"\"")
 			assert.Contains(t, values["startupProbe"], "\"path\": \""+tc.wantStartup+"\"")
+		})
+	}
+}
+
+func Test_serviceMonitorRelativePath(t *testing.T) {
+	tests := map[string]struct {
+		relativePath string
+		wantInternal string
+		wantRealms   string
+	}{
+		"default root path": {
+			relativePath: "/",
+			wantInternal: "/metrics",
+			wantRealms:   "/realms/master/metrics",
+		},
+		"empty path": {
+			relativePath: "",
+			wantInternal: "/metrics",
+			wantRealms:   "/realms/master/metrics",
+		},
+		"custom relative path": {
+			relativePath: "/auth",
+			wantInternal: "/auth/metrics",
+			wantRealms:   "/auth/realms/master/metrics",
+		},
+		"custom relative path with trailing slash": {
+			relativePath: "/auth/",
+			wantInternal: "/auth/metrics",
+			wantRealms:   "/auth/realms/master/metrics",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			svc := commontest.LoadRuntimeFromFile(t, "vshnkeycloak/01_default.yaml")
+			comp := &vshnv1.VSHNKeycloak{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "mycloak",
+					Namespace: "default",
+				},
+				Spec: vshnv1.VSHNKeycloakSpec{
+					Parameters: vshnv1.VSHNKeycloakParameters{
+						Service: vshnv1.VSHNKeycloakServiceSpec{
+							RelativePath: tc.relativePath,
+						},
+					},
+				},
+			}
+
+			assert.NoError(t, addServiceMonitor(comp, svc))
+
+			sm := &prom.ServiceMonitor{}
+			assert.NoError(t, svc.GetDesiredKubeObject(sm, comp.GetName()+"-service-monitor"))
+
+			paths := map[string]string{}
+			for _, ep := range sm.Spec.Endpoints {
+				paths[ep.Port] = ep.Path
+			}
+			assert.Equal(t, tc.wantInternal, paths["http-internal"])
+			assert.Equal(t, tc.wantRealms, paths["http"])
 		})
 	}
 }

--- a/pkg/sliexporter/vshnkeycloak_controller/vshnkeycloak_controller.go
+++ b/pkg/sliexporter/vshnkeycloak_controller/vshnkeycloak_controller.go
@@ -5,6 +5,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
+	"strings"
 	"time"
 
 	vshnv1 "github.com/vshn/appcat/v4/apis/vshn/v1"
@@ -85,7 +86,7 @@ func (r VSHNKeycloakReconciler) getKeycloakProber(ctx context.Context, obj slire
 		return nil, fmt.Errorf("secret does not contain Keycloak url")
 	}
 
-	url := "https://" + string(host) + ":9000/health"
+	url := keycloakHealthURL(string(host), inst.Spec.Parameters.Service.RelativePath)
 
 	rawCACert, ok := credentials.Data["ca.crt"]
 	if !ok {
@@ -104,6 +105,11 @@ func (r VSHNKeycloakReconciler) getKeycloakProber(ctx context.Context, obj slire
 	compositionName := inst.Spec.CompositionRef.Name
 
 	return probes.NewHTTP(url, true, cert, vshnKeycloakServiceKey, inst.GetName(), claimNamespace, instanceNamespace, org, string(sla), compositionName, ha), nil
+}
+
+func keycloakHealthURL(host, relativePath string) string {
+	basePath := strings.TrimSuffix(relativePath, "/")
+	return "https://" + host + ":9000" + basePath + "/health"
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/pkg/sliexporter/vshnkeycloak_controller/vshnkeycloak_controller_test.go
+++ b/pkg/sliexporter/vshnkeycloak_controller/vshnkeycloak_controller_test.go
@@ -132,6 +132,33 @@ func TestVSHNKeycloak_Suspended_Stop_Running_Probe(t *testing.T) {
 	assert.False(t, manager.probers[getFakeKey(pi)])
 }
 
+func TestKeycloakHealthURL(t *testing.T) {
+	tests := map[string]struct {
+		host         string
+		relativePath string
+		want         string
+	}{
+		"root path empty": {
+			host: "kc.example.svc", relativePath: "", want: "https://kc.example.svc:9000/health",
+		},
+		"root path slash": {
+			host: "kc.example.svc", relativePath: "/", want: "https://kc.example.svc:9000/health",
+		},
+		"custom relative path": {
+			host: "kc.example.svc", relativePath: "/auth", want: "https://kc.example.svc:9000/auth/health",
+		},
+		"custom relative path trailing slash": {
+			host: "kc.example.svc", relativePath: "/auth/", want: "https://kc.example.svc:9000/auth/health",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.want, keycloakHealthURL(tc.host, tc.relativePath))
+		})
+	}
+}
+
 func setupVSHNKeycloakTest(t *testing.T, objs ...client.Object) (VSHNKeycloakReconciler, *fakeProbeManager, client.Client) {
 	scheme := runtime.NewScheme()
 	require.NoError(t, clientgoscheme.AddToScheme(scheme))


### PR DESCRIPTION
## Summary

The SLI prober and the appcat ServiceMonitor hardcoded Keycloak's health/metrics paths, so instances with a non-root `service.relativePath` got 404s and firing false `VSHNKeycloakSla down` alerts and silently dropping realm metrics. This prefixes both with the trimmed `relativePath`

## Checklist

- [x] Update tests.
- [x] Link this PR to related issues.
- [ ] Follow [deprecation guidelines](https://github.com/vshn/appcat#deprecation-guidelines) where applicable.
- [x] Merge with `/merge` comment.


Component PR: https://github.com/vshn/component-appcat/pull/1223