### PR TITLE
Read gateway domain from observed XLS, not connection details

### DIFF
--- a/pkg/comp-functions/functions/common/tcproute/tcproute.go
+++ b/pkg/comp-functions/functions/common/tcproute/tcproute.go
@@ -79,6 +79,27 @@ func AddTCPRoute(svc *runtime.ServiceRuntime, cfg TCPRouteConfig) (*xfnproto.Res
 	return nil, observed
 }
 
+// ObserveGatewayDomain returns the instance's gateway domain from the observed
+// XLS and gateways config, or "" until a port is allocated.
+func ObserveGatewayDomain(svc *runtime.ServiceRuntime, resourceName string) string {
+	state := observeXListenerSet(svc, resourceName+"-xls")
+	if state.Port == 0 {
+		return ""
+	}
+
+	gatewayName := state.GatewayName
+	if gatewayName == "" {
+		gatewayName, _ = defaultGatewayName(svc, defaultGatewaysConfigKey)
+	}
+
+	domain, err := lookupDomain(svc, defaultGatewaysConfigKey, gatewayName)
+	if err != nil {
+		svc.Log.Error(err, "cannot look up gateway domain", "gateway", gatewayName)
+		return ""
+	}
+	return domain
+}
+
 func createXListenerSet(svc *runtime.ServiceRuntime, cfg TCPRouteConfig, gatewayNamespace, gatewayName string, port int32, allowedGateways []string) error {
 	xls := &unstructured.Unstructured{
 		Object: map[string]any{},

--- a/pkg/comp-functions/functions/common/tcproute/tcproute_test.go
+++ b/pkg/comp-functions/functions/common/tcproute/tcproute_test.go
@@ -26,6 +26,20 @@ func testConfig() TCPRouteConfig {
 	}
 }
 
+func TestObserveGatewayDomain(t *testing.T) {
+	t.Run("ReturnsDomainWhenPortAllocated", func(t *testing.T) {
+		svc := commontest.LoadRuntimeFromFile(t, "tcproute/02_with_port.yaml")
+		domain := ObserveGatewayDomain(svc, testConfig().ResourceName)
+		assert.Equal(t, "tcp.example.com", domain)
+	})
+
+	t.Run("EmptyUntilPortAllocated", func(t *testing.T) {
+		svc := commontest.LoadRuntimeFromFile(t, "tcproute/01_basic.yaml")
+		domain := ObserveGatewayDomain(svc, testConfig().ResourceName)
+		assert.Empty(t, domain, "no observed XListenerSet yet -> no domain")
+	})
+}
+
 func TestAddTCPRoute(t *testing.T) {
 	t.Run("AllResourcesCreated", func(t *testing.T) {
 		svc := commontest.LoadRuntimeFromFile(t, "tcproute/01_basic.yaml")

--- a/pkg/comp-functions/functions/vshnmariadb/mariadb_deploy.go
+++ b/pkg/comp-functions/functions/vshnmariadb/mariadb_deploy.go
@@ -74,7 +74,7 @@ func DeployMariadb(ctx context.Context, comp *vshnv1.VSHNMariaDB, svc *runtime.S
 	if common.ExternalAccessEnabled(svc) {
 		switch comp.Spec.Parameters.Network.ServiceType {
 		case tcproute.ServiceTypeTCPGateway:
-			if v := string(cd["MARIADB_GATEWAY_HOST"]); v != "" {
+			if v := tcproute.ObserveGatewayDomain(svc, comp.GetName()); v != "" {
 				gatewayHost = v
 				externalSans = append(externalSans, v)
 			}

--- a/pkg/comp-functions/functions/vshnpostgrescnpg/deploy.go
+++ b/pkg/comp-functions/functions/vshnpostgrescnpg/deploy.go
@@ -101,8 +101,11 @@ func createCerts(comp *vshnv1.VSHNPostgreSQL, svc *runtime.ServiceRuntime) error
 	if v, ok := cd["LOADBALANCER_IP"]; ok && comp.Spec.Parameters.Network.ServiceType == string(corev1.ServiceTypeLoadBalancer) && common.ExternalAccessEnabled(svc) {
 		ipAddresses = append(ipAddresses, string(v))
 	}
-	if v, ok := cd["POSTGRESQL_GATEWAY_HOST"]; ok && comp.Spec.Parameters.Network.ServiceType == tcproute.ServiceTypeTCPGateway && common.ExternalAccessEnabled(svc) {
-		dnsNames = append(dnsNames, string(v))
+
+	if comp.Spec.Parameters.Network.ServiceType == tcproute.ServiceTypeTCPGateway && common.ExternalAccessEnabled(svc) {
+		if h := tcproute.ObserveGatewayDomain(svc, comp.GetName()); h != "" {
+			dnsNames = append(dnsNames, h)
+		}
 	}
 
 	certificate := &cmv1.Certificate{
@@ -166,8 +169,8 @@ func createCerts(comp *vshnv1.VSHNPostgreSQL, svc *runtime.ServiceRuntime) error
 	}
 
 	if comp.Spec.Parameters.Network.ServiceType == tcproute.ServiceTypeTCPGateway && common.ExternalAccessEnabled(svc) {
-		if v, ok := cd["POSTGRESQL_GATEWAY_HOST"]; ok && string(v) != "" {
-			if err := common.WaitForCertSAN(svc, "certificate", certObserver, certificateSecretName, comp.GetInstanceNamespace(), common.CertHasDNS(string(v))); err != nil {
+		if h := tcproute.ObserveGatewayDomain(svc, comp.GetName()); h != "" {
+			if err := common.WaitForCertSAN(svc, "certificate", certObserver, certificateSecretName, comp.GetInstanceNamespace(), common.CertHasDNS(h)); err != nil {
 				return err
 			}
 		} else {

--- a/pkg/comp-functions/functions/vshnredis/redis_deploy.go
+++ b/pkg/comp-functions/functions/vshnredis/redis_deploy.go
@@ -31,7 +31,6 @@ const (
 	redisPasswordConnectionDetailsField = "REDIS_PASSWORD"
 	redisURLConnectionDetailsField      = "REDIS_URL"
 	sentinelHostsConnectionDetailsField = "SENTINEL_HOSTS"
-	redisGatewayHostConnectionDetails   = "REDIS_GATEWAY_HOST"
 
 	redisRelease = "release"
 )
@@ -73,7 +72,7 @@ func DeployRedis(ctx context.Context, comp *vshnv1.VSHNRedis, svc *runtime.Servi
 	loadbalancerIP := ""
 	if common.ExternalAccessEnabled(svc) {
 		if comp.Spec.Parameters.Network.ServiceType == tcproute.ServiceTypeTCPGateway {
-			if v := string(cd[redisGatewayHostConnectionDetails]); v != "" {
+			if v := tcproute.ObserveGatewayDomain(svc, comp.GetName()); v != "" {
 				gatewayHost = v
 				additionalSans = append(additionalSans, gatewayHost)
 			}


### PR DESCRIPTION
## Summary

Reading the gateway domain from published connection details is racy: if the first publish beats port allocation, the domain never arrives and the cert-SAN readiness gate stays closed, stranding the instance at READY=False. Read it from the observed XListenerSet instead. Fixes MariaDB, Redis, and CNPG

## Checklist

- [ ] Update tests.
- [ ] Link this PR to related issues.
- [ ] Follow [deprecation guidelines](https://github.com/vshn/appcat#deprecation-guidelines) where applicable.
- [ ] Merge with `/merge` comment.



Component PR: https://github.com/vshn/component-appcat/pull/1240