### PR TITLE
Fix a potential early return for pg ready check

### DIFF
--- a/pkg/comp-functions/functions/vshnkeycloak/deploy.go
+++ b/pkg/comp-functions/functions/vshnkeycloak/deploy.go
@@ -130,24 +130,29 @@ func DeployKeycloak(ctx context.Context, comp *vshnv1.VSHNKeycloak, svc *runtime
 		return runtime.NewWarningResult(fmt.Sprintf("cannot deploy pull secret: %s", err))
 	}
 
-	svc.Log.Info("Checking readiness of cluster")
+	obsRelease := &xhelmv1.Release{}
+	err = svc.GetObservedComposedResource(obsRelease, comp.GetName()+"-release")
+	if err == runtime.ErrNotFound {
 
-	resourceCDMap := map[string][]string{
-		comp.GetName() + common.PgInstanceNameSuffix: {
-			vshnpostgres.PostgresqlHost,
-			vshnpostgres.PostgresqlPort,
-			vshnpostgres.PostgresqlDb,
-			vshnpostgres.PostgresqlUser,
-			vshnpostgres.PostgresqlPassword,
-		},
-	}
+		svc.Log.Info("Checking readiness of cluster")
 
-	ready, err := svc.WaitForObservedDependenciesWithConnectionDetails(comp.GetName(), resourceCDMap)
-	if err != nil {
-		// We're returning a fatal here, so in case something is wrong we won't delete anything by mistake.
-		return runtime.NewFatalResult(err)
-	} else if !ready {
-		return runtime.NewWarningResult("postgresql instance not yet ready")
+		resourceCDMap := map[string][]string{
+			comp.GetName() + common.PgInstanceNameSuffix: {
+				vshnpostgres.PostgresqlHost,
+				vshnpostgres.PostgresqlPort,
+				vshnpostgres.PostgresqlDb,
+				vshnpostgres.PostgresqlUser,
+				vshnpostgres.PostgresqlPassword,
+			},
+		}
+
+		ready, err := svc.WaitForObservedDependenciesWithConnectionDetails(comp.GetName(), resourceCDMap)
+		if err != nil {
+			// We're returning a fatal here, so in case something is wrong we won't delete anything by mistake.
+			return runtime.NewFatalResult(err)
+		} else if !ready {
+			return runtime.NewWarningResult("postgresql instance not yet ready")
+		}
 	}
 
 	svc.Log.Info("Adding release")


### PR DESCRIPTION


## Summary

There's a chance that the deployment of keycloak returns early due to a an unready PostgreSQL.

The readiness check for PostgreSQL only has the purpose to make the initial provisioning faster. It ensures that all the necessary connection details are provisioned before the Keycloak release is spawned.

This commit contains new logic to first check if the Keycloak release exists or not. If the Keycloak release exists, the check is skipped.

This will reduce the blast radius of transcient issues with the nested PostgreSQL instance.

## Checklist

- [ ] Update tests.
- [ ] Link this PR to related issues.
- [ ] Follow [deprecation guidelines](https://github.com/vshn/appcat#deprecation-guidelines) where applicable.
- [ ] Merge with `/merge` comment.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->


Component PR: https://github.com/vshn/component-appcat/pull/1239