### PR TITLE
(fix) Nextcloud initial bootstrap during psql initial maintenance

### DIFF
--- a/pkg/comp-functions/functions/common/maintenance/maintenance.go
+++ b/pkg/comp-functions/functions/common/maintenance/maintenance.go
@@ -520,7 +520,18 @@ func (m *Maintenance) createInitialMaintenanceJob(_ context.Context) error {
 		},
 	}
 
+	// The initial maintenance runs a backup and, if necessary, a security upgrade, which
+	// restarts the instance. As long as the job hasn't completed, the object stays unready,
+	// which propagates to the composite. Parent composites (e.g. Nextcloud) wait for the
+	// readiness of their database before deploying on top of it, so this keeps them from
+	// bootstrapping into a restart.
+	readiness := xkubev1.Readiness{
+		Policy:   xkubev1.ReadinessPolicyDeriveFromCelQuery,
+		CelQuery: `has(object.status) && has(object.status.conditions) && object.status.conditions.exists(c, c.type == "Complete" && c.status == "True")`,
+	}
+
 	kubeOpts := append([]runtime.KubeObjectOption{runtime.KubeOptionAllowDeletion}, m.extraKubeOptions...)
+	kubeOpts = append(kubeOpts, runtime.KubeOptionCustomReadiness(readiness))
 
 	return m.svc.SetDesiredKubeObject(job, m.getInitialMaintenanceJobName(), kubeOpts...)
 }

--- a/pkg/comp-functions/functions/common/maintenance/maintenance_test.go
+++ b/pkg/comp-functions/functions/common/maintenance/maintenance_test.go
@@ -297,6 +297,31 @@ func TestInitialMaintenanceJob(t *testing.T) {
 	}
 }
 
+func TestInitialMaintenanceJobReadiness(t *testing.T) {
+	ctx := context.TODO()
+
+	svc := commontest.LoadRuntimeFromFile(t, "vshn-postgres/maintenance/01-GivenSchedule.yaml")
+
+	comp := &vshnv1.VSHNPostgreSQL{}
+	assert.NoError(t, svc.GetObservedComposite(comp))
+
+	in := "vshn-postgresql-" + comp.GetName()
+	result := New(comp, svc, comp.Spec.Parameters.Maintenance, in, "postgresql").
+		WithPolicyRules([]rbacv1.PolicyRule{}).
+		WithAdditionalClusterRoleBinding("cluster-role-binding").
+		WithRole("crossplane:appcat:job:postgres:maintenance").
+		WithExtraResources(createMaintenanceSecretTest(in, svc.Config.Data["sgNamespace"], comp.GetName()+"-maintenance-secret")).
+		Run(ctx)
+	assert.Nil(t, result)
+
+	obj := &xkubev1.Object{}
+	assert.NoError(t, svc.GetDesiredComposedResourceByName(obj, comp.GetName()+"-initial-maintenance"))
+
+	// The composite must stay unready until the job completed.
+	assert.Equal(t, xkubev1.ReadinessPolicyDeriveFromCelQuery, obj.Spec.Readiness.Policy)
+	assert.Contains(t, obj.Spec.Readiness.CelQuery, `c.type == "Complete" && c.status == "True"`)
+}
+
 func createMaintenanceSecretTest(instanceNamespace, sgNamespace, resourceName string) ExtraResource {
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
## Summary

* Fix the nextcloud bootstrap process that can break sometimes when the initial maintenance of the postgresql instance runs during the bootstrap process of nextcloud

## Checklist

- [x] Update tests.
- [ ] Link this PR to related issues.
- [ ] Follow [deprecation guidelines](https://github.com/vshn/appcat#deprecation-guidelines) where applicable.
- [ ] Merge with `/merge` comment.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->


Component PR: https://github.com/vshn/component-appcat/pull/1253