### PR TITLE
fix(maintenance): skip pre maintenance backup when backups are disabled

### DIFF
--- a/pkg/maintenance/backup/k8up.go
+++ b/pkg/maintenance/backup/k8up.go
@@ -35,7 +35,8 @@ func (k *K8upBackupRunner) RunBackup(ctx context.Context, namespace, backupName 
 	}
 
 	if len(scheduleList.Items) == 0 {
-		return fmt.Errorf("no k8up Schedule found in namespace %s", namespace)
+		k.log.Info("No k8up Schedule found in namespace, skipping backup", "namespace", namespace)
+		return nil
 	}
 
 	// Use the first schedule found (there should typically only be one per instance)

--- a/pkg/maintenance/backup/k8up_test.go
+++ b/pkg/maintenance/backup/k8up_test.go
@@ -39,11 +39,10 @@ func TestK8upBackupRunner_RunBackup(t *testing.T) {
 		errContains  string
 	}{
 		{
-			name:        "GivenNoSchedule_ThenReturnError",
-			namespace:   "test-ns",
-			backupName:  "test-backup",
-			wantErr:     true,
-			errContains: "no k8up Schedule found",
+			name:       "GivenNoSchedule_ThenSkip",
+			namespace:  "test-ns",
+			backupName: "test-backup",
+			wantErr:    false,
 		},
 		{
 			name:       "GivenScheduleWithNoBackend_ThenReturnError",

--- a/pkg/maintenance/postgresqlcnpg.go
+++ b/pkg/maintenance/postgresqlcnpg.go
@@ -61,6 +61,18 @@ func NewPostgreSQLCNPG(c client.WithWatch, hc *http.Client, versionHandler relea
 
 // RunBackup executes a pre-maintenance backup
 func (p *PostgreSQLCNPG) RunBackup(ctx context.Context) error {
+	comp := &vshnv1.XVSHNPostgreSQL{}
+	if err := p.k8sClient.Get(ctx, client.ObjectKey{Name: p.compName}, comp); err != nil {
+		return fmt.Errorf("couldn't get composite: %w", err)
+	}
+
+	// Backup disabled means the barman-cloud plugin is not configured on the cluster,
+	// so a Backup resource would fail. Skip it like the other runners do.
+	if !comp.Spec.Parameters.Backup.IsEnabled() {
+		p.log.Info("Backup disabled, skipping pre-maintenance backup")
+		return nil
+	}
+
 	return p.backupHelper.RunBackup(ctx)
 }
 

--- a/pkg/maintenance/postgresqlcnpg.go
+++ b/pkg/maintenance/postgresqlcnpg.go
@@ -67,7 +67,7 @@ func (p *PostgreSQLCNPG) RunBackup(ctx context.Context) error {
 	}
 
 	// Backup disabled means the barman-cloud plugin is not configured on the cluster,
-	// so a Backup resource would fail. Skip it like the other runners do.
+	// so a Backup resource would fail.
 	if !comp.Spec.Parameters.Backup.IsEnabled() {
 		p.log.Info("Backup disabled, skipping pre-maintenance backup")
 		return nil

--- a/pkg/maintenance/postgresqlcnpg_test.go
+++ b/pkg/maintenance/postgresqlcnpg_test.go
@@ -271,3 +271,20 @@ func Test_RetrieveObjectsAndPatchImageCatalog(t *testing.T) {
 	err = p.applyImageCatalog(context.TODO(), latestCatalog, fakeCluster)
 	require.NoError(t, err)
 }
+
+// When backup is disabled the barman-cloud plugin is absent, so a pre-maintenance
+// Backup would fail. RunBackup must skip instead of aborting maintenance.
+func Test_RunBackup_Disabled_Skips(t *testing.T) {
+	comp, _, _ := newTestObjects(16)
+	disabled := false
+	comp.Spec.Parameters.Backup.Enabled = &disabled
+
+	fclient := fake.NewClientBuilder().
+		WithScheme(pkg.SetupScheme()).
+		WithObjects(comp).
+		Build()
+
+	p := newTestRunner(fclient, "")
+
+	require.NoError(t, p.RunBackup(context.TODO()))
+}


### PR DESCRIPTION
## Summary

* This fixes the issue where maintenance fails when backups are disabled.
* Our maintenance treated missing backup configurations as an error and aborted

## Checklist

- [x] Update tests.
- [ ] Link this PR to related issues.
- [ ] Follow [deprecation guidelines](https://github.com/vshn/appcat#deprecation-guidelines) where applicable.
- [ ] Merge with `/merge` comment.


Component PR: https://github.com/vshn/component-appcat/pull/1228