### PR TITLE
Fix e2e tests by using fully qualified CRD name

### DIFF
--- a/pkg/comp-functions/functions/vshnpostgres/scripts/copy-pg-backup.sh
+++ b/pkg/comp-functions/functions/vshnpostgres/scripts/copy-pg-backup.sh
@@ -9,9 +9,9 @@ then
     xrdservicename=$(kubectl -n "${CLAIM_NAMESPACE}" get "${xrdtype#?}" "${CLAIM_NAME}" -ojson | jq -r '.spec.resourceRef.name')
     xrdname=$(kubectl -n "${CLAIM_NAMESPACE}" get "${xrdtype}" "${xrdservicename}" -ojson | jq -r '.spec.resourceRefs | map(select(.kind == "XVSHNPostgreSQL")) | .[].name')
 else
-    xrdname=$(kubectl -n "${CLAIM_NAMESPACE}" get vshnpostgresqls "${CLAIM_NAME}" -ojson | jq -r '.spec.resourceRef.name')
+    xrdname=$(kubectl -n "${CLAIM_NAMESPACE}" get vshnpostgresqls.vshn.appcat.vshn.io "${CLAIM_NAME}" -ojson | jq -r '.spec.resourceRef.name')
 fi
-source_namespace=$(kubectl get xvshnpostgresqls "${xrdname}" -ojson | jq -r '.status.instanceNamespace')
+source_namespace=$(kubectl get xvshnpostgresqls.vshn.appcat.vshn.io "${xrdname}" -ojson | jq -r '.status.instanceNamespace')
 
 echo "copy secret"
 kubectl -n "${source_namespace}" get secret "pgbucket-${xrdname}" -ojson | jq 'del(.metadata.namespace) | del(.metadata.ownerReferences)' | kubectl -n "${TARGET_NAMESPACE}" apply -f -

--- a/pkg/comp-functions/functions/vshnpostgrescnpg/scripts/copy-cnpg-backup-creds.sh
+++ b/pkg/comp-functions/functions/vshnpostgrescnpg/scripts/copy-cnpg-backup-creds.sh
@@ -9,13 +9,13 @@ then
     xrdservicename=$(kubectl -n "${CLAIM_NAMESPACE}" get "${xrdtype#?}" "${CLAIM_NAME}" -ojson | jq -r '.spec.resourceRef.name')
     xrdname=$(kubectl -n "${CLAIM_NAMESPACE}" get "${xrdtype}" "${xrdservicename}" -ojson | jq -r '.spec.resourceRefs | map(select(.kind == "XVSHNPostgreSQL")) | .[].name')
 else
-    xrdname=$(kubectl -n "${CLAIM_NAMESPACE}" get vshnpostgresqls "${CLAIM_NAME}" -ojson | jq -r '.spec.resourceRef.name')
+    xrdname=$(kubectl -n "${CLAIM_NAMESPACE}" get vshnpostgresqls.vshn.appcat.vshn.io "${CLAIM_NAME}" -ojson | jq -r '.spec.resourceRef.name')
 fi
 
 echo "resolved source composite: ${xrdname}"
 
 # Get source instance's major version
-source_major_version=$(kubectl get xvshnpostgresqls "${xrdname}" -ojson | jq -r '.spec.parameters.service.majorVersion')
+source_major_version=$(kubectl get xvshnpostgresqls.vshn.appcat.vshn.io "${xrdname}" -ojson | jq -r '.spec.parameters.service.majorVersion')
 echo "source major version: ${source_major_version}"
 
 # Read backup bucket credentials from the Crossplane namespace


### PR DESCRIPTION
## Summary

* We can't use the short form anymore because with appcat 2.0 we use the same short form of the CRD as with appcat 1.0 with causes conflicts when only using the short form

## Checklist

- [x] Update tests.
- [ ] Link this PR to related issues.
- [ ] Follow [deprecation guidelines](https://github.com/vshn/appcat#deprecation-guidelines) where applicable.
- [x] Merge with `/merge` comment.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->


Component PR: https://github.com/vshn/component-appcat/pull/1250