### PR TITLE
Fix pinImageTag warning short-circuiting webhook validation

### DIFF
--- a/pkg/controller/webhooks/codey.go
+++ b/pkg/controller/webhooks/codey.go
@@ -72,9 +72,6 @@ func (n *CodeyInstanceWebhookHandler) ValidateCreate(ctx context.Context, obj ru
 		tmpErr := err.(*fieldErrors)
 		allErrs.Add(tmpErr.List()...)
 	}
-	if warning != nil && err == nil {
-		return warning, nil
-	}
 
 	codeyFqdn := codeyInstance.ObjectMeta.Name + codeyUrlSuffix
 
@@ -83,7 +80,7 @@ func (n *CodeyInstanceWebhookHandler) ValidateCreate(ctx context.Context, obj ru
 		allErrs.Add(err)
 	}
 
-	return nil, allErrs.Get()
+	return warning, allErrs.Get()
 }
 
 // ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type
@@ -104,16 +101,13 @@ func (p *CodeyInstanceWebhookHandler) ValidateUpdate(ctx context.Context, oldObj
 		tmpErr := parentErr.(*fieldErrors)
 		allErrs.Add(tmpErr.List()...)
 	}
-	if warnings != nil {
-		return warnings, nil
-	}
 
 	codeyFqdn := newCodeyInstance.ObjectMeta.Name + codeyUrlSuffix
 	if err := isCodeyFqdnUnique(codeyFqdn, newCodeyInstance.Spec.ResourceRef.Name, p.client); err != nil {
 		allErrs.Add(err)
 	}
 
-	return nil, allErrs.Get()
+	return warnings, allErrs.Get()
 }
 
 // Checks if a given FQDN is already in use by some CodeyInstance in the cluster

--- a/pkg/controller/webhooks/forgejo.go
+++ b/pkg/controller/webhooks/forgejo.go
@@ -69,9 +69,6 @@ func (n *ForgejoWebhookHandler) ValidateCreate(ctx context.Context, obj runtime.
 		tmpErr := err.(*fieldErrors)
 		allErrs.Add(tmpErr.List()...)
 	}
-	if warning != nil && err == nil {
-		return warning, nil
-	}
 
 	if err := validateFQDNs(forgejo.Spec.Parameters.Service.FQDN); err != nil {
 		allErrs.Add(err)
@@ -81,7 +78,7 @@ func (n *ForgejoWebhookHandler) ValidateCreate(ctx context.Context, obj runtime.
 		allErrs.Add(err)
 	}
 
-	return nil, allErrs.Get()
+	return warning, allErrs.Get()
 }
 
 // ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type
@@ -106,9 +103,6 @@ func (p *ForgejoWebhookHandler) ValidateUpdate(ctx context.Context, oldObj, newO
 		tmpErr := err.(*fieldErrors)
 		allErrs.Add(tmpErr.List()...)
 	}
-	if warnings != nil && err == nil {
-		return warnings, nil
-	}
 
 	if err := validateFQDNs(newForgejo.Spec.Parameters.Service.FQDN); err != nil {
 		allErrs.Add(err)
@@ -118,7 +112,7 @@ func (p *ForgejoWebhookHandler) ValidateUpdate(ctx context.Context, oldObj, newO
 		allErrs.Add(err)
 	}
 
-	return nil, allErrs.Get()
+	return warnings, allErrs.Get()
 }
 
 func validateForgejoConfig(settings vshnv1.VSHNForgejoSettings) *field.Error {

--- a/pkg/controller/webhooks/forgejo_test.go
+++ b/pkg/controller/webhooks/forgejo_test.go
@@ -1,0 +1,67 @@
+package webhooks
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	vshnv1 "github.com/vshn/appcat/v4/apis/vshn/v1"
+	"github.com/vshn/appcat/v4/pkg"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestForgejoWebhookHandler_ValidateCreate_DeniedMailerProtocol(t *testing.T) {
+	ctx := context.TODO()
+	fclient := fake.NewClientBuilder().
+		WithScheme(pkg.SetupScheme()).
+		Build()
+
+	handler := ForgejoWebhookHandler{
+		DefaultWebhookHandler: DefaultWebhookHandler{
+			client:     fclient,
+			log:        logr.Discard(),
+			withQuota:  false,
+			obj:        &vshnv1.VSHNForgejo{},
+			name:       "forgejo",
+			nameLength: 30,
+		},
+	}
+
+	newForgejo := func(pinImageTag string) *vshnv1.VSHNForgejo {
+		return &vshnv1.VSHNForgejo{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "myinstance",
+				Namespace: "testns",
+			},
+			Spec: vshnv1.VSHNForgejoSpec{
+				Parameters: vshnv1.VSHNForgejoParameters{
+					Service: vshnv1.VSHNForgejoServiceSpec{
+						FQDN: []string{"myforgejo.example.tld"},
+						ForgejoSettings: vshnv1.VSHNForgejoSettings{
+							Config: vshnv1.VSHNForgejoConfig{
+								Mailer: map[string]string{
+									"PROTOCOL": "sendmail",
+								},
+							},
+						},
+					},
+					Maintenance: vshnv1.VSHNDBaaSMaintenanceScheduleSpec{
+						PinImageTag: pinImageTag,
+					},
+				},
+			},
+		}
+	}
+
+	t.Log("denied mailer protocol without pinImageTag: expect rejection")
+	_, err := handler.ValidateCreate(ctx, newForgejo(""))
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "bad mailer.PROTOCOL")
+
+	t.Log("denied mailer protocol with pinImageTag set: expect rejection (no bypass)")
+	_, err = handler.ValidateCreate(ctx, newForgejo("forgejo:1.0.0"))
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "bad mailer.PROTOCOL")
+}

--- a/pkg/controller/webhooks/mariadb.go
+++ b/pkg/controller/webhooks/mariadb.go
@@ -70,9 +70,6 @@ func (p *MariaDBWebhookHandler) ValidateUpdate(ctx context.Context, oldObj, newO
 		tmpErr := err.(*fieldErrors)
 		allErs.Add(tmpErr.List()...)
 	}
-	if warnings != nil && err == nil {
-		return warnings, nil
-	}
 
 	if newDb.Spec.Parameters.Instances > 1 {
 		if oldDb.Spec.Parameters.TLS.TLSEnabled != newDb.Spec.Parameters.TLS.TLSEnabled {
@@ -84,5 +81,5 @@ func (p *MariaDBWebhookHandler) ValidateUpdate(ctx context.Context, oldObj, newO
 		}
 	}
 
-	return nil, allErs.Get()
+	return warnings, allErs.Get()
 }

--- a/pkg/controller/webhooks/nextcloud.go
+++ b/pkg/controller/webhooks/nextcloud.go
@@ -63,9 +63,6 @@ func (n *NextcloudWebhookHandler) ValidateCreate(ctx context.Context, obj runtim
 		tmpErr := err.(*fieldErrors)
 		allErrs.Add(tmpErr.List()...)
 	}
-	if warning != nil && err == nil {
-		return warning, nil
-	}
 
 	if err := validateFQDNs(nx.Spec.Parameters.Service.FQDN); err != nil {
 		allErrs.Add(err)
@@ -84,7 +81,7 @@ func (n *NextcloudWebhookHandler) ValidateCreate(ctx context.Context, obj runtim
 		}
 	}
 
-	return nil, allErrs.Get()
+	return warning, allErrs.Get()
 }
 
 func (n *NextcloudWebhookHandler) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
@@ -103,9 +100,6 @@ func (n *NextcloudWebhookHandler) ValidateUpdate(ctx context.Context, oldObj, ne
 	if err != nil {
 		tmpErr := err.(*fieldErrors)
 		allErrs.Add(tmpErr.List()...)
-	}
-	if warning != nil && err == nil {
-		return warning, err
 	}
 
 	oldNx, ok := oldObj.(*vshnv1.VSHNNextcloud)
@@ -146,7 +140,7 @@ func (n *NextcloudWebhookHandler) ValidateUpdate(ctx context.Context, oldObj, ne
 		}
 	}
 
-	return nil, allErrs.Get()
+	return warning, allErrs.Get()
 }
 
 func validateNoVersionDowngrade(oldVersion, newVersion string) *field.Error {

--- a/pkg/controller/webhooks/nextcloud_test.go
+++ b/pkg/controller/webhooks/nextcloud_test.go
@@ -405,6 +405,53 @@ func TestNextcloudWebhookHandler_ValidateUpdate_CollaboraFQDN(t *testing.T) {
 	assert.NoError(t, err, "Updating Collabora FQDN to another valid one should pass validation")
 }
 
+func TestNextcloudWebhookHandler_ValidateCreate_PinImageTagNoBypass(t *testing.T) {
+	ctx := context.TODO()
+	fclient := fake.NewClientBuilder().
+		WithScheme(pkg.SetupScheme()).
+		Build()
+
+	handler := NextcloudWebhookHandler{
+		DefaultWebhookHandler: DefaultWebhookHandler{
+			client:     fclient,
+			log:        logr.Discard(),
+			withQuota:  false,
+			obj:        &vshnv1.VSHNNextcloud{},
+			name:       "nextcloud",
+			nameLength: 30,
+		},
+	}
+
+	newNC := func(pinImageTag string) *vshnv1.VSHNNextcloud {
+		return &vshnv1.VSHNNextcloud{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "myinstance",
+				Namespace: "testns",
+			},
+			Spec: vshnv1.VSHNNextcloudSpec{
+				Parameters: vshnv1.VSHNNextcloudParameters{
+					Service: vshnv1.VSHNNextcloudServiceSpec{
+						FQDN: []string{"n€xtcloud.example.tld"},
+					},
+					Maintenance: vshnv1.VSHNDBaaSMaintenanceScheduleSpec{
+						PinImageTag: pinImageTag,
+					},
+				},
+			},
+		}
+	}
+
+	t.Log("invalid FQDN without pinImageTag: expect rejection")
+	_, err := handler.ValidateCreate(ctx, newNC(""))
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "is not a valid DNS name")
+
+	t.Log("invalid FQDN with pinImageTag set: expect rejection (no bypass)")
+	_, err = handler.ValidateCreate(ctx, newNC("nextcloud:30.0.5"))
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "is not a valid DNS name")
+}
+
 func TestNextcloudWebhookHandler_ValidateUpdate_VersionDowngrade(t *testing.T) {
 	ctx := context.TODO()
 	fclient := fake.NewClientBuilder().

--- a/pkg/controller/webhooks/redis.go
+++ b/pkg/controller/webhooks/redis.go
@@ -63,11 +63,8 @@ func (r *RedisWebhookHandler) ValidateCreate(ctx context.Context, obj runtime.Ob
 		tmpErr := parentErr.(*fieldErrors)
 		allErrs.Add(tmpErr.List()...)
 	}
-	if parentWarnings != nil && parentErr == nil {
-		return parentWarnings, nil
-	}
 
-	return nil, allErrs.Get()
+	return parentWarnings, allErrs.Get()
 }
 
 // ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type
@@ -89,9 +86,6 @@ func (r *RedisWebhookHandler) ValidateUpdate(ctx context.Context, oldObj, newObj
 		tmpErr := parentErr.(*fieldErrors)
 		allErrs.Add(tmpErr.List()...)
 	}
-	if parentWarnings != nil && parentErr == nil {
-		return parentWarnings, nil
-	}
 
-	return nil, allErrs.Get()
+	return parentWarnings, allErrs.Get()
 }


### PR DESCRIPTION
When the default handler emitted a warning the webhook returned early and skipped the service specific validation, so an invalid config passed whenever a warning was present. This collects the parent warnings and always runs the service checks.