### PR TITLE
Update default versions for PostgreSQL and Forgejo

### DIFF
--- a/apis/vshn/v1/dbaas_vshn_forgejo.go
+++ b/apis/vshn/v1/dbaas_vshn_forgejo.go
@@ -109,7 +109,7 @@ type VSHNForgejoServiceSpec struct {
 
 	// Version contains supported version of Forgejo.
 	// Multiple versions are supported. Defaults to 14.0.0 if not set.
-	// +kubebuilder:default="14.0.0"
+	// +kubebuilder:default="15.0.0"
 	MajorVersion string `json:"majorVersion,omitempty"`
 
 	// SSH contains settings for SSH access to the Forgejo instance.

--- a/apis/vshn/v1/dbaas_vshn_postgresql.go
+++ b/apis/vshn/v1/dbaas_vshn_postgresql.go
@@ -134,7 +134,7 @@ type VSHNPostgreSQLUpdateStrategy struct {
 // VSHNPostgreSQLServiceSpec contains PostgreSQL DBaaS specific properties
 type VSHNPostgreSQLServiceSpec struct {
 	// +kubebuilder:validation:Enum="12";"13";"14";"15";"16";"17";"18"
-	// +kubebuilder:default="15"
+	// +kubebuilder:default="18"
 
 	// MajorVersion contains supported version of PostgreSQL.
 	// Multiple versions are supported. The latest version "15" is the default version.

--- a/config/controller/webhooks.yaml
+++ b/config/controller/webhooks.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:

--- a/crds/vshn.appcat.vshn.io_vshnforgejoes.yaml
+++ b/crds/vshn.appcat.vshn.io_vshnforgejoes.yaml
@@ -4755,7 +4755,7 @@ spec:
                           minItems: 1
                           type: array
                         majorVersion:
-                          default: 14.0.0
+                          default: 15.0.0
                           description: |-
                             Version contains supported version of Forgejo.
                             Multiple versions are supported. Defaults to 14.0.0 if not set.

--- a/crds/vshn.appcat.vshn.io_vshnkeycloaks.yaml
+++ b/crds/vshn.appcat.vshn.io_vshnkeycloaks.yaml
@@ -9714,7 +9714,7 @@ spec:
                                     type: object
                                   type: array
                                 majorVersion:
-                                  default: "15"
+                                  default: "18"
                                   description: |-
                                     MajorVersion contains supported version of PostgreSQL.
                                     Multiple versions are supported. The latest version "15" is the default version.

--- a/crds/vshn.appcat.vshn.io_vshnnextclouds.yaml
+++ b/crds/vshn.appcat.vshn.io_vshnnextclouds.yaml
@@ -9581,7 +9581,7 @@ spec:
                                     type: object
                                   type: array
                                 majorVersion:
-                                  default: "15"
+                                  default: "18"
                                   description: |-
                                     MajorVersion contains supported version of PostgreSQL.
                                     Multiple versions are supported. The latest version "15" is the default version.

--- a/crds/vshn.appcat.vshn.io_vshnpostgresqls.yaml
+++ b/crds/vshn.appcat.vshn.io_vshnpostgresqls.yaml
@@ -4928,7 +4928,7 @@ spec:
                             type: object
                           type: array
                         majorVersion:
-                          default: "15"
+                          default: "18"
                           description: |-
                             MajorVersion contains supported version of PostgreSQL.
                             Multiple versions are supported. The latest version "15" is the default version.

--- a/crds/vshn.appcat.vshn.io_xvshnforgejoes.yaml
+++ b/crds/vshn.appcat.vshn.io_xvshnforgejoes.yaml
@@ -5486,7 +5486,7 @@ spec:
                         minItems: 1
                         type: array
                       majorVersion:
-                        default: 14.0.0
+                        default: 15.0.0
                         description: |-
                           Version contains supported version of Forgejo.
                           Multiple versions are supported. Defaults to 14.0.0 if not set.

--- a/crds/vshn.appcat.vshn.io_xvshnkeycloaks.yaml
+++ b/crds/vshn.appcat.vshn.io_xvshnkeycloaks.yaml
@@ -11532,7 +11532,7 @@ spec:
                                   type: object
                                 type: array
                               majorVersion:
-                                default: "15"
+                                default: "18"
                                 description: |-
                                   MajorVersion contains supported version of PostgreSQL.
                                   Multiple versions are supported. The latest version "15" is the default version.

--- a/crds/vshn.appcat.vshn.io_xvshnnextclouds.yaml
+++ b/crds/vshn.appcat.vshn.io_xvshnnextclouds.yaml
@@ -11381,7 +11381,7 @@ spec:
                                   type: object
                                 type: array
                               majorVersion:
-                                default: "15"
+                                default: "18"
                                 description: |-
                                   MajorVersion contains supported version of PostgreSQL.
                                   Multiple versions are supported. The latest version "15" is the default version.

--- a/crds/vshn.appcat.vshn.io_xvshnpostgresqls.yaml
+++ b/crds/vshn.appcat.vshn.io_xvshnpostgresqls.yaml
@@ -5622,7 +5622,7 @@ spec:
                           type: object
                         type: array
                       majorVersion:
-                        default: "15"
+                        default: "18"
                         description: |-
                           MajorVersion contains supported version of PostgreSQL.
                           Multiple versions are supported. The latest version "15" is the default version.


### PR DESCRIPTION
## Summary

* We used a rather old default version for PostgreSQL as well as for Forgejo and therefore update the default version of those two services to use the latest stable major version

## Checklist

- [ ] Update tests.
- [ ] Link this PR to related issues.
- [ ] Follow [deprecation guidelines](https://github.com/vshn/appcat#deprecation-guidelines) where applicable.
- [x] Merge with `/merge` comment.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->


Component PR: https://github.com/vshn/component-appcat/pull/1248