### PR TITLE
Restrict nextcloud pg network policy to postgresql namespaces

### DIFF
--- a/pkg/comp-functions/functions/vshnnextcloud/deploy.go
+++ b/pkg/comp-functions/functions/vshnnextcloud/deploy.go
@@ -213,7 +213,14 @@ func getPgInstanceNamespace(host string) (string, error) {
 	if len(parts) < 2 {
 		return "", fmt.Errorf("invalid host format: %s", host)
 	}
-	return parts[1], nil
+	// The host comes from a tenant-controlled connection secret. Only allow it to
+	// point at a PostgreSQL instance namespace, otherwise a crafted host could make
+	// us apply a network policy into an arbitrary namespace.
+	ns := parts[1]
+	if !strings.HasPrefix(ns, "vshn-postgresql-") {
+		return "", fmt.Errorf("derived namespace %q is not a postgresql instance namespace", ns)
+	}
+	return ns, nil
 }
 
 func getObservedPostgresSettings(svc *runtime.ServiceRuntime, comp *vshnv1.VSHNNextcloud) (map[string]string, map[string]string, string, error) {

--- a/pkg/comp-functions/functions/vshnnextcloud/deploy_test.go
+++ b/pkg/comp-functions/functions/vshnnextcloud/deploy_test.go
@@ -14,6 +14,23 @@ import (
 	"github.com/vshn/appcat/v4/pkg/comp-functions/runtime"
 )
 
+func Test_getPgInstanceNamespace(t *testing.T) {
+	t.Log("legitimate postgresql host: return instance namespace")
+	ns, err := getPgInstanceNamespace("myinstance.vshn-postgresql-myinstance.svc.cluster.local")
+	assert.NoError(t, err)
+	assert.Equal(t, "vshn-postgresql-myinstance", ns)
+
+	t.Log("hostile host pointing at a foreign namespace: rejected")
+	ns, err = getPgInstanceNamespace("x.kube-system.svc.cluster.local")
+	assert.Error(t, err)
+	assert.Empty(t, ns)
+
+	t.Log("host without a namespace segment: rejected")
+	ns, err = getPgInstanceNamespace("nodots")
+	assert.Error(t, err)
+	assert.Empty(t, ns)
+}
+
 func Test_addNextcloud(t *testing.T) {
 	svc, comp := getNextcloudComp(t, "vshnnextcloud/01_default.yaml")
 


### PR DESCRIPTION
The nextcloud postgres network policy took its namespace from a tenant controlled connection host, so it could be applied into an arbitrary namespace. This requires the postgresql namespace prefix that real hosts carry.