### PR TITLE
Override APPUiO activeDeadlineSeconds

### DIFF
--- a/pkg/common/quotas/quotas.go
+++ b/pkg/common/quotas/quotas.go
@@ -206,6 +206,11 @@ func AddInitalNamespaceQuotas(ctx context.Context, ns *corev1.Namespace, s *util
 		added = true
 	}
 
+	if _, ok := annotations[utils.ActiveDeadlineSecondsOverrideAnnotation]; !ok {
+		annotations[utils.ActiveDeadlineSecondsOverrideAnnotation] = utils.DefaultActiveDeadlineSeconds
+		added = true
+	}
+
 	// Add Exoscale-specific storage class quotas
 	if cloudProvider == "exoscale" {
 		if _, ok := annotations[utils.StorageClassesAnnotation]; !ok {

--- a/pkg/common/utils/resources.go
+++ b/pkg/common/utils/resources.go
@@ -63,6 +63,15 @@ const (
 
 	// Message snippets
 	contactSupportMessage = "Please reduce the resources and then contact VSHN support to increase the quota for the instance support@vshn.ch."
+
+	// ActiveDeadlineSecondsOverrideAnnotation overrides APPUiO Cloud's default
+	// activeDeadlineSeconds (30m) applied to run-once pods (Jobs/CronJobs).
+	// Value must be a plain number of seconds, e.g. "3600".
+	ActiveDeadlineSecondsOverrideAnnotation = "appuio.io/active-deadline-seconds-override"
+	// DefaultActiveDeadlineSeconds is the deadline (in seconds) we set for
+	// run-once pods so service jobs (backup/restore/maintenance) aren't killed
+	// after the 30m APPUiO Cloud default. 2h.
+	DefaultActiveDeadlineSeconds = "7200"
 )
 
 var (


### PR DESCRIPTION
## Summary

* APPUiO Cloud defaults `activeDeadlineSeconds` to 30m for run-once pods (Jobs/CronJobs). Ran into a PostgreSQL backup taking longer than 30m and getting terminated.
* Sets `appuio.io/active-deadline-seconds-override: 7200` (2h) on instance namespaces so service jobs (backup/restore/maintenance) aren't killed early.

## Checklist

- [ ] Update tests.
- [ ] Link this PR to related issues.
- [ ] Follow [deprecation guidelines](https://github.com/vshn/appcat#deprecation-guidelines) where applicable.
- [ ] Merge with `/merge` comment.



Component PR: https://github.com/vshn/component-appcat/pull/1227