### PR TITLE
Read desired release in redis pvc resize fallback

### DIFF
--- a/pkg/comp-functions/functions/vshnredis/pvcresize.go
+++ b/pkg/comp-functions/functions/vshnredis/pvcresize.go
@@ -36,6 +36,11 @@ func ResizePVCs(ctx context.Context, comp *vshnv1.VSHNRedis, svc *runtime.Servic
 	}
 
 	release, err := getObservedOrDesiredRelease(svc)
+	if err == runtime.ErrNotFound {
+		// Release isn't created yet. Nothing to resize and we must not fatal here
+		// or the whole desired state gets discarded, which would deadlock the bootstrap.
+		return nil
+	}
 	if err != nil {
 		return runtime.NewFatalResult(fmt.Errorf("cannot get release: %w", err))
 	}
@@ -146,18 +151,23 @@ func getSizeAsInt(size string) (int64, error) {
 	return finalSize, nil
 }
 
+// getObservedOrDesiredRelease returns the redis release, preferring the observed
+// one and falling back to the desired one (which the deploy step may have just
+// added in this same reconcile). Returns runtime.ErrNotFound if it exists in
+// neither, so callers can skip rather than fatal.
 func getObservedOrDesiredRelease(svc *runtime.ServiceRuntime) (*helmv1beta1.Release, error) {
 	r := &helmv1beta1.Release{}
 	err := svc.GetObservedComposedResource(r, redisRelease)
-	if err != nil && err != runtime.ErrNotFound {
-		return nil, fmt.Errorf("cannot get redis release from observed iof: %v", err)
+	if err == nil {
+		return r, nil
+	}
+	if err != runtime.ErrNotFound {
+		return nil, fmt.Errorf("cannot get redis release from observed iof: %w", err)
 	}
 
-	if err == runtime.ErrNotFound {
-		err := svc.GetObservedComposedResource(r, redisRelease)
-		if err != nil {
-			return nil, fmt.Errorf("cannot get redis release from desired iof: %v", err)
-		}
+	// Not observed yet, try desired.
+	if err := svc.GetDesiredComposedResourceByName(r, redisRelease); err != nil {
+		return nil, err
 	}
 	return r, nil
 }

--- a/pkg/comp-functions/functions/vshnredis/pvcresize_test.go
+++ b/pkg/comp-functions/functions/vshnredis/pvcresize_test.go
@@ -36,6 +36,16 @@ func TestPVCResize(t *testing.T) {
 	assert.Nil(t, ResizePVCs(ctx, &vshnv1.VSHNRedis{}, svc))
 	assert.Error(t, svc.GetDesiredKubeObject(job, "redis-gc9x4-sts-deleter"))
 
+	// Fresh creation: release exists only in desired (not yet observed).
+	// Must not fatal, resize has to read the desired release as fallback.
+	svc = commontest.LoadRuntimeFromFile(t, "vshnredis/pvcresize/01_fresh.yaml")
+	assert.Nil(t, ResizePVCs(ctx, &vshnv1.VSHNRedis{}, svc))
+
+	// No release at all yet (namespace still bootstrapping). Must skip, not
+	// fatal, otherwise the desired state gets discarded and bootstrap deadlocks.
+	svc = commontest.LoadRuntimeFromFile(t, "vshnredis/pvcresize/01_no_release.yaml")
+	assert.Nil(t, ResizePVCs(ctx, &vshnv1.VSHNRedis{}, svc))
+
 }
 
 func Test_needReleasePatch(t *testing.T) {

--- a/test/functions/vshnredis/pvcresize/01_fresh.yaml
+++ b/test/functions/vshnredis/pvcresize/01_fresh.yaml
@@ -1,0 +1,68 @@
+desired:
+  composite:
+    resource:
+      apiVersion: vshn.appcat.vshn.io/v1
+      kind: XVSHNRedis
+      metadata:
+        creationTimestamp: "2023-03-21T16:52:31Z"
+        finalizers:
+        - composite.apiextensions.crossplane.io
+        generateName: redis-
+        generation: 13
+        labels:
+          appuio.io/organization: vshn
+          crossplane.io/claim-name: redis
+          crossplane.io/claim-namespace: unit-test
+          crossplane.io/composite: redis-gc9x4
+        name: redis-gc9x4
+      spec:
+        parameters:
+          service:
+            version: "7.0"
+          size:
+            disk: 16Gi
+        writeConnectionSecretToRef: {}
+      status: {}
+  resources:
+    release:
+      resource:
+        apiVersion: helm.crossplane.io/v1beta1
+        kind: Release
+        spec:
+          forProvider:
+            chart:
+              name: redis
+              repository: https://charts.bitnami.com/bitnami
+            values:
+              architecture: standalone
+              fullnameOverride: redis
+              replica:
+                persistence:
+                  size: 16Gi
+          providerConfigRef:
+            name: helm
+observed:
+  composite:
+    resource:
+      apiVersion: vshn.appcat.vshn.io/v1
+      kind: XVSHNRedis
+      metadata:
+        creationTimestamp: "2023-03-21T16:52:31Z"
+        finalizers:
+        - composite.apiextensions.crossplane.io
+        generateName: redis-
+        generation: 13
+        labels:
+          appuio.io/organization: vshn
+          crossplane.io/claim-name: redis
+          crossplane.io/claim-namespace: unit-test
+          crossplane.io/composite: redis-gc9x4
+        name: redis-gc9x4
+      spec:
+        parameters:
+          service:
+            version: "7.0"
+          size:
+            disk: 16Gi
+        writeConnectionSecretToRef: {}
+      status: {}

--- a/test/functions/vshnredis/pvcresize/01_no_release.yaml
+++ b/test/functions/vshnredis/pvcresize/01_no_release.yaml
@@ -1,0 +1,50 @@
+desired:
+  composite:
+    resource:
+      apiVersion: vshn.appcat.vshn.io/v1
+      kind: XVSHNRedis
+      metadata:
+        creationTimestamp: "2023-03-21T16:52:31Z"
+        finalizers:
+        - composite.apiextensions.crossplane.io
+        generateName: redis-
+        generation: 13
+        labels:
+          appuio.io/organization: vshn
+          crossplane.io/claim-name: redis
+          crossplane.io/claim-namespace: unit-test
+          crossplane.io/composite: redis-gc9x4
+        name: redis-gc9x4
+      spec:
+        parameters:
+          service:
+            version: "7.0"
+          size:
+            disk: 16Gi
+        writeConnectionSecretToRef: {}
+      status: {}
+observed:
+  composite:
+    resource:
+      apiVersion: vshn.appcat.vshn.io/v1
+      kind: XVSHNRedis
+      metadata:
+        creationTimestamp: "2023-03-21T16:52:31Z"
+        finalizers:
+        - composite.apiextensions.crossplane.io
+        generateName: redis-
+        generation: 13
+        labels:
+          appuio.io/organization: vshn
+          crossplane.io/claim-name: redis
+          crossplane.io/claim-namespace: unit-test
+          crossplane.io/composite: redis-gc9x4
+        name: redis-gc9x4
+      spec:
+        parameters:
+          service:
+            version: "7.0"
+          size:
+            disk: 16Gi
+        writeConnectionSecretToRef: {}
+      status: {}


### PR DESCRIPTION
## Summary

getObservedOrDesiredRelease re-queried observed instead of desired on the not-found fallback, so day-one instances with size.disk set fatal'd (release exists only in desired) and never deployed. Add fresh-creation test covering the desired-only path.

## Checklist

- [ ] Update tests.
- [ ] Link this PR to related issues.
- [ ] Follow [deprecation guidelines](https://github.com/vshn/appcat#deprecation-guidelines) where applicable.
- [ ] Merge with `/merge` comment.

Component PR: https://github.com/vshn/component-appcat/pull/1236