### PR TITLE
Change description for VSHNRedis default version

### DIFF
--- a/apis/vshn/v1/dbaas_vshn_redis.go
+++ b/apis/vshn/v1/dbaas_vshn_redis.go
@@ -99,7 +99,7 @@ type VSHNRedisServiceSpec struct {
 	// +kubebuilder:default="7.2"
 
 	// Version contains supported version of Redis.
-	// Multiple versions are supported. The latest version "7.2" is the default version.
+	// Multiple versions are supported. Version "7.2" is the default version.
 	Version string `json:"version,omitempty"`
 
 	// RedisSettings contains additional Redis settings.

--- a/crds/vshn.appcat.vshn.io_vshnredis.yaml
+++ b/crds/vshn.appcat.vshn.io_vshnredis.yaml
@@ -4741,7 +4741,7 @@ spec:
                           default: "7.2"
                           description: |-
                             Version contains supported version of Redis.
-                            Multiple versions are supported. The latest version "7.2" is the default version.
+                            Multiple versions are supported. Version "7.2" is the default version.
                           enum:
                             - "7.0"
                             - "7.2"

--- a/crds/vshn.appcat.vshn.io_xvshnredis.yaml
+++ b/crds/vshn.appcat.vshn.io_xvshnredis.yaml
@@ -5481,7 +5481,7 @@ spec:
                         default: "7.2"
                         description: |-
                           Version contains supported version of Redis.
-                          Multiple versions are supported. The latest version "7.2" is the default version.
+                          Multiple versions are supported. Version "7.2" is the default version.
                         enum:
                         - "7.0"
                         - "7.2"


### PR DESCRIPTION
VSHNRedis also supports version 8. The default is still 7, however it is not the latest.

Component PR: https://github.com/vshn/component-appcat/pull/1243